### PR TITLE
Fixed build on UNIX-like operating systems.

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -35,7 +35,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-examples/pom.xml
+++ b/flying-saucer-examples/pom.xml
@@ -61,7 +61,7 @@
     <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-log4j/pom.xml
+++ b/flying-saucer-log4j/pom.xml
@@ -40,7 +40,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -40,7 +40,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -40,7 +40,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-swt-examples/pom.xml
+++ b/flying-saucer-swt-examples/pom.xml
@@ -116,7 +116,7 @@
 	<resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-swt/pom.xml
+++ b/flying-saucer-swt/pom.xml
@@ -97,7 +97,7 @@
 	  <resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>/META-INF</targetPath>
+	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>


### PR DESCRIPTION
Specifying "/META-INF" as target for the license files in the <resources> tag will result in maven trying to put the license files into a directory "META-INF" located directly under the filesystem root. This directory does not exist and is outside of the maven build folder. Therefore we need to prefix the target directory with the maven property "${project.build.outputDirectory}" which points to the respective "target/classes" subfolder in each maven module.