### PR TITLE
Text may be painted on wrong page

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
     <!-- =================================================
    Documentation
    ================================================= -->
-    <target name="docs" description="Creates JavaDocs" depends="clean.java2html, clean.javadoc">
+    <target name="docs" description="Creates JavaDocs" depends="check.app.version, clean.java2html, clean.javadoc">
         <antcall target="_javadoc">
             <param name="antcall.dest.javadoc.dir" value="${dest.javadoc.full.dir}"/>
             <param name="antcall.javadoc.file" value=""/>

--- a/src/java/org/xhtmlrenderer/css/sheet/PageRule.java
+++ b/src/java/org/xhtmlrenderer/css/sheet/PageRule.java
@@ -116,7 +116,7 @@ public class PageRule implements RulesetContainer {
             return true;
         } else if (_name == null && _pseudoPage != null && 
                 (_pseudoPage.equals(pseudoPage) || 
-                        (_pseudoPage.equals("left") && pseudoPage != null && pseudoPage.equals("first")))) { // assume first page is a left page
+                        (_pseudoPage.equals("right") && pseudoPage != null && pseudoPage.equals("first")))) { // assume first page is a right page
             return true;
         } else if (_name != null && _name.equals(pageName) && _pseudoPage == null) {
             return true;

--- a/src/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/src/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -400,6 +400,10 @@ public class CalculatedStyle {
         return _font;
     }
 
+    public FontSpecification getFontSpecification() {
+	return _font;
+    }
+
     private IdentValue resolveAbsoluteFontSize() {
         FSDerivedValue fontSize = valueByName(CSSName.FONT_SIZE);
         if (! (fontSize instanceof IdentValue)) {
@@ -453,7 +457,7 @@ public class CalculatedStyle {
                 // Make sure rasterized characters will (probably) fit inside
                 // the line box
                 FSFontMetrics metrics = getFSFontMetrics(ctx);
-                float lineHeight2 = (float)Math.ceil(metrics.getDescent() + Math.round(metrics.getAscent()));
+                float lineHeight2 = (float)Math.ceil(metrics.getDescent() + metrics.getAscent());
                 _lineHeight = Math.max(lineHeight1, lineHeight2);
             } else if (isLength(CSSName.LINE_HEIGHT)) {
                 //could be more elegant, I suppose

--- a/src/java/org/xhtmlrenderer/layout/InlineBoxing.java
+++ b/src/java/org/xhtmlrenderer/layout/InlineBoxing.java
@@ -578,12 +578,16 @@ public class InlineBoxing {
         CalculatedStyle style = iB.getStyle();
         float lineHeight = style.getLineHeight(c);
 
-        int halfLeading = Math.round((lineHeight - iB.getStyle().getFont(c).size) / 2);
-        if (halfLeading > 0) {
-            halfLeading = Math.round((lineHeight -
-                    (fm.getDescent() + fm.getAscent())) / 2);
-        }
-
+	//
+	// Floating the text up (negative halfLeading value) will cause text on the
+	// first line of a page to appear a second time (clipped, and therefore hidden)
+	// on the previous page. In Acrobat Reader the cursor can land on this hidden text
+	// and the text can be found when searching (displays as a blue background).
+	//
+	// For time being not centering a positive float value either.
+	// Should probably honor CSS vertical alignment.
+	//
+        
         iB.setBaseline(Math.round(fm.getAscent()));
 
         alignInlineContent(c, iB, fm.getAscent(), fm.getDescent(), vaContext);
@@ -594,7 +598,7 @@ public class InlineBoxing {
 
         InlineBoxMeasurements result = new InlineBoxMeasurements();
         result.setBaseline(iB.getY() + iB.getBaseline());
-        result.setInlineTop(iB.getY() - halfLeading);
+        result.setInlineTop(iB.getY());
         result.setInlineBottom(Math.round(result.getInlineTop() + lineHeight));
         result.setTextTop(iB.getY());
         result.setTextBottom((int) (result.getBaseline() + fm.getDescent()));
@@ -699,19 +703,16 @@ public class InlineBoxing {
             LayoutContext c, Box container, FSFontMetrics strutM) {
         float lineHeight = container.getStyle().getLineHeight(c);
 
-        int halfLeading = Math.round((lineHeight -
-                container.getStyle().getFont(c).size) / 2);
-        if (halfLeading > 0) {
-            halfLeading = Math.round((lineHeight -
-                    (strutM.getDescent() + strutM.getAscent())) / 2);
-        }
-
+	//
+	// See comments above (in calculateInlineMeasurements) as to why 
+	// the halfLeading code has been removed.
+	//
         InlineBoxMeasurements measurements = new InlineBoxMeasurements();
-        measurements.setBaseline((int) (halfLeading + strutM.getAscent()));
-        measurements.setTextTop(halfLeading);
+        measurements.setBaseline((int) strutM.getAscent());
+        measurements.setTextTop(0);
         measurements.setTextBottom((int) (measurements.getBaseline() + strutM.getDescent()));
-        measurements.setInlineTop(halfLeading);
-        measurements.setInlineBottom((int) (halfLeading + lineHeight));
+        measurements.setInlineTop(0);
+        measurements.setInlineBottom((int) lineHeight);
 
         return measurements;
     }

--- a/src/java/org/xhtmlrenderer/layout/Layer.java
+++ b/src/java/org/xhtmlrenderer/layout/Layer.java
@@ -760,9 +760,9 @@ public class Layer {
         if (pages.size() == 0) {
             pseudoPage = "first";
         } else if (pages.size() % 2 == 0) {
-            pseudoPage = "left";
-        } else {
             pseudoPage = "right";
+        } else {
+            pseudoPage = "left";
         }
         PageBox pageBox = createPageBox(c, pseudoPage);
         if (pages.size() == 0) {

--- a/src/java/org/xhtmlrenderer/pdf/DOMUtil.java
+++ b/src/java/org/xhtmlrenderer/pdf/DOMUtil.java
@@ -55,4 +55,34 @@ public class DOMUtil {
         }
         return result.size() == 0 ? null : result;
     }
+    
+    /**
+     * Loads all of the text content in all offspring of an element.
+     * Ignores all attributes, comments and processing instructions.
+     *
+     * @return a String with the text content of an element (may be an empty string but will not be null).
+     */
+    public static String getText(Element parent) {
+	StringBuilder sb = new StringBuilder();
+	getText(parent, sb);
+        return sb.toString();
+    }
+    
+    /**
+     * Appends all text content in all offspring of an element to a StringBuffer.
+     * Ignores all attributes, comments and processing instructions.
+     *
+     * @return a String with the text content of an element (may be an empty string but will not be null).
+     */
+    public static void getText(Element parent, StringBuilder sb) {
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = (Node)children.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE) {
+		getText((Element)n, sb);
+            } else if (n.getNodeType() == Node.TEXT_NODE) {
+                sb.append(n.getNodeValue());
+	    }
+        }
+    }
 }

--- a/src/java/org/xhtmlrenderer/pdf/DefaultPDFCreationListener.java
+++ b/src/java/org/xhtmlrenderer/pdf/DefaultPDFCreationListener.java
@@ -12,5 +12,10 @@ public class DefaultPDFCreationListener implements PDFCreationListener {
     /**
      * {@inheritDoc}
      */
+    public void preWrite(ITextRenderer iTextRenderer, int pageCount) {}
+
+    /**
+     * {@inheritDoc}
+     */
     public void onClose(ITextRenderer renderer) { }
 }

--- a/src/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/src/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -394,8 +394,8 @@ public class ITextFontResolver implements FontResolver {
 
         return null;
     }
-
-    private int convertWeightToInt(IdentValue weight) {
+    
+    public static int convertWeightToInt(IdentValue weight) {
         if (weight == IdentValue.NORMAL) {
             return 400;
         } else if (weight == IdentValue.BOLD) {

--- a/src/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/src/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -129,6 +129,10 @@ public class ITextRenderer {
         _sharedContext.setInteractive(false);
     }
 
+    public Document getDocument() {
+	return _doc;
+    }
+    
     public ITextFontResolver getFontResolver() {
         return (ITextFontResolver)_sharedContext.getFontResolver();
     }
@@ -332,6 +336,11 @@ public class ITextRenderer {
             _listener.preOpen(this);
         }
     }
+    private void firePreWrite(int pageCount) {
+        if (_listener != null) {
+            _listener.preWrite(this, pageCount);
+        }
+    }
     private void fireOnClose() {
         if (_listener != null) {
             _listener.onClose(this);
@@ -349,6 +358,8 @@ public class ITextRenderer {
 
         int pageCount = _root.getLayer().getPages().size();
         c.setPageCount(pageCount);
+        firePreWrite(pageCount);				// opportunity to adjust meta data
+	setDidValues(doc);					// set PDF header fields from meta data
         for (int i = 0; i < pageCount; i++) {
             PageBox currentPage = (PageBox)pages.get(i);
             c.setPage(i, currentPage);
@@ -370,6 +381,26 @@ public class ITextRenderer {
         _outputDevice.finish(c, _root);
     }
 
+    // Sets the document information dictionary values from html metadata
+    private void setDidValues(com.lowagie.text.Document doc) {
+	String v = _outputDevice.getMetadataByName("title");
+	if (v != null) {
+	    doc.addTitle(v);
+	}
+	v = _outputDevice.getMetadataByName("author");
+	if (v != null) {
+	    doc.addAuthor(v);
+	}
+	v = _outputDevice.getMetadataByName("subject");
+	if (v != null) {
+	    doc.addSubject(v);
+	}
+	v = _outputDevice.getMetadataByName("keywords");
+	if (v != null) {
+	    doc.addKeywords(v);
+	}
+    }
+    
     private void paintPage(RenderingContext c, PdfWriter writer, PageBox page) {
         provideMetadataToPage(writer, page);
 

--- a/src/java/org/xhtmlrenderer/pdf/PDFCreationListener.java
+++ b/src/java/org/xhtmlrenderer/pdf/PDFCreationListener.java
@@ -39,6 +39,17 @@ public interface PDFCreationListener {
     void preOpen(ITextRenderer iTextRenderer);
 
     /**
+     * Called immediately before the pages of the PDF file are about to be written out.
+     * This is an opportunity to modify any document metadata that will be used to generate
+     * the PDF header fields (the document information dictionary). Document metadata may be accessed
+     * through the {@link ITextOutputDevice} that is returned by {@link ITextRenderer#getOutputDevice()}.
+     *
+     * @param iTextRenderer the renderer preparing the document
+     * @param pageCount the number of pages that will be written to the PDF document
+     */
+    void preWrite(ITextRenderer iTextRenderer, int pageCount);
+
+    /**
      * Called immediately before the iText Document instance is closed, e.g. before
      * {@link com.lowagie.text.Document#close()} is called.
      *

--- a/src/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
+++ b/src/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
@@ -36,6 +36,7 @@ import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.CssContext;
 import org.xhtmlrenderer.css.style.derived.BorderPropertySet;
 import org.xhtmlrenderer.css.style.derived.LengthValue;
+import org.xhtmlrenderer.css.value.FontSpecification;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.OutputDevice;
 import org.xhtmlrenderer.util.Configuration;
@@ -46,8 +47,11 @@ import org.xhtmlrenderer.util.Uu;
  * implementations for many <code>OutputDevice</code> methods.
  */
 public abstract class AbstractOutputDevice implements OutputDevice {
-    protected abstract void drawLine(int x1, int y1, int x2, int y2);
 
+    private FontSpecification _fontSpec;
+
+    protected abstract void drawLine(int x1, int y1, int x2, int y2);
+    
     public void drawText(RenderingContext c, InlineText inlineText) {
         InlineLayoutBox iB = inlineText.getParent();
         String text = inlineText.getSubstring();
@@ -55,6 +59,7 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         if (text != null && text.length() > 0) {
             setColor(iB.getStyle().getColor());
             setFont(iB.getStyle().getFSFont(c));
+            setFontSpecification(iB.getStyle().getFontSpecification());
             if (inlineText.getParent().getStyle().isTextJustify()) {
                 JustificationInfo info = inlineText.getParent().getLineBox().getJustificationInfo();
                 if (info != null) {
@@ -394,5 +399,23 @@ public abstract class AbstractOutputDevice implements OutputDevice {
                     0,
                     c);
         }
+    }
+
+    /**
+     * Gets the FontSpecification for this AbstractOutputDevice.
+     *
+     * @return current FontSpecification.
+     */
+    public FontSpecification getFontSpecification() {
+	return _fontSpec;
+    }
+
+    /**
+     * Sets the FontSpecification for this AbstractOutputDevice.
+     *
+     * @param fs current FontSpecification.
+     */
+    public void setFontSpecification(FontSpecification fs) {
+	_fontSpec = fs;
     }
 }


### PR DESCRIPTION
If the content area of a line box overflows the line box itself, text may be painted on the previous page for the first line box of a page.
