### PR TITLE
NPE in BlockBox

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -409,9 +409,11 @@ public class BlockBox extends Box implements InlinePaintable {
     public void calcCanvasLocation() {
         if (isFloated()) {
             FloatManager manager = _floatedBoxData.getManager();
-            Point offset = manager.getOffset(this);
-            setAbsX(manager.getMaster().getAbsX() + getX() - offset.x);
-            setAbsY(manager.getMaster().getAbsY() + getY() - offset.y);
+            if(manager !=null){
+	            Point offset = manager.getOffset(this);
+	            setAbsX(manager.getMaster().getAbsX() + getX() - offset.x);
+	            setAbsY(manager.getMaster().getAbsY() + getY() - offset.y);
+            }
         }
 
         LineBox lineBox = getLineBox();


### PR DESCRIPTION
Just added a null check in calcCanvasLocation.  Exception was happening when a paginated table with headers that had a row with a floating div in it was spanning pages.  Just adding the null check seemed to cause the page to display fine.

Sample that causes the exception:

``` HTML
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html>
<head>
    <style type='text/css'>
        .left { float: left; }
        table { -fs-table-paginate: paginate; }
    </style>
</head>
<body>  
<div style="height:930px">&nbsp;</div>
<table>
    <thead>
        <tr>
            <th>test header</th>
        </tr>
    </thead>
    <tbody>                 
        <tr>
            <td>
                <div class="left">test cell</div>
            </td>
        </tr>                   
    </tbody>
</table>
</body>
</html>
```
