### PR TITLE
Fixed copying resources directories in core and example modules.

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -32,14 +32,17 @@
   </dependencies>
   
   <build>
-	  <resources>
-	    <resource>
-	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
-	      <includes>
-	        <include>LICENSE*</include>
-	      </includes>
-	    </resource>
-	  </resources>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>../</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
+    </resources>
   </build>
 </project>

--- a/flying-saucer-examples/pom.xml
+++ b/flying-saucer-examples/pom.xml
@@ -59,13 +59,16 @@
       </plugin>
     </plugins>
     <resources>
-	    <resource>
-	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
-	      <includes>
-	        <include>LICENSE*</include>
-	      </includes>
-	    </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>../</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
 	</resources>
   </build>
 </project>


### PR DESCRIPTION
This ensures that the contents of the src/main/resources directories ends up in the final jar file when building the core and example maven modules. Apparently they need to be specified explicitly when adding the <resource> tag for the license files.