### PR TITLE
ITextRenderer has been made more customizable

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -99,11 +99,18 @@ public class ITextRenderer {
     }
 
     public ITextRenderer(float dotsPerPoint, int dotsPerPixel) {
+        this(dotsPerPoint, dotsPerPixel, new ITextOutputDevice(dotsPerPoint));
+    }
+
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice) {
+        this(dotsPerPoint, dotsPerPixel, outputDevice, new ITextUserAgent(outputDevice));
+    }
+
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice, ITextUserAgent userAgent) {
         _dotsPerPoint = dotsPerPoint;
 
-        _outputDevice = new ITextOutputDevice(_dotsPerPoint);
+        _outputDevice = outputDevice;
 
-        ITextUserAgent userAgent = new ITextUserAgent(_outputDevice);
         _sharedContext = new SharedContext();
         _sharedContext.setUserAgentCallback(userAgent);
         _sharedContext.setCss(new StyleReference(userAgent));


### PR DESCRIPTION
- Before this commit it was hard to customize the ITextUserAgent, as it was private and not accessible from the descendant classes. 
- We had to rework the entire the ITextRenderer instead of just extending it. Now user can just extend the class and initialize it according to his needs.
- Now we can add our own customized ITextUserAgent and OutputDevice. 