### PR TITLE
Added method which layouts and paints pdf files page by page

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -109,6 +109,20 @@ public class BlockBox extends Box implements InlinePaintable {
         super();
     }
 
+    public void clear() {
+        super.clear();
+
+        _markerData = null;
+        _persistentBFC = null;
+        _staticEquivalent = null;
+        _replacedElement = null;
+        _inlineContent = null;
+        _pendingCollapseCalculation = null;
+        _firstLineStyle = null;
+        _firstLetterStyle = null;
+        _floatedBoxData = null;
+    }
+
     public BlockBox copyOf() {
         BlockBox result = new BlockBox();
         result.setStyle(getStyle());

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/Box.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/Box.java
@@ -101,6 +101,20 @@ public abstract class Box implements Styleable {
     protected Box() {
     }
 
+    public void clear() {
+        _element = null;
+        _layer = null;
+        _containingLayer = null;
+        _boxes = null;
+        _relativeOffset = null;
+        _paintingInfo = null;
+        _workingMargin = null;
+        //_pseudoElementOrClass = null;
+        //_parent = null;
+        //_style = null;
+        //_containingBlock = null;
+    }
+
     public abstract String dump(LayoutContext c, String indent, int which);
 
     protected void dumpBoxes(

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/PageBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/PageBox.java
@@ -81,6 +81,12 @@ public class PageBox {
     private MarginAreaContainer[] _marginAreas = new MarginAreaContainer[MARGIN_AREA_DEFS.length];
     
     private Element _metadata;
+
+    public void clear() {
+        this._metadata = null;
+        this._marginAreas = null;
+        this._pageInfo = null;
+    }
     
     public int getWidth(CssContext cssCtx) {
         resolvePageDimensions(cssCtx);

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -273,6 +273,9 @@ public class ITextRenderer {
         renderingContext.setPageCount(pageCount);
         firePreWrite(pageCount); // opportunity to adjust meta data
         setDidValues(doc); // set PDF header fields from meta data
+        if(docListener != null) {
+            docListener.setPageCount(pageCount);
+        }
 
         for (int i = 0; i < pageCount; i++) {
             PageBox currentPage = (PageBox) pages.get(i);
@@ -291,6 +294,8 @@ public class ITextRenderer {
                 doc.newPage();
                 _outputDevice.initializePage(writer.getDirectContent(), nextPageSize.getHeight());
             }
+
+            currentPage.clear();
         }
 
         _outputDevice.finish(renderingContext, _root);

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -61,6 +61,7 @@ import org.xhtmlrenderer.simple.extend.XhtmlNamespaceHandler;
 import org.xhtmlrenderer.util.Configuration;
 import org.xml.sax.InputSource;
 
+import com.lowagie.text.DocListener;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.pdf.PdfWriter;
 
@@ -209,6 +210,96 @@ public class ITextRenderer {
         root.getLayer().trimEmptyPages(c, dim.height);
         root.getLayer().layoutPages(c);
         _root = root;
+    }
+
+    public void layoutAndPaint(OutputStream os, DocListener docListener) throws DocumentException
+    {
+        //------------------------------------------------------------------------------
+        //creation basic layout
+        //------------------------------------------------------------------------------
+        LayoutContext layoutContext = newLayoutContext();
+        BlockBox root = BoxBuilder.createRootBox(layoutContext, _doc);
+        root.setContainingBlock(new ViewportBox(getInitialExtents(layoutContext)));
+        root.layout(layoutContext);
+        Dimension dim = root.getLayer().getPaintingDimension(layoutContext);
+        root.getLayer().trimEmptyPages(layoutContext, dim.height);
+
+        //------------------------------------------------------------------------------
+        //layout first page
+        //------------------------------------------------------------------------------
+        _root = root;
+        layoutContext.setRootDocumentLayer(layoutContext.getRootLayer());
+        ((PageBox)(_root.getLayer().getPages().get(0))).layout(layoutContext);
+
+        //------------------------------------------------------------------------------
+        //initialising output device
+        //------------------------------------------------------------------------------
+        List pages = _root.getLayer().getPages();
+
+        RenderingContext renderingContext = newRenderingContext();
+        renderingContext.setInitialPageNo(0);
+        PageBox firstPage = (PageBox) pages.get(0);
+        com.lowagie.text.Rectangle firstPageSize = new com.lowagie.text.Rectangle(0, 0, firstPage.getWidth(renderingContext) / _dotsPerPoint,
+                firstPage.getHeight(renderingContext) / _dotsPerPoint);
+
+        com.lowagie.text.Document doc = new com.lowagie.text.Document(firstPageSize, 0, 0, 0, 0);
+        PdfWriter writer = docListener == null ? PdfWriter.getInstance(doc, os) :
+                PdfWriter.getInstance(doc, os, docListener);
+        if (_pdfVersion != null) {
+            writer.setPdfVersion(_pdfVersion.charValue());
+        }
+        if (_pdfEncryption != null) {
+            writer.setEncryption(_pdfEncryption.getUserPassword(), _pdfEncryption.getOwnerPassword(),
+                    _pdfEncryption.getAllowedPrivileges(), _pdfEncryption.getEncryptionType());
+        }
+        _pdfDoc = doc;
+        _writer = writer;
+
+        firePreOpen();
+        doc.open();
+
+        //------------------------------------------------------------------------------
+        //writing page by page
+        //------------------------------------------------------------------------------
+        _outputDevice.setRoot(_root);
+
+        _outputDevice.start(_doc);
+        _outputDevice.setWriter(writer);
+        _outputDevice.initializePage(writer.getDirectContent(), firstPageSize.getHeight());
+
+        _root.getLayer().assignPagePaintingPositions(renderingContext, Layer.PAGED_MODE_PRINT);
+
+        int pageCount = _root.getLayer().getPages().size();
+        renderingContext.setPageCount(pageCount);
+        firePreWrite(pageCount); // opportunity to adjust meta data
+        setDidValues(doc); // set PDF header fields from meta data
+
+        for (int i = 0; i < pageCount; i++) {
+            PageBox currentPage = (PageBox) pages.get(i);
+            if(i > 0) {
+                currentPage.layout(layoutContext);
+            }
+
+            renderingContext.setPage(i, currentPage);
+            paintPage(renderingContext, writer, currentPage);
+            _outputDevice.finishPage();
+            if (i != pageCount - 1) {
+                PageBox nextPage = (PageBox) pages.get(i + 1);
+                com.lowagie.text.Rectangle nextPageSize = new com.lowagie.text.Rectangle(0, 0, nextPage.getWidth(renderingContext) / _dotsPerPoint,
+                        nextPage.getHeight(renderingContext) / _dotsPerPoint);
+                doc.setPageSize(nextPageSize);
+                doc.newPage();
+                _outputDevice.initializePage(writer.getDirectContent(), nextPageSize.getHeight());
+            }
+        }
+
+        _outputDevice.finish(renderingContext, _root);
+
+        //------------------------------------------------------------------------------
+        //closing stuff
+        //------------------------------------------------------------------------------
+        fireOnClose();
+        doc.close();
     }
 
     private Rectangle getInitialExtents(LayoutContext c) {


### PR DESCRIPTION
Regular pdf creation approach (layout everything, then paint everything) may not always work. For example, in a case of exporting huge html file, it makes sense to run export task in background. But there is no easy way of telling actual progress for this task - how many pages were rendered? Added method allows to layout and render content page-by-page, which allows to calculate progress more precisely.
