### PR TITLE
Implement Scrollable interface for viewport resize rules in Swing RootPanel.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import javax.swing.CellRendererPane;
-import javax.swing.JLayer;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JViewport;
@@ -679,19 +678,10 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     }
 
     public boolean getScrollableTracksViewportHeight() {
-        // We find the JViewport, and if the last layout height of this
-        // component is <= the viewport height then we make the viewport
-        // height match the component size.
-        
-        // Track back until we find a parent that isn't a JLayer,
-        Container parent = getParent();
-        while (parent instanceof JLayer) {
-            parent = parent.getParent();
-        }
-        if (parent instanceof JViewport) {
-            return getPreferredSize().height <= parent.getHeight();
-        }
-        return false;
+        // If the last layout height of this component is <= the viewport
+        // height then we make the viewport height match the component size.
+        int viewportHeight = enclosingScrollPane.getViewport().getHeight();
+        return getPreferredSize().height <= viewportHeight;
     }
 
 }


### PR DESCRIPTION
I noticed when Flying Saucer lays out a page within a JScrollPane, the viewport dimensions were often lagging behind the JScrollPane component size. This was causing scroll bars to flicker when resizing a frame with a scrollable RootPanel in it (very noticeable when scroll bar policy is set to 'AS_NEEDED'). This patch fixes the problem by using the Scrollable interface to handle setting the viewport size.
