### PR TITLE
Resolves ClassCastException for grid layouts

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BoxCollector.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BoxCollector.java
@@ -123,7 +123,7 @@ public class BoxCollector {
                 if (intersectsAggregateBounds || 
                         (container.getPaintingInfo() == null && container.intersects(c, clip))) {
                     blockContent.add(container);
-                    if (container.getStyle().isTable() && c instanceof RenderingContext) {  // HACK
+                    if (container.getStyle().isTable() && c instanceof RenderingContext && container instanceof TableBox) {  // HACK
                         TableBox table = (TableBox)container;
                         if (table.hasContentLimitContainer()) {
                             table.updateHeaderFooterPosition((RenderingContext)c);


### PR DESCRIPTION
## The Problem

When running `ITextRenderer.layout()` on a grid formatted html file, you would get:

```
java.lang.ClassCastException: org.xhtmlrenderer.render.BlockBox cannot be cast to org.xhtmlrenderer.newtable.TableBox
```

A great example would be to tagsoup http://twitter.github.com/bootstrap/
## The Solution

An extra check to block the exception from bubbling to the surface. This simple change resolves:
- http://code.google.com/p/flying-saucer/issues/detail?id=144

Thank you for a such a great library!
