### PR TITLE
Avoid line breaking before punctuation characters.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -177,7 +177,7 @@ public class Breaker {
     }
 
 	public static BreakIterator getWordStream(String s) {
-		BreakIterator i = BreakIterator.getWordInstance();
+		BreakIterator i = new UrlAwareLineBreakIterator();
 		i.setText(s);
 		return i;
 	}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/UrlAwareLineBreakIterator.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/UrlAwareLineBreakIterator.java
@@ -1,0 +1,203 @@
+package org.xhtmlrenderer.layout;
+
+import java.text.BreakIterator;
+import java.text.CharacterIterator;
+
+
+/**
+ * BreakIterator implementation that improves line breaking for URLs. Break points are supported
+ * before path fragments.
+ */
+public class UrlAwareLineBreakIterator extends BreakIterator {
+
+    private static final String BREAKING_CHARS = ".,:;!?- \n\r\t/";
+
+    private BreakIterator delegate = BreakIterator.getLineInstance();
+    private String text;
+    private Range currentRange;
+
+
+    public int preceding(int offset) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int last() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int previous() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int next() {
+        checkNotAheadOfDelegate();
+
+        Range searchRange = currentRange; // the range in which we search for slashes
+
+        if (isDelegateInSync()) {
+            boolean reachedEnd = advanceDelegate();
+            if (reachedEnd) {
+                return BreakIterator.DONE;
+            }
+
+            if ("://".equals(substring(new Range(currentRange.getStop(), -1, 2)))) {
+                searchRange = searchRange.withStart(currentRange.getStop() + 2);
+                advanceDelegate(); // no reached-end check needed here, because there are at least two slashes ahead
+            }
+        }
+        searchRange = searchRange.withStop(currentRange.getStop());
+
+        searchRange = trimSearchRange(searchRange);
+        int nextSlash = findSlashInRange(searchRange);
+        currentRange = currentRange.withStart(nextSlash > -1 ? nextSlash : delegate.current());
+
+        return currentRange.getStart();
+    }
+
+
+    private Range trimSearchRange(Range searchRange) {
+        // Exclude leading breaking characters (should really only be slash).
+        while (searchRange.getStart() < currentRange.getStop() && BREAKING_CHARS.indexOf(text.charAt(searchRange.getStart())) > -1) {
+            searchRange = searchRange.incrementStart();
+        }
+
+        // Exclude trailing breaking characters.
+        while (searchRange.getStop() > searchRange.getStart() && BREAKING_CHARS.indexOf(text.charAt(searchRange.getStop() - 1)) > -1) {
+            searchRange = searchRange.decrementStop();
+        }
+
+        return searchRange;
+    }
+
+
+    private int findSlashInRange(Range searchRange) {
+        int nextSlash = text.indexOf('/', searchRange.getStart());
+        return nextSlash < searchRange.getStop() ? nextSlash : -1;
+    }
+
+
+    private String substring(Range range) {
+        return text.substring(Math.max(0, range.getStart()), Math.min(text.length(), range.getStop()));
+    }
+
+
+    private void checkNotAheadOfDelegate() {
+        // This is a sanity check. We should never be in this state.
+        if (currentRange.getStart() > delegate.current()) {
+            throw new IllegalStateException("Iterator ahead of delegate.");
+        }
+    }
+
+
+    private boolean isDelegateInSync() {
+        return currentRange.getStart() == delegate.current();
+    }
+
+
+    private boolean advanceDelegate() {
+        int next = delegate.next();
+        currentRange = currentRange.withStop(next);
+        return next == BreakIterator.DONE;
+    }
+
+
+    public int next(int n) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public boolean isBoundary(int offset) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int following(int offset) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int first() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public void setText(CharacterIterator newText) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public int current() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    public CharacterIterator getText() {
+        return delegate.getText();
+    }
+
+
+    public void setText(String newText) {
+        delegate.setText(newText);
+        text = newText;
+        currentRange = new Range(delegate.current(), delegate.current());
+    }
+
+
+    private static class Range {
+
+        int start;
+        int stop;
+
+
+        public Range(int start, int stop) {
+            this.start = start;
+            this.stop = Math.max(start, stop);
+        }
+
+
+        public Range(int referencePoint, int startOffset, int stopOffset) {
+            this(referencePoint + startOffset, referencePoint + stopOffset);
+        }
+
+
+        public Range withStart(int start) {
+            return new Range(start, stop);
+        }
+
+
+        public Range withStop(int stop) {
+            return new Range(start, stop);
+        }
+
+
+        public Range incrementStart() {
+            int newStart = start + 1;
+            return new Range(newStart, Math.max(newStart, stop));
+        }
+
+
+        public Range decrementStop() {
+            int newStop = stop + -1;
+            return new Range(Math.min(start, newStop), newStop);
+        }
+
+
+        public int getStart() {
+            return start;
+        }
+
+
+        public int getStop() {
+            return stop;
+        }
+
+
+        public String toString() {
+            return "[" + start + ", " + stop + ")";
+        }
+    }
+
+}

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/UrlAwareLineBreakIteratorTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/UrlAwareLineBreakIteratorTest.java
@@ -1,0 +1,129 @@
+package org.xhtmlrenderer.layout;
+
+import java.text.BreakIterator;
+
+import junit.framework.TestCase;
+
+
+public class UrlAwareLineBreakIteratorTest extends TestCase {
+
+    public void testNext_BreakAtSpace() throws Exception {
+        assertBreaksCorrectly("Hello World! World foo",
+                new String[] {"Hello ", "World! ", "World ", "foo"});
+    }
+
+
+    public void testNext_BreakAtPunctuation() throws Exception {
+        assertBreaksCorrectly("The.quick,brown:fox;jumps!over?the(lazy)[dog]",
+                new String[] {"The.", "quick,", "brown:", "fox;", "jumps!", "over?", "the", "(lazy)", "[dog]"});
+    }
+
+
+    public void testNext_BreakAtHyphen() throws Exception {
+        assertBreaksCorrectly("Pseudo-element",
+                new String[] {"Pseudo-", "element"});
+    }
+
+
+    public void testNext_BreakAtSlash() throws Exception {
+        assertBreaksCorrectly("Justice/Law",
+                new String[] {"Justice", "/Law"});
+    }
+
+
+    public void testNext_WordBeginsWithSlash() throws Exception {
+        assertBreaksCorrectly("Justice /Law",
+                new String[] {"Justice ", "/Law"});
+    }
+
+
+    public void testNext_WordEndsWithSlash() throws Exception {
+        assertBreaksCorrectly("Justice/ Law",
+                new String[] {"Justice/ ", "Law"});
+    }
+
+
+    public void testNext_WordEndsWithSlashMultipleWhitespace() throws Exception {
+        assertBreaksCorrectly("Justice/    Law",
+                new String[] {"Justice/    ", "Law"});
+    }
+
+
+    public void testNext_SlashSeparatedSequence() throws Exception {
+        assertBreaksCorrectly("/this/is/a/long/path/name/",
+                new String[] {"/this", "/is", "/a", "/long", "/path", "/name/"});
+    }
+
+
+    public void testNext_UrlInside() throws Exception {
+        assertBreaksCorrectly("Sentence with url https://github.com/flyingsaucerproject/flyingsaucer?test=true&param2=false inside.",
+                new String[] {"Sentence ", "with ", "url ", "https://github.", "com", "/flyingsaucerproject", "/flyingsaucer?",
+                        "test=true&param2=false ", "inside."});
+    }
+
+
+    public void testNext_MultipleSlashesInWord() throws Exception {
+        assertBreaksCorrectly("word/////word",
+                new String[] {"word", "/////word"});
+    }
+
+
+    public void testNext_MultipleSlashesBeforeWord() throws Exception {
+        assertBreaksCorrectly("hello /////world",
+                new String[] {"hello ", "/////world"});
+    }
+
+
+    public void testNext_MultipleSlashesAfterWord() throws Exception {
+        assertBreaksCorrectly("hello world/////",
+                new String[] {"hello ", "world/////"});
+    }
+
+
+    public void testNext_MultipleSlashesAroundWord() throws Exception {
+        assertBreaksCorrectly("hello /////world/////",
+                new String[] {"hello ", "/////world/////"});
+    }
+
+
+    public void testNext_WhitespaceAfterTrailingSlashes() throws Exception {
+        assertBreaksCorrectly("hello world///    ",
+                new String[] {"hello ", "world///    "});
+    }
+
+
+    public void testNext_ShortUrl() throws Exception {
+        assertBreaksCorrectly("http://localhost",
+                new String[] {"http://localhost"});
+    }
+
+
+    public void testNext_IncompleteUrl() throws Exception {
+        assertBreaksCorrectly("http://",
+                new String[] {"http://"});
+    }
+
+
+    private void assertBreaksCorrectly(String input, String[] segments) {
+        BreakIterator iterator = new UrlAwareLineBreakIterator();
+        iterator.setText(input);
+
+        int segmentIndex = 0;
+        int lastBreakPoint = 0;
+        int breakpoint;
+        while ((breakpoint = iterator.next()) != BreakIterator.DONE) {
+            if (segmentIndex < segments.length) {
+                String segment = segments[segmentIndex++];
+                assertEquals("Segment #" + segmentIndex + " does not match.", segment, input.substring(lastBreakPoint, breakpoint));
+                lastBreakPoint = breakpoint;
+            } else {
+                fail("Too few segments.");
+            }
+        }
+        assertEquals("Last breakpoint is wrong.", input.length(), lastBreakPoint);
+        if (segmentIndex != segments.length) {
+            fail("Too many segments.");
+        }
+    }
+
+}


### PR DESCRIPTION
Follow-up fix for pull request #60 

This introduces a new BreakIterator that delegates to BreakIterator.getLineInstance to retrieve break points. Additionally it provides breakpoints in long URLs at slash characters.

@pbrant  @tobymckoi @kmtong 
Would be nice if you could test this and let me know how it works for you.