### PR TITLE
Detect "PDF-Images" using the first few bytes of stream

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapper.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapper.java
@@ -1,0 +1,60 @@
+package org.xhtmlrenderer.util;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This class wraps an input stream and detects if it contains certain content using "magic numbers".
+ * 
+ * http://en.wikipedia.org/wiki/Magic_number_(programming)
+ * 
+ * currently only pdf detection is implemented
+ * 
+ * @author mwyraz
+ */
+public class ContentTypeDetectingInputStreamWrapper extends BufferedInputStream
+{
+    protected static final int MAX_MAGIC_BYTES=4;
+    protected final byte[] MAGIC_BYTES;
+    
+    public ContentTypeDetectingInputStreamWrapper(InputStream source) throws IOException
+    {
+        super(source);
+        byte[] MAGIC_BYTES=new byte[MAX_MAGIC_BYTES];
+        mark(MAX_MAGIC_BYTES);
+        
+        try
+        {
+            int bytesRead=read(MAGIC_BYTES);
+            if (bytesRead<MAX_MAGIC_BYTES) // Not enough data in stream
+            {
+                if (bytesRead<=0) MAGIC_BYTES=new byte[0]; // no data
+                else MAGIC_BYTES=Arrays.copyOf(MAGIC_BYTES, bytesRead); // fewer bytes
+            }
+            this.MAGIC_BYTES=MAGIC_BYTES;
+        }
+        finally
+        {
+            reset();
+        }
+    }
+    
+    protected boolean streamStartsWithMagicBytes(byte[] bytes)
+    {
+        if (MAGIC_BYTES.length<bytes.length) return false;
+        for (int i=0;i<bytes.length;i++)
+        {
+            if (MAGIC_BYTES[i]!=bytes[i]) return false;
+        }
+        return true;
+    }
+    
+    protected final static byte[] MAGIC_BYTES_PDF="%PDF".getBytes();
+    public boolean isPdf()
+    {
+        return streamStartsWithMagicBytes(MAGIC_BYTES_PDF);
+    }
+    
+}

--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -30,6 +30,7 @@ import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.resource.ImageResource;
 import org.xhtmlrenderer.swing.NaiveUserAgent;
+import org.xhtmlrenderer.util.ContentTypeDetectingInputStreamWrapper;
 import org.xhtmlrenderer.util.XRLog;
 
 import com.itextpdf.text.Image;
@@ -72,8 +73,10 @@ public class ITextUserAgent extends NaiveUserAgent {
                 InputStream is = resolveAndOpenStream(uriStr);
                 if (is != null) {
                     try {
-                        URI uri = new URI(uriStr);
-                        if (uri.getPath() != null && uri.getPath().toLowerCase().endsWith(".pdf")) {
+                        ContentTypeDetectingInputStreamWrapper cis=new ContentTypeDetectingInputStreamWrapper(is);
+                        is=cis;
+                        if (cis.isPdf()) {
+                            URI uri = new URI(uriStr);
                             PdfReader reader = _outputDevice.getReader(uri);
                             PDFAsImage image = new PDFAsImage(uri);
                             Rectangle rect = reader.getPageSizeWithRotation(1);

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -30,6 +30,7 @@ import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.resource.ImageResource;
 import org.xhtmlrenderer.swing.NaiveUserAgent;
+import org.xhtmlrenderer.util.ContentTypeDetectingInputStreamWrapper;
 import org.xhtmlrenderer.util.ImageUtil;
 import org.xhtmlrenderer.util.XRLog;
 
@@ -71,8 +72,10 @@ public class ITextUserAgent extends NaiveUserAgent {
                 InputStream is = resolveAndOpenStream(uriStr);
                 if (is != null) {
                     try {
-                        URI uri = new URI(uriStr);
-                        if (uri.getPath() != null && uri.getPath().toLowerCase().endsWith(".pdf")) {
+                        ContentTypeDetectingInputStreamWrapper cis=new ContentTypeDetectingInputStreamWrapper(is);
+                        is=cis;
+                        if (cis.isPdf()) {
+                            URI uri = new URI(uriStr);
                             PdfReader reader = _outputDevice.getReader(uri);
                             PDFAsImage image = new PDFAsImage(uri);
                             Rectangle rect = reader.getPageSizeWithRotation(1);


### PR DESCRIPTION
Hi,

I had some problems with background-pdf-images from classpath after packaging as jar. The problem is that ITextRenderer tries to detect if an image is a PDF using "path" from the URI which points to the jar, not to the PDF.

So I created a stream wrapper that reads a few bytes (and then resets the stream) to detect the stream's content on a reliable way and changed both ITextRenderer implementations.
