### PR TITLE
Support for page sequences in target-counter function

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/ContentFunctionFactory.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/ContentFunctionFactory.java
@@ -152,8 +152,8 @@ public class ContentFunctionFactory {
                 String anchor = uri.substring(1);
                 Box target = c.getBoxById(anchor);
                 if (target != null) {
-                    PageBox targetPage = c.getRootLayer().getPage(c, target.getAbsY());
-                    return CounterFunction.createCounterText(IdentValue.DECIMAL, targetPage.getPageNo()+1);
+                    int pageNo = c.getRootLayer().getRelativePageNo(c, target.getAbsY());
+                    return CounterFunction.createCounterText(IdentValue.DECIMAL, pageNo + 1);
                 }
             }
             return "";

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
@@ -1100,6 +1100,35 @@ public class Layer {
         return _sortedPageSequences;
     }
     
+    public int getRelativePageNo(RenderingContext c, int absY) {
+        List sequences = getSortedPageSequences();
+        int initial = 0;
+        if (c.getInitialPageNo() > 0) {
+            initial = c.getInitialPageNo() - 1;
+        }
+        if ((sequences == null) || sequences.isEmpty()) {
+            return initial + getPage(c, absY).getPageNo();
+        } else {
+            BlockBox pageSequence = findPageSequence(sequences, absY);
+            int sequenceStartAbsolutePageNo = getPage(c, pageSequence.getAbsY()).getPageNo();
+            int absoluteRequiredPageNo = getPage(c, absY).getPageNo();
+            return absoluteRequiredPageNo - sequenceStartAbsolutePageNo;
+        }
+    }
+    
+    private BlockBox findPageSequence(List sequences, int absY) {
+        BlockBox result = null;
+        
+        for (int i = 0; i < sequences.size(); i++) {
+            result = (BlockBox) sequences.get(i);
+            if ((i < sequences.size() - 1) && (((BlockBox) sequences.get(i + 1)).getAbsY() > absY)) {
+                break;
+            }
+        }
+        
+        return result;
+    }
+    
     public int getRelativePageNo(RenderingContext c) {
         List sequences = getSortedPageSequences();
         int initial = 0;


### PR DESCRIPTION
This change makes the target-counter() function aware of page sequences. 

Until now when you have some introduction pages (title page, toc, etc) without page numbering and the actual numbering starting with 1 at the first content page, the target-counter function would always return the absolute page number of the target not the number relative to the page sequence containing that page.

Here is some example HTML:

```
<html>
<head>
    <style type="text/css" media="print">
        @page content {
            @bottom-right {
                content: counter(page) " of " counter(pages);
            }
        }
        a.toc-entry:after {
            content: " (" target-counter(attr(href), page) ")";
        }
        .content-block {
            page: content;
        }
    </style>
</head>
<body>
    <div>
        <h1>first page</h1>
    </div>

    <div style="page-break-before: always;">
        <h1>toc page</h1>
        <ul>
            <li><a class="toc-entry" href="#test1">link to toc entry 1</a></li>
            <li><a class="toc-entry" href="#test2">link to toc entry 2</a></li>
            <li><a class="toc-entry" href="#test3">link to toc entry 3</a></li>
            <li><a class="toc-entry" href="#test4">link to toc entry 4</a></li>
        </ul>
    </div>

    <div class="content-block" style="-fs-page-sequence: start; page-break-before: always;">
        <h1>content page</h1>
        <p id="test1">toc entry here</p>
        <p style="page-break-before: always;" id="test2">toc entry here</p>
    </div>

    <div class="content-block" style="-fs-page-sequence: start; page-break-before: always;">
        <h1>content page</h1>
        <p id="test3">toc entry here</p>
        <p style="page-break-before: always;" id="test4">toc entry here</p>
    </div>
</body>
</html>
```
