### PR TITLE
itext5: Allow PDF resources as background image

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -99,7 +99,11 @@ public class ITextUserAgent extends NaiveUserAgent {
             }
 
             if (resource != null) {
-                resource = new ImageResource(resource.getImageUri(), (FSImage) ((ITextFSImage) resource.getImage()).clone());
+                FSImage image=resource.getImage();
+                if (image instanceof ITextFSImage) {
+                    image=(FSImage) ((ITextFSImage) resource.getImage()).clone();
+                }
+                resource = new ImageResource(resource.getImageUri(), image);
             } else {
                 resource = new ImageResource(uriStr, null);
             }


### PR DESCRIPTION
This patch just applies the fix to ITextUserAgent from flyingsaucerproject/flyingsaucer#51 to the corresponding itext5 version.
