### PR TITLE
Add fix on PDF conversion of a HTML form hidden field with long value

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/EmptyReplacedElement.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/EmptyReplacedElement.java
@@ -43,6 +43,14 @@ public class EmptyReplacedElement extends AbstractFormField
     Element elem = box.getElement();
     String name = getFieldName(outputDevice, elem);
     String value = getValue(elem);
+    /*ISO-32000-1 defines the limit for a name in a PDF file to be at maximum 127 bytes.
+     *Source(http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf) 
+     *  see Annex C § 2 Architectural limits "Table C.1" pages 649 and 650.
+     *iText stores the hidden field value as a PDFName 
+     */
+    if (value.length() > 127) {
+    	value = value.substring(0, 127);
+    }
     acroForm.addHiddenField(name, value);
 
 


### PR DESCRIPTION
Found a problem on org.xhtmlrenderer.pdf.EmptyReplacedElement while converting an html file to PDF(IllegalArgumentException at com.lowagie.text.pdf.PdfName). The html file have an form hidden field with a long value (> 127 bytes):

```
<input id="javax.faces.ViewState" 
name="javax.faces.ViewState" type="hidden"
value="H4sIAAAAAAAAAL1XS2wbRRieOEmTtmmVtlD6UEpKi9qojeM8nPihCvKOkZNUTloQFXLH64k
96XpnOjsbOxwqeoEDFw5wQBQBEhKXcuqNAwj1wAkkkLhwQpyBExKPC/wz3rWdZtd5kHYOo33MfP
P973/u/4baHYGO3Uiv4jUcNrFVCC/mVokhk+9898pH3XafGUKowhFC3bZAwwYrhW3HCq9gg9hhzLlJ
DSwps8JLEksyjy1cICJV4ub5ZUHIAsuTP1a++PLzyOxXXQqnfAWp0atOq7gogMmZRSwZvpa6Tkk5w5
...gAH01EPA+d/Q9rgPoURhUAAA==" />
```

ISO-32000-1 defines the limit for a name in a PDF file to be at maximum 127 bytes (see discussion: http://stackoverflow.com/questions/18254576/the-name-is-too-long-argumentexception).
iText stores the hidden field value as a PDFName and check its length. If more than 127 bytes throws an IllegalArgumentException. 

This fix, limits the length to 127 bytes.
