### PR TITLE
debug trim leading spaces  in "white-space: pre-wrap;" style context

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
@@ -885,7 +885,6 @@ public class InlineBoxing {
                     || whitespace == IdentValue.PRE_LINE
                     || (whitespace == IdentValue.PRE_WRAP
                         && lbContext.getStart() > 0
-                        && (lbContext.getStart() - 1 >= 0)
                         && (lbContext.getMaster().length() > lbContext.getStart() - 1)
                         && lbContext.getMaster().charAt(lbContext.getStart() - 1) != WhitespaceStripper.EOLC)) {
                 return true;


### PR DESCRIPTION
Fixes an issue with leading whitepsaces being trimmed although white-space: pre-wrap; is set.
