### PR TITLE
Fix the maven build for the java 8 JDK.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
See http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete for details.
