### PR TITLE
This is an extension to the named destination support providing better c...

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -385,6 +385,18 @@ public final class CSSName implements Comparable {
         );
 
     /**
+     * Used to control creation of named destinations for boxes having the id attribute set.
+     */
+    public final static CSSName FS_NAMED_DESTINATION =
+            addProperty(
+                    "-fs-named-destination",
+                    PRIMITIVE,
+                    "none",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.FSNamedDestination()
+            );
+
+    /**
      * Unique CSSName instance for CSS2 property.
      */
     public final static CSSName BOTTOM =

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
@@ -83,6 +83,7 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue COMPACT = addValue("compact");
     public final static IdentValue CONTAIN = addValue("contain");
     public final static IdentValue COVER = addValue("cover");
+    public final static IdentValue CREATE = addValue("create");
     public final static IdentValue DASHED = addValue("dashed");
     public final static IdentValue DECIMAL = addValue("decimal");
     public final static IdentValue DECIMAL_LEADING_ZERO = addValue("decimal-leading-zero");

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -1124,6 +1124,16 @@ public class PrimitivePropertyBuilders {
         }
     }
 
+    public static class FSNamedDestination extends SingleIdent {
+        // none | create
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] { IdentValue.NONE, IdentValue.CREATE });
+
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
     public static class Left extends LengthLikeWithAuto {
     }
 


### PR DESCRIPTION
...ontrol over named destination creation.

Apply "-fs-named-destination: create;" to an element having the id attribute set to create a named destination or override (disable named destination) with "-fs-named-destination: none;".

This should avoid "destination pollution" in PDFs that were created from generated HTML contain a lot of IDs that should not be converted to named destinations.
