### PR TITLE
Fixed an issue in which pdf links were duplicated on other pages

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -286,19 +286,26 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                         _writer.addAnnotation(annot);
                     }
                 } else if (uri.indexOf("://") != -1) {
-                    PdfAction action = new PdfAction(uri);
+                    int boxTop = box.getAbsY();
+                    int boxBottom = boxTop + box.getHeight();
+                    int pageTop = c.getPage().getTop();
+                    int pageBottom = c.getPage().getBottom();
 
-                    com.itextpdf.text.Rectangle targetArea = checkLinkArea(c, box);
-                    if (targetArea == null) {
-                        return;
-                    }
-                    PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(), targetArea.getRight(),
+                    if (boxTop < pageBottom && boxBottom > pageTop) {
+                        PdfAction action = new PdfAction(uri);
+
+                        com.itextpdf.text.Rectangle targetArea = checkLinkArea(c, box);
+                        if (targetArea == null) {
+                            return;
+                        }
+                        PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(), targetArea.getRight(),
                             targetArea.getTop(), action);
-                    annot.put(PdfName.SUBTYPE, PdfName.LINK);
+                        annot.put(PdfName.SUBTYPE, PdfName.LINK);
 
-                    annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
-                    annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
-                    _writer.addAnnotation(annot);
+                        annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
+                        annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
+                        _writer.addAnnotation(annot);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The anchor elements are added to every page in the PDF.  In some circumstances this caused them to show up on other pages, hanging off the top or bottom of the pages.

This fix first checks the bounds of the box associated with the link, and only puts it on the page if it overlaps the page.
