### PR TITLE
Fix for wrapping on div as seen on chrome and firefox

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -115,11 +115,15 @@ public class Breaker {
         int lastWrap = 0;
         int graphicsLength = 0;
         int lastGraphicsLength = 0;
-
+        int lastTokenLength = 0;
+        String currentToken = "";
+        
         while (right > 0 && graphicsLength <= avail) {
             lastGraphicsLength = graphicsLength;
-            graphicsLength += c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentString.substring(left, right));
+            currentToken = currentString.substring(left, right);
+            lastTokenLength = c.getTextRenderer().getWidth(
+                    c.getFontContext(), font, currentToken);
+            graphicsLength += lastTokenLength;
             lastWrap = left;
             left = right;
             if ( tryToBreakAnywhere ) {
@@ -129,6 +133,16 @@ public class Breaker {
                 right = iterator.next();
             }
         }
+        
+        //try to see if trimming last spaces pushes content inside, browsers trim last spaces to flow the content
+        if (graphicsLength > avail) {
+            int allowanceOnTokenLength = c.getTextRenderer().getWidth(
+                    c.getFontContext(), font, currentToken.replaceFirst("\\s+$", ""));
+            if((graphicsLength - lastTokenLength + allowanceOnTokenLength) < avail) {
+                graphicsLength = graphicsLength - lastTokenLength + allowanceOnTokenLength;
+            }
+        }
+
 
         if (graphicsLength <= avail) {
             //try for the last bit too!

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -115,11 +115,15 @@ public class Breaker {
         int lastWrap = 0;
         int graphicsLength = 0;
         int lastGraphicsLength = 0;
-
+        int lastTokenLength = 0;
+        String currentToken = "";
         while (right > 0 && graphicsLength <= avail) {
             lastGraphicsLength = graphicsLength;
-            graphicsLength += c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentString.substring(left, right));
+            currentToken = currentString.substring(left, right);
+            lastTokenLength = c.getTextRenderer().getWidth(
+                    c.getFontContext(), font, currentToken);
+            graphicsLength += lastTokenLength;
+            //System.out.println(String.format("Current string -%s-", currentString.substring(left, right)));
             lastWrap = left;
             left = right;
             if ( tryToBreakAnywhere ) {
@@ -127,6 +131,15 @@ public class Breaker {
             }
             else { // break relies on BreakIterator
                 right = iterator.next();
+            }
+        }
+        
+        //try to see if trimming last spaces pushes content inside, browsers trim last spaces to flow the content
+        if (graphicsLength > avail) {
+            int allowanceOnTokenLength = c.getTextRenderer().getWidth(
+                    c.getFontContext(), font, currentToken.replaceFirst("\\s+$", ""));
+            if((graphicsLength - lastTokenLength + allowanceOnTokenLength) < avail) {
+                graphicsLength = graphicsLength - lastTokenLength + allowanceOnTokenLength;
             }
         }
 
@@ -175,10 +188,9 @@ public class Breaker {
     }
 
 	public static BreakIterator getWordStream(String s) {
-		BreakIterator i = new UrlAwareLineBreakIterator();
+	    BreakIterator i = new UrlAwareLineBreakIterator();
 		i.setText(s);
 		return i;
 	}
 
 }
-

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Breaker.java
@@ -115,15 +115,11 @@ public class Breaker {
         int lastWrap = 0;
         int graphicsLength = 0;
         int lastGraphicsLength = 0;
-        int lastTokenLength = 0;
-        String currentToken = "";
+
         while (right > 0 && graphicsLength <= avail) {
             lastGraphicsLength = graphicsLength;
-            currentToken = currentString.substring(left, right);
-            lastTokenLength = c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentToken);
-            graphicsLength += lastTokenLength;
-            //System.out.println(String.format("Current string -%s-", currentString.substring(left, right)));
+            graphicsLength += c.getTextRenderer().getWidth(
+                    c.getFontContext(), font, currentString.substring(left, right));
             lastWrap = left;
             left = right;
             if ( tryToBreakAnywhere ) {
@@ -131,15 +127,6 @@ public class Breaker {
             }
             else { // break relies on BreakIterator
                 right = iterator.next();
-            }
-        }
-        
-        //try to see if trimming last spaces pushes content inside, browsers trim last spaces to flow the content
-        if (graphicsLength > avail) {
-            int allowanceOnTokenLength = c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentToken.replaceFirst("\\s+$", ""));
-            if((graphicsLength - lastTokenLength + allowanceOnTokenLength) < avail) {
-                graphicsLength = graphicsLength - lastTokenLength + allowanceOnTokenLength;
             }
         }
 
@@ -188,9 +175,10 @@ public class Breaker {
     }
 
 	public static BreakIterator getWordStream(String s) {
-	    BreakIterator i = new UrlAwareLineBreakIterator();
+		BreakIterator i = new UrlAwareLineBreakIterator();
 		i.setText(s);
 		return i;
 	}
 
 }
+


### PR DESCRIPTION
There an issue with the last commit in Breaker.java , most browsers at end of the line trim the spaces in block, so for an example if I have text "A Certificate will be issued in view of:" and the block can only have content of length "A Certificate will be issued" (notice missing space in end) then the chrome and firefox are keeping the word 'issued' on same line and breaking after that,

![image 5](https://cloud.githubusercontent.com/assets/17438011/13298441/bb305a7a-db04-11e5-8290-7bb5d578f8fe.png)
![image 6](https://cloud.githubusercontent.com/assets/17438011/13298440/bb2f251a-db04-11e5-894e-46c9746cf009.png)

Chrome and firefox are behaving close to second scenario and are allowing the text even if it has trailng spaces going out of bounds of block. The old code without UrlAware breaker was behaving close to the chrome and firefox

```
<div style="width:675px;background-color:orange;font-size:f10pt;font-family:'Arial'">
        Prosecution on the merits is (or remains) closed in this inter partes reexamination proceeding.  This proceeding is subject to reopening at the initiative of the Office or upon petition.  <span class="italics">Cf</span>. 37 CFR 1.313(a).  A Certificate will be issued in view of:
      </div>
```

I have added the fix by allowing extra calculation on graphics length when it is reaching end of line
