### PR TITLE
Fix integer arithmetic rounding error in BorderPainter.generateBorderShape()

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/LineBreakContext.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/LineBreakContext.java
@@ -76,6 +76,13 @@ public class LineBreakContext {
     }
     
     public String getCalculatedSubstring() {
+        // mimic the calculation in InlineText.setSubstring to strip newlines for our width calculations
+        // the original text width calculation in InlineBox.calcMaxWidthFromLineLength() excludes the newline character
+        // so if we include them here we get spurious newlines
+        // apparently newlines do take up some width in most fonts
+        if (_end > 0 && _master.charAt(_end-1) == WhitespaceStripper.EOLC) {
+            return _master.substring(_start, _end-1);
+        }
         return _master.substring(_start, _end);
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
@@ -138,7 +138,7 @@ public class BorderPainter {
         path.transform(AffineTransform.getRotateInstance(
                 props.getRotation()));
         path.transform(AffineTransform.getTranslateInstance( 
-                bounds.width/2+bounds.x, bounds.height/2+bounds.y));
+                bounds.width/2f+bounds.x, bounds.height/2f+bounds.y));
         
         return path;
     }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
@@ -247,6 +247,8 @@ public class InlineBox implements Styleable {
                         wordWidth += spaceWidth;
                         minWordWidth += spaceWidth;
                     }
+                } else {
+                    maxWidth += spaceWidth;
                 }
                 spaceCount = 0;
             }
@@ -261,9 +263,6 @@ public class InlineBox implements Styleable {
                 _minWidth = minWordWidth;
             }
             maxWidth += wordWidth;
-            if (! includeWS) {
-                maxWidth += spaceWidth;
-            }
 
             last = current;
             for (int i = current; i < text.length(); i++) {
@@ -290,6 +289,8 @@ public class InlineBox implements Styleable {
                     wordWidth += spaceWidth;
                     minWordWidth += spaceWidth;
                 }
+            } else {
+                maxWidth += spaceWidth;
             }
             spaceCount = 0;
         }


### PR DESCRIPTION
This error causes a (incorrect) 1 pixel offset when rendering borders for boxes that have either a width or height that is an odd number.

The error occurs in the final translation of the border into position.  Seems like it was a simple oversight given that the same error is avoided two lines above. 

PS:  Any chance of a 9.0.8 release any time soon, would be nice to be able to pull this version from maven central...