### PR TITLE
Initial (one-level) support for CSS quotes property

### DIFF
--- a/demos/samples/src/QuotingExample.java
+++ b/demos/samples/src/QuotingExample.java
@@ -1,0 +1,59 @@
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import org.xhtmlrenderer.simple.XHTMLPanel;
+import org.xhtmlrenderer.util.XMLUtil;
+
+
+public class QuotingExample extends JFrame {
+    //currently we cannot display different quotes based on depth
+    private static final String DOCUMENT = 
+        "<html>\n" +
+        "  <head>\n" +
+        "    <style type='text/css'><![CDATA[\n" +
+        "      * { quotes: '\"' '\"' \"'\" \"'\" }\n" +
+        "      q:before { content: open-quote }\n" +
+        "      q:after { content: close-quote }\n" +
+        "      blockquote p:before     { content: open-quote }\n" +
+        "      blockquote p:after      { content: no-close-quote }\n" + 
+        "      blockquote p.last:after { content: close-quote }\n" +
+        "    ]]></style>\n" +
+        "  </head>\n" +
+        "  <body>\n" +
+        "    <blockquote>\n" +
+        "      <p>This is just a test of the emergency <q>quoting</q> system.</p>\n" +
+        "      <p>This is only a test.</p>\n" +
+        "      <p class='last'>Thank you for your cooperation during this <q>test.</q></p>\n" +
+        "    </blockquote>\n" +
+        "  </body>\n" +
+        "</html>\n";
+    
+    protected void frameInit() {
+        super.frameInit();
+        
+        setTitle("CSS Quoting Example");
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
+        
+        XHTMLPanel xr = new XHTMLPanel();
+        try {
+            xr.setDocument(XMLUtil.documentFromString(DOCUMENT));
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+        
+        add(xr);
+        
+        setSize(500, 300);
+    }
+    
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                new QuotingExample().setVisible(true);
+            }
+        });
+    }
+}

--- a/src/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/src/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -37,6 +37,7 @@ import org.xhtmlrenderer.css.parser.property.ListStylePropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.OneToFourPropertyBuilders;
 import org.xhtmlrenderer.css.parser.property.PrimitivePropertyBuilders;
 import org.xhtmlrenderer.css.parser.property.PropertyBuilder;
+import org.xhtmlrenderer.css.parser.property.QuotesPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.SizePropertyBuilder;
 import org.xhtmlrenderer.css.sheet.StylesheetInfo;
 import org.xhtmlrenderer.css.style.FSDerivedValue;
