### PR TITLE
maven package should work with java 7 as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@
     </developer>
   </developers>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -83,7 +95,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalparam>${javadoc.opts}</additionalparam>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Since commit 64d02a7f6d78aa8d5b6609f3d4e080c68c1c6a60 it was not possible to build Flying Saucer Core Renderer. With this patch Java 8 and Java 7 will work. Tested both using mvn package.