### PR TITLE
Adds the option of use fractional font rendering in Java2D

### DIFF
--- a/src/conf/xhtmlrenderer.conf
+++ b/src/conf/xhtmlrenderer.conf
@@ -171,6 +171,10 @@ xr.text.aa-fontsize-threshhold=25
 #    when using Java2D for rendering, hint to renderer for AA algorithm to use
 xr.text.aa-rendering-hint=RenderingHints.VALUE_TEXT_ANTIALIAS_HGRB
 
+#When using Java2D for rendering, hint to render with fractional font metrics.
+# default is false. valid values: true|false
+#xr.text.fractional-font-metrics=false
+
 # whether or not to cache stylesheets
 # note that there is currently no way to remove
 # stylesheets from the cache

--- a/src/java/org/xhtmlrenderer/swing/Java2DTextRenderer.java
+++ b/src/java/org/xhtmlrenderer/swing/Java2DTextRenderer.java
@@ -49,6 +49,7 @@ public class Java2DTextRenderer implements TextRenderer {
     protected float scale;
     protected float threshold;
     protected Object antiAliasRenderingHint;
+    protected Object fractionalFontMetricsHint;
 
     public Java2DTextRenderer() {
         scale = Configuration.valueAsFloat("xr.text.scale", 1.0f);
@@ -56,7 +57,7 @@ public class Java2DTextRenderer implements TextRenderer {
 
         Object dummy = new Object();
 
-        Object aaHint = Configuration.valueFromClassConstant("xr.text.aa-rendering-hint", dummy);
+        Object aaHint = Configuration.valueFromClassConstant("xr.text.aa-rendering-hint", dummy);        
         if (aaHint == dummy) {
             try {
                 Map map;
@@ -73,30 +74,42 @@ public class Java2DTextRenderer implements TextRenderer {
         } else {
             antiAliasRenderingHint = aaHint;
         }
+        if("true".equals(Configuration.valueFor("xr.text.fractional-font-metrics", "false"))) {
+            fractionalFontMetricsHint = RenderingHints.VALUE_FRACTIONALMETRICS_ON;
+        } else {
+            fractionalFontMetricsHint = RenderingHints.VALUE_FRACTIONALMETRICS_OFF;
+        }
     }
 
     /** {@inheritDoc} */
     public void drawString(OutputDevice outputDevice, String string, float x, float y ) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         if ( graphics.getFont().getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         graphics.drawString( string, (int)x, (int)y );
         if ( graphics.getFont().getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
     }
     
     public void drawString(
             OutputDevice outputDevice, String string, float x, float y, JustificationInfo info) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         if ( graphics.getFont().getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         
         GlyphVector vector = graphics.getFont().createGlyphVector(
                 graphics.getFontRenderContext(), string);
@@ -106,8 +119,9 @@ public class Java2DTextRenderer implements TextRenderer {
         graphics.drawGlyphVector(vector, x, y);
         
         if ( graphics.getFont().getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
     }
 
     private void adjustGlyphPositions(
@@ -129,25 +143,30 @@ public class Java2DTextRenderer implements TextRenderer {
     }
     
     public void drawGlyphVector(OutputDevice outputDevice, FSGlyphVector fsGlyphVector, float x, float y ) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         
         if ( graphics.getFont().getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
+
         GlyphVector vector = ((AWTFSGlyphVector)fsGlyphVector).getGlyphVector();
         graphics.drawGlyphVector(vector, (int)x, (int)y );
         if ( graphics.getFont().getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
     }
 
     /** {@inheritDoc} */
     public void setup(FontContext fontContext) {
         //Uu.p("setup graphics called");
-        ((Java2DFontContext)fontContext).getGraphics().setRenderingHint( 
-                RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF );
+//        ((Java2DFontContext)fontContext).getGraphics().setRenderingHint( 
+//                RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_OFF );
     }
 
     public void setFontScale( float scale ) {
@@ -161,17 +180,33 @@ public class Java2DTextRenderer implements TextRenderer {
     public void setSmoothingLevel( int level ) { /* no-op */ }
 
     public FSFontMetrics getFSFontMetrics(FontContext fc, FSFont font, String string ) {
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DFontContext)fc).getGraphics();
-        return new LineMetricsAdapter(
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
+        LineMetricsAdapter adapter = new LineMetricsAdapter(
                 ((AWTFSFont)font).getAWTFont().getLineMetrics(
                         string, graphics.getFontRenderContext()));
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
+        return adapter;
     }
     
     public int getWidth(FontContext fc, FSFont font, String string) {
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DFontContext)fc).getGraphics();
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         Font awtFont = ((AWTFSFont)font).getAWTFont();
-        return (int)Math.ceil(
-                graphics.getFontMetrics(awtFont).getStringBounds(string, graphics).getWidth());
+        int width = 0;
+        if(fractionalFontMetricsHint == RenderingHints.VALUE_FRACTIONALMETRICS_ON) {
+            width = (int)Math.round(
+                    graphics.getFontMetrics(awtFont).getStringBounds(string, graphics).getWidth());            
+        } else {
+            width = (int)Math.ceil(
+                    graphics.getFontMetrics(awtFont).getStringBounds(string, graphics).getWidth());
+        }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
+        return width;
     }
 
     public float getFontScale() {
@@ -203,14 +238,18 @@ public class Java2DTextRenderer implements TextRenderer {
     }
 
     public float[] getGlyphPositions(OutputDevice outputDevice, FSFont font, String text) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         Font awtFont = ((AWTFSFont)font).getAWTFont();
         
         if (awtFont.getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
+
         
         GlyphVector vector = awtFont.createGlyphVector(
                 graphics.getFontRenderContext(),
@@ -218,71 +257,84 @@ public class Java2DTextRenderer implements TextRenderer {
         float[] result = vector.getGlyphPositions(0, text.length() + 1, null);
         
         if (awtFont.getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
         
         return result;
     }
 
     public Rectangle getGlyphBounds(OutputDevice outputDevice, FSFont font, FSGlyphVector fsGlyphVector, int index, float x, float y) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         Font awtFont = ((AWTFSFont)font).getAWTFont();
         
         if (awtFont.getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         
         GlyphVector vector = ((AWTFSGlyphVector)fsGlyphVector).getGlyphVector();
         
         Rectangle result = vector.getGlyphPixelBounds(index, graphics.getFontRenderContext(), x, y);
         
         if (awtFont.getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
         
         return result;
     }
 
     public float[] getGlyphPositions(OutputDevice outputDevice, FSFont font, FSGlyphVector fsGlyphVector) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         Font awtFont = ((AWTFSFont)font).getAWTFont();
         
         if (awtFont.getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         
         GlyphVector vector = ((AWTFSGlyphVector)fsGlyphVector).getGlyphVector();
         
         float[] result = vector.getGlyphPositions(0, vector.getNumGlyphs() + 1, null);
         
         if (awtFont.getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
         
         return result;
     }
 
     public FSGlyphVector getGlyphVector(OutputDevice outputDevice, FSFont font, String text) {
-        Object prevHint = null;
+        Object aaHint = null;
+        Object fracHint = null;
         Graphics2D graphics = ((Java2DOutputDevice)outputDevice).getGraphics();
         Font awtFont = ((AWTFSFont)font).getAWTFont();
         
         if (awtFont.getSize() > threshold ) {
-            prevHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
             graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );
         }
+        fracHint = graphics.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fractionalFontMetricsHint);
         
         GlyphVector vector = awtFont.createGlyphVector(
                 graphics.getFontRenderContext(),
                 text);
         
         if (awtFont.getSize() > threshold ) {
-            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, prevHint );
+            graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );
         }
+        graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, fracHint);
         
         return new AWTFSGlyphVector(vector);
     }


### PR DESCRIPTION
This adds the option of using fractional font rendering in the Java2DFontRenderer. To enable it you set the new configuration "xr.text.fractional-font-metrics" to true. It defaults to false. The font looks really nice when you set fractional font rendering on and anti-aliasing. The fonts use the metrics defined in the font rather than using adjustments Java decided it should do. This allows better letter spacing for most fonts and a closer to linear font scaling.