@@ -861,8 +862,7 @@ public final class CSSName implements Comparable {
                     PRIMITIVE,
                     "none",
                     INHERITS,
-                    false,
-                    null
+                    new QuotesPropertyBuilder()
             );
 
     /**

--- a/src/java/org/xhtmlrenderer/css/parser/property/ContentPropertyBuilder.java
+++ b/src/java/org/xhtmlrenderer/css/parser/property/ContentPropertyBuilder.java
@@ -74,7 +74,7 @@ public class ContentPropertyBuilder extends AbstractPropertyBuilder {
                 IdentValue ident = checkIdent(CSSName.CONTENT, value);
                 if (ident == IdentValue.OPEN_QUOTE || ident == IdentValue.CLOSE_QUOTE ||
                         ident == IdentValue.NO_CLOSE_QUOTE || ident == IdentValue.NO_OPEN_QUOTE) {
-                    throw new CSSParseException("The quotes property is not implemented", -1);
+                    resultValues.add(value);
                 } else {
                     throw new CSSParseException(
                             "Identifier " + ident + " is not a valid value for the content property", -1);

--- a/src/java/org/xhtmlrenderer/css/parser/property/QuotesPropertyBuilder.java
+++ b/src/java/org/xhtmlrenderer/css/parser/property/QuotesPropertyBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2011 Wisconsin Court System
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package org.xhtmlrenderer.css.parser.property;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.w3c.dom.css.CSSPrimitiveValue;
+import org.w3c.dom.css.CSSValue;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.constants.IdentValue;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+
+public class QuotesPropertyBuilder extends AbstractPropertyBuilder {
+
+    public List buildDeclarations(CSSName cssName, List values, int origin, boolean important, boolean inheritAllowed) {
+        if (values.size() == 1) {
+            PropertyValue value = (PropertyValue)values.get(0);
+            if (value.getCssValueType() == CSSValue.CSS_INHERIT) {
+                return Collections.EMPTY_LIST;
+            } else if (value.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+                IdentValue ident = checkIdent(CSSName.QUOTES, value);
+                if (ident == IdentValue.NONE) {
+                    return Collections.singletonList(
+                            new PropertyDeclaration(CSSName.QUOTES, value, important, origin));
+                }
+            }
+        }
+        
+        if (values.size() % 2 == 1) {
+            throw new CSSParseException(
+                    "Mismatched quotes " + values, -1);
+        }
+        
+        List resultValues = new ArrayList();
+        for (Iterator i = values.iterator(); i.hasNext(); ) {
+            PropertyValue value = (PropertyValue)i.next();
+            
+            if (value.getOperator() != null) {
+                throw new CSSParseException(
+                        "Found unexpected operator, " + value.getOperator().getExternalName(), -1);
+            }
+            
+            short type = value.getPrimitiveType();
+            if (type == CSSPrimitiveValue.CSS_STRING) {
+                resultValues.add(value.getStringValue());
+            } else if (type == CSSPrimitiveValue.CSS_URI) {
+                throw new CSSParseException(
+                        "URI is not allowed here", -1);
+            } else if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_FUNCTION) {
+                throw new CSSParseException(
+                        "Function " + value.getFunction().getName() + " is not allowed here", -1);
+            } else if (type == CSSPrimitiveValue.CSS_IDENT) {
+                throw new CSSParseException(
+                        "Identifier is not a valid value for the quotes property", -1);
+            } else {
+                throw new CSSParseException(
+                        value.getCssText() + " is not a value value for the quotes property", -1);
+            }
+        }
+        
+        if (resultValues.size() > 0) {
+            return Collections.singletonList(
+                    new PropertyDeclaration(CSSName.QUOTES, new PropertyValue(resultValues), important, origin));
+        } else {
+            return Collections.EMPTY_LIST;
+        }
+    }
+}

--- a/src/java/org/xhtmlrenderer/css/style/derived/ListValue.java
+++ b/src/java/org/xhtmlrenderer/css/style/derived/ListValue.java
@@ -19,6 +19,7 @@
  */
 package org.xhtmlrenderer.css.style.derived;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.xhtmlrenderer.css.constants.CSSName;
@@ -36,5 +37,20 @@ public class ListValue extends DerivedValue {
     
     public List getValues() {
         return _values;
+    }
+    
+    public String[] asStringArray() {
+        if (_values == null || _values.isEmpty()) {
+            return new String[0];
+        }
+        
+        String[] arr = new String[_values.size()];
+        int i = 0;
+        
+        for (Iterator iter = _values.iterator(); iter.hasNext();) {
+            arr[i++] = iter.next().toString();
+        }
+        
+        return arr;
     }
 }

--- a/src/java/org/xhtmlrenderer/layout/BoxBuilder.java
+++ b/src/java/org/xhtmlrenderer/layout/BoxBuilder.java
@@ -46,6 +46,7 @@ import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
 import org.xhtmlrenderer.css.sheet.StylesheetInfo;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.EmptyStyle;
+import org.xhtmlrenderer.css.style.FSDerivedValue;
 import org.xhtmlrenderer.newtable.TableBox;
 import org.xhtmlrenderer.newtable.TableCellBox;
 import org.xhtmlrenderer.newtable.TableColumn;
@@ -842,6 +843,20 @@ public class BoxBuilder {
                                 content = contentFunction.getLayoutReplacementText();
                             }
                         }
+                    }
+                }
+            } else if (type == CSSPrimitiveValue.CSS_IDENT) {
+                FSDerivedValue dv = style.valueByName(CSSName.QUOTES);
+                
+                if (dv != IdentValue.NONE) {
+                    IdentValue ident = value.getIdentValue();
+                    
+                    if (ident == IdentValue.OPEN_QUOTE) {
+                        String[] quotes = style.asStringArray(CSSName.QUOTES);
+                        content = quotes[0];
+                    } else if (ident == IdentValue.CLOSE_QUOTE) {
+                        String[] quotes = style.asStringArray(CSSName.QUOTES);
+                        content = quotes[1];
                     }
                 }
             }


### PR DESCRIPTION
It is now possible to specify the quotes property and to
configure the content property to use the quotes with the
identifiers: open-quote, no-open-quote, close-quote, and
no-close-quote.

This initial version does not offer full quotes support.  It
is currently possible only to use the first-level quotes 
enumerated in the quotes list or none to suppress quoting.
The QuotingExample program demonstrates how to configure the
quotes and content properties to elicit the insertion of 
quotes.  The example also demonstrate the current flaw where
embedded quotes do not use quotes for the correct depth.
