### PR TITLE
Support for CSS3 'tab-size' property

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -902,6 +902,18 @@ public final class CSSName implements Comparable {
             );
 
     /**
+     * Used for controlling tab size in pre tags. See http://dev.w3.org/csswg/css3-text/#tab-size
+     */
+    public final static CSSName TAB_SIZE =
+            addProperty(
+                    "tab-size",
+                    PRIMITIVE,
+                    "8",
+                    INHERITS,
+                    new PrimitivePropertyBuilders.TabSize()
+                    );
+
+    /**
      * Unique CSSName instance for CSS2 property.
      */
     public final static CSSName TABLE_LAYOUT =

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -1337,6 +1337,12 @@ public class PrimitivePropertyBuilders {
     public static class Src extends GenericURIWithNone {
     }
 
+    public static class TabSize extends PlainInteger {
+        protected boolean isNegativeValuesAllowed() {
+            return false;
+        }
+    }
+
     public static class Top extends LengthLikeWithAuto {
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/WhitespaceStripper.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/WhitespaceStripper.java
@@ -19,6 +19,7 @@
  */
 package org.xhtmlrenderer.layout;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -127,7 +128,7 @@ public class WhitespaceStripper {
         
         String text = iB.getText();
 
-        text = collapseWhitespace(whitespace, text, collapseLeading);
+        text = collapseWhitespace(iB, whitespace, text, collapseLeading);
 
         boolean collapseNext = (text.endsWith(SPACE) &&
                 (whitespace == IdentValue.NORMAL || whitespace == IdentValue.NOWRAP || whitespace == IdentValue.PRE));
@@ -145,7 +146,7 @@ public class WhitespaceStripper {
         return text.equals("") ? collapseLeading : collapseNext;
     }
 
-    private static String collapseWhitespace(IdentValue whitespace, String text, boolean collapseLeading) {
+    private static String collapseWhitespace(InlineBox iB, IdentValue whitespace, String text, boolean collapseLeading) {
         if (whitespace == IdentValue.NORMAL || whitespace == IdentValue.NOWRAP) {
             text = linefeed_space_collapse.matcher(text).replaceAll(EOL);
         } else if (whitespace == IdentValue.PRE) {
@@ -156,8 +157,11 @@ public class WhitespaceStripper {
             text = linefeed_to_space.matcher(text).replaceAll(SPACE);
             text = tab_to_space.matcher(text).replaceAll(SPACE);
             text = space_collapse.matcher(text).replaceAll(SPACE);
-        } else if (whitespace == IdentValue.PRE || whitespace == IdentValue.PRE_WRAP) { // not correct, should treat as 8 space tab stops
-            text = tab_to_space.matcher(text).replaceAll(SPACE);
+        } else if (whitespace == IdentValue.PRE || whitespace == IdentValue.PRE_WRAP) {
+            int tabSize = (int) iB.getStyle().asFloat(CSSName.TAB_SIZE);
+            char[] tabs = new char[tabSize];
+            Arrays.fill(tabs, ' ');
+            text = tab_to_space.matcher(text).replaceAll(new String(tabs));
         } else if (whitespace == IdentValue.PRE_LINE) {
             text = tab_to_space.matcher(text).replaceAll(SPACE);
             text = space_collapse.matcher(text).replaceAll(SPACE);


### PR DESCRIPTION
This adds support for the upcoming CSS3 property 'tab-size' to flyingsaucer.

I used no '-fs' prefix for the property since it's going to be standardized. If that's not fine it can be changed of course.

See http://dev.w3.org/csswg/css3-text/#tab-size for more information.
