### PR TITLE
Added proper font-weight and font-style handling with @font-face rule.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/sheet/FontFaceRule.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/sheet/FontFaceRule.java
@@ -69,4 +69,26 @@ public class FontFaceRule implements RulesetContainer {
 
         return false;
     }
+
+    public boolean hasFontWeight() {
+        for (Iterator i = _ruleset.getPropertyDeclarations().iterator(); i.hasNext(); ) {
+            PropertyDeclaration decl = (PropertyDeclaration)i.next();
+            if (decl.getPropertyName().equals("font-weight")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean hasFontStyle() {
+        for (Iterator i = _ruleset.getPropertyDeclarations().iterator(); i.hasNext(); ) {
+            PropertyDeclaration decl = (PropertyDeclaration)i.next();
+            if (decl.getPropertyName().equals("font-style")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -134,15 +134,25 @@ public class ITextFontResolver implements FontResolver {
             }
 
             boolean embedded = style.isIdent(CSSName.FS_PDF_FONT_EMBED, IdentValue.EMBED);
-
             String encoding = style.getStringProperty(CSSName.FS_PDF_FONT_ENCODING);
-
             String fontFamily = null;
+            IdentValue fontWeight = null;
+            IdentValue fontStyle = null;
+
             if (rule.hasFontFamily()) {
                 fontFamily = style.valueByName(CSSName.FONT_FAMILY).asString();
             }
+
+            if (rule.hasFontWeight()) {
+                fontWeight = style.getIdent(CSSName.FONT_WEIGHT);
+            }
+
+            if (rule.hasFontStyle()) {
+                fontStyle = style.getIdent(CSSName.FONT_STYLE);
+            }
+
             try {
-                addFontFaceFont(fontFamily, src.asString(), encoding, embedded, font1, font2);
+                addFontFaceFont(fontFamily, fontWeight, fontStyle, src.asString(), encoding, embedded, font1, font2);
             } catch (DocumentException e) {
                 XRLog.exception("Could not load font " + src.asString(), e);
                 continue;
@@ -243,7 +253,7 @@ public class ITextFontResolver implements FontResolver {
     }
 
     private void addFontFaceFont(
-            String fontFamilyNameOverride, String uri, String encoding, boolean embedded, byte[] afmttf, byte[] pfb)
+            String fontFamilyNameOverride, IdentValue fontWeightOverride, IdentValue fontStyleOverride, String uri, String encoding, boolean embedded, byte[] afmttf, byte[] pfb)
             throws DocumentException, IOException {
         String lower = uri.toLowerCase();
         if (lower.endsWith(".otf") || lower.endsWith(".ttf") || lower.indexOf(".ttc,") != -1) {
@@ -267,6 +277,14 @@ public class ITextFontResolver implements FontResolver {
                 }
 
                 descr.setFromFontFace(true);
+
+                if (fontWeightOverride != null) {
+                    descr.setWeight(convertWeightToInt(fontWeightOverride));
+                }
+
+                if (fontStyleOverride != null) {
+                    descr.setStyle(fontStyleOverride);
+                }
 
                 fontFamily.addFontDescription(descr);
             }
@@ -379,6 +397,7 @@ public class ITextFontResolver implements FontResolver {
 
         String cacheKey = getHashName(normalizedFontFamily, weight, style);
         FontDescription result = (FontDescription)_fontCache.get(cacheKey);
+
         if (result != null) {
             return new ITextFSFont(result, size);
         }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -505,6 +505,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
         if (fontSpec != null) {
             int need = ITextFontResolver.convertWeightToInt(fontSpec.fontWeight);
             int have = desc.getWeight();
+
             if (need > have) {
                 cb.setTextRenderingMode(PdfContentByte.TEXT_RENDER_MODE_FILL_STROKE);
                 float lineWidth = fontSize * 0.04f; // 4% of font size


### PR DESCRIPTION
This change fixes some issues when specifying a specific font-style or
font-weight through @font-face. For example, when importing a special font
resource specifically for the italic font-style, the PDF output would not
match the correct font if the css rule specifies the style/weight.

Example from my stylesheet:

``` css
@font-face {
  font-family: "Eurostile LT";
  font-weight: normal;
  src: asset-url("pdf/fonts/eurostile.ttf");
  -fs-pdf-font-embed: embed;
  -fs-pdf-font-encoding: Identity-H;
}

@font-face {
  font-family: "Eurostile LT";
  src: asset-url("pdf/fonts/eurostile_bold.ttf");
  font-weight: bold;
  -fs-pdf-font-embed: embed;
  -fs-pdf-font-encoding: Identity-H;
}

body {
   font-family: "Eurostile LT";
   font-weight: bold;
}
```

Without this patch the PDF would not use the bold font.
