### PR TITLE
Stream from redirected conn

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -173,9 +173,14 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 		if (needsRedirect(status)) {
 			// get redirect url from "location" header field
 			String newUrl = origin.getHeaderField("Location");
-			XRLog.load("Connection is redirected to: " + newUrl);
-			// open the new connnection again
-			connection = new URL(newUrl).openConnection();
+			
+			if (origin.getInstanceFollowRedirects()) {
+				XRLog.load("Connection is redirected to: " + newUrl);
+				// open the new connnection again
+				connection = new URL(newUrl).openConnection();
+			} else {
+				XRLog.load("Redirect is required but not allowed to: " + newUrl);
+			}
 		}
 		return connection;
 	}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -121,7 +121,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         java.io.InputStream is = null;
         String resolvedUri = resolveURI(uri);
         try {
-            is = new URL(resolvedUri).openStream();
+            is = openStream(resolvedUri);
         } catch (java.net.MalformedURLException e) {
             XRLog.exception("bad URL given: " + resolvedUri, e);
         } catch (java.io.FileNotFoundException e) {
@@ -131,6 +131,10 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         }
         return is;
     }
+	
+	protected InputStream openStream(String uri) throws MalformedURLException, IOException {
+		return new URL(uri).openStream();
+	}
 
     /**
      * Retrieves the CSS located at the given URI.  It's assumed the URI does point to a CSS file--the URI will

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -117,17 +117,17 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      * @return The stylesheet value
      */
     //TOdO:implement this with nio.
-    protected InputStream resolveAndOpenStream(String uri) {
+    protected InputStream resolveAndOpenStream(final String uri) {
         java.io.InputStream is = null;
-        uri = resolveURI(uri);
+        String resolvedUri = resolveURI(uri);
         try {
-            is = new URL(uri).openStream();
+            is = new URL(resolvedUri).openStream();
         } catch (java.net.MalformedURLException e) {
-            XRLog.exception("bad URL given: " + uri, e);
+            XRLog.exception("bad URL given: " + resolvedUri, e);
         } catch (java.io.FileNotFoundException e) {
-            XRLog.exception("item at URI " + uri + " not found");
+            XRLog.exception("item at URI " + resolvedUri + " not found");
         } catch (java.io.IOException e) {
-            XRLog.exception("IO problem for " + uri, e);
+            XRLog.exception("IO problem for " + resolvedUri, e);
         }
         return is;
     }


### PR DESCRIPTION
Hi,
we have a setup were our application operates in a HTTP-context behind a proxy that has SSL enabled and that redirects HTTP to HTTPS. The HTML we pass over to flying-saucer only contains HTTP references.
The problem is that flying-saucer won't follow redirects.

We implement the handling of redirection in flying-saucer.

It would be nice if you could merge this.
