### PR TITLE
Allow PDF resources as background image

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -97,7 +97,11 @@ public class ITextUserAgent extends NaiveUserAgent {
             }
 
             if (resource != null) {
-                resource = new ImageResource(resource.getImageUri(), (FSImage) ((ITextFSImage) resource.getImage()).clone());
+                FSImage image=resource.getImage();
+                if (image instanceof ITextFSImage) {
+                    image=(FSImage) ((ITextFSImage) resource.getImage()).clone();
+                }
+                resource = new ImageResource(resource.getImageUri(), image);
             } else {
                 resource = new ImageResource(uri, null);
             }


### PR DESCRIPTION
This fails because the image is casted to ITextFSImage which is wrong if the resource is a PdfAsImage. With this patch it works fine.
