### PR TITLE
Support of CSS property 'background-size' when using Java2DRenderer.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/AWTFSImage.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/AWTFSImage.java
@@ -69,7 +69,18 @@ public abstract class AWTFSImage implements FSImage {
         }
 
         public void scale(int width, int height) {
-            ImageUtil.getScaledInstance(img, width, height);
+            int targetWidth = width;
+            int targetHeight = height;
+
+            if (targetWidth == -1) {
+                targetWidth = (int)(getWidth() * ((double)targetHeight / getHeight()));
+            }
+
+            if (targetHeight == -1) {
+                targetHeight = (int)(getHeight() * ((double)targetWidth / getWidth()));
+            }
+
+            img = ImageUtil.getScaledInstance(img, targetWidth, targetHeight);
         }
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
@@ -149,20 +149,35 @@ public class Java2DRenderer {
 	}
    
    
-    /**
-     * Creates a new instance pointing to the given Document. Does not render until {@link #getImage(int)} is called for
-     * the first time.
-     *
-     * @param doc The document to be rendered.
-     * @param width Target width, in pixels, for the image; required to provide horizontal bounds for the layout.
-     * @param height Target height, in pixels, for the image.
-     */
-    public Java2DRenderer(Document doc, int width, int height) {
-        this(DEFAULT_DOTS_PER_POINT, DEFAULT_DOTS_PER_PIXEL);
-        this.doc = doc;
-        this.width = width;
-        this.height = height;
-    }
+        /**
+         * Creates a new instance pointing to the given Document. Does not render until {@link #getImage(int)} is called for
+         * the first time.
+         *
+         * @param doc The document to be rendered.
+         * @param width Target width, in pixels, for the image; required to provide horizontal bounds for the layout.
+         * @param height Target height, in pixels, for the image.
+         */
+        public Java2DRenderer(Document doc, int width, int height) {
+            this(DEFAULT_DOTS_PER_POINT, DEFAULT_DOTS_PER_PIXEL);
+            this.doc = doc;
+            this.width = width;
+            this.height = height;
+        }
+
+
+        /**
+         * Creates a new instance pointing to the given Document. Does not render until {@link #getImage(int)} is called for
+         * the first time.
+         *
+         * @param doc The document to be rendered.
+         * @param baseUrl The base url for the document, against which  relative paths are resolved.
+         * @param width Target width, in pixels, for the image; required to provide horizontal bounds for the layout.
+         * @param height Target height, in pixels, for the image.
+         */
+        public Java2DRenderer(Document doc, String baseUrl, int width, int height) {
+            this(doc, width, height);
+            this.sourceDocumentBase = baseUrl;
+        }
 
 	/**
 	 * Creates a new instance for a given File. Does not render until {@link #getImage(int)} is called for


### PR DESCRIPTION
Fix the bug when using property 'background-size' with Java2DRenderer.
Add a constructor to Java2DRenderer for more conveniance.
