### PR TITLE
Added support for CSS-3 nth-child pseudo class

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Selector.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Selector.java
@@ -168,7 +168,15 @@ public class Selector {
         _specificityC++;
         addCondition(Condition.createLastChildCondition());
     }
-    
+
+    /**
+     * the CSS condition that element has pseudo-class :nth-child(an+b)
+     */
+    public void addNthChildCondition(String number) {
+        _specificityC++;
+        addCondition(Condition.createNthChildCondition(number));
+    }
+
     /**
      * the CSS condition that element has pseudo-class :even
      */


### PR DESCRIPTION
This commit adds support for the CSS3 pseudo class nth-child to flying-saucer.

Some sample HTML code for testing:

```
<html>
<head>

<style>
tr:nth-child(2n) {
    background-color: yellow;
}
tr:nth-child(3) {
    color: red;
}
tr:nth-child(2n+1) {
    background-color: lime;
}
</style>

</head>
<body>

<table>
    <tr>
        <th>h1</th>
        <th>h2</th>
    </tr>
    <tr>
        <td>a1</td>
        <td>a2</td>
    </tr>
    <tr>
        <td>b1</td>
        <td>b2</td>
    </tr>
    <tr>
        <td>c1</td>
        <td>c2</td>
    </tr>
    <tr>
        <td>d1</td>
        <td>d2</td>
    </tr>
</table>

</body>
</html>
```
