### PR TITLE
InlineBox use same logic in Breaker to prevent breaking logic scattering...

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -108,7 +108,8 @@ public class Breaker {
         FSFont font = style.getFSFont(c);
         String currentString = context.getStartSubstring();
         int left = 0;
-        int right = tryToBreakAnywhere ? 1 : currentString.indexOf(WhitespaceStripper.SPACE, left + 1);
+        int right = tryToBreakAnywhere ? 1 : getNextBreakableChar(
+                currentString, left + 1);
         int lastWrap = 0;
         int graphicsLength = 0;
         int lastGraphicsLength = 0;
@@ -122,8 +123,8 @@ public class Breaker {
             if ( tryToBreakAnywhere ) {
                 right = ( right + 1 ) % currentString.length();
             }
-            else { // break only on whitespace
-                right = currentString.indexOf(WhitespaceStripper.SPACE, left + 1);
+            else { // break only on whitespace or CJK character
+                right = getNextBreakableChar(currentString, left + 1);
             }
         }
 
@@ -170,6 +171,34 @@ public class Breaker {
         }
         return;
     }
+
+	/**
+	 * Detect the next breakable character (a white-space or the next character
+	 * after a CJK character)
+	 */
+	public static int getNextBreakableChar(String s, int left) {
+		if (left >= s.length())
+			return -1;
+		char[] ch = s.toCharArray();
+		for (int i = left; i < ch.length; i++) {
+			if (isCJKCharacter(ch[i])) {
+				return (i + 1);
+			} else if (' ' == ch[i]) {
+				return i == 0 ? i + 1 : i;
+			}
+		}
+		return -1;
+	}
+
+	private static boolean isCJKCharacter(char c) {
+		Character.UnicodeBlock ub = Character.UnicodeBlock.of(c);
+		if (ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS
+				|| ub == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS
+				|| ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A) {
+			return true;
+		}
+		return false;
+	}
 
 }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
@@ -24,6 +24,7 @@ import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.extend.ContentFunction;
 import org.xhtmlrenderer.css.parser.FSFunction;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.layout.Breaker;
 import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.layout.Styleable;
 import org.xhtmlrenderer.layout.TextUtil;
@@ -226,7 +227,8 @@ public class InlineBox implements Styleable {
 
         String text = getText(trimLeadingSpace);
 
-        while ( (current = text.indexOf(WhitespaceStripper.SPACE, last)) != -1) {
+        // Breaker should be used
+        while ( (current = Breaker.getNextBreakableChar(text, last)) != -1) {
             String currentWord = text.substring(last, current);
             int wordWidth = getTextWidth(c, currentWord);
             int minWordWidth;


### PR DESCRIPTION
There are several attempts previously for CJK line break handling.  I used that but still discovered that table content are not wrapped.  Probably the breaking logic is not centralised in a single class.  This patch should work for CJK breaking rule.
