### PR TITLE
Fix for Google Code Issue 231: Bold font emulation for PDF rendering causes black borders around each letter

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -502,6 +502,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                 float lineWidth = fontSize * 0.04f; // 4% of font size
                 cb.setLineWidth(lineWidth);
                 resetMode = true;
+                ensureStrokeColor();
             }
             if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC)) {
                 b = 0f;

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -511,6 +511,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                 float lineWidth = fontSize * 0.04f; // 4% of font size
                 cb.setLineWidth(lineWidth);
                 resetMode = true;
+                ensureStrokeColor();
             }
             if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC)) {
                 b = 0f;


### PR DESCRIPTION
As described in Google Code [Issue 231](https://code.google.com/p/flying-saucer/issues/detail?id=231), using bold font emulation causes a black border around the text.

This was happening because the stroke colour wasn't getting set prior to rendering the text.