### PR TITLE
Remove stacktrace

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/StylesheetFactoryImpl.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/StylesheetFactoryImpl.java
@@ -79,7 +79,6 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
             return _cssParser.parseStylesheet(info.getUri(), info.getOrigin(), reader);
         } catch (IOException e) {
             XRLog.cssParse(Level.WARNING, "Couldn't parse stylesheet at URI " + info.getUri() + ": " + e.getMessage(), e);
-            e.printStackTrace();
             return new Stylesheet(info.getUri(), info.getOrigin());
         }
     }


### PR DESCRIPTION
The stacktrace is causing messages to be output to stderr which is causing issues in our logging system due to formating, as there is a line above that logs this info the stacktrace seems redundant.
