### PR TITLE
Use BreakIterator.getWordInstance instead of BreakIterator.getLineInstan...

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -175,7 +175,7 @@ public class Breaker {
     }
 
 	public static BreakIterator getWordStream(String s) {
-		BreakIterator i = BreakIterator.getLineInstance();
+		BreakIterator i = BreakIterator.getWordInstance();
 		i.setText(s);
 		return i;
 	}


### PR DESCRIPTION
...ce to find breaking points in text.

As discussed here: https://groups.google.com/forum/#!topic/flying-saucer-users/qKol3scrEVY

@kmtong Can you please have a look at this? Thanks
