### PR TITLE
Fix for 'ul' using decimal style.

### DIFF
--- a/src/css/XhtmlNamespaceHandler.css
+++ b/src/css/XhtmlNamespaceHandler.css
@@ -38,6 +38,7 @@ s, strike, del  { text-decoration: line-through }
 ol, ul, dir,
 menu            { padding-left: 40px }
 dd              { margin-left: 40px }
+ul              { list-style-type: disc }
 ol              { list-style-type: decimal }
 ol ul, ul ol,
 ul ul, ol ol    { margin-top: 0; margin-bottom: 0 }


### PR DESCRIPTION
The XhtmlNamespaceHandler.css only specifies a list-style-type
for 'ol'.  Without a type specified for 'ul', the 'ul' list items
are inheriting the list-style-type of the 'ol' list.

Test case:
<html>
  <body>
    <ol>
      <li>
        ordered one
        <ul>
          <li>unordered one</li>
        </ul>
      </li>
    </ol>
  </body>
</html>
