### PR TITLE
Border radius with zero-width border fix

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
@@ -20,19 +20,15 @@
 package org.xhtmlrenderer.render;
 
 import java.awt.BasicStroke;
-import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Arc2D;
 import java.awt.geom.Area;
 import java.awt.geom.Path2D;
-import java.awt.geom.Point2D;
 
 import org.xhtmlrenderer.css.constants.IdentValue;
-import org.xhtmlrenderer.css.parser.FSColor;
 import org.xhtmlrenderer.css.parser.FSRGBColor;
 import org.xhtmlrenderer.css.style.BorderRadiusCorner;
 import org.xhtmlrenderer.css.style.derived.BorderPropertySet;
@@ -112,10 +108,18 @@ public class BorderPainter {
         }
         Path2D path = new Path2D.Float();
         
-        float angle = 90 * props.getTop() / (props.getTop() + props.getLeft());
+        float angle = 90;
+        float widthSum = props.getTop() + props.getLeft();
+        if (widthSum != 0.0f) { // Avoid NaN
+        	angle = angle * props.getTop() / widthSum;
+        }
         appendPath(path, 0-props.getLeft(), 0-props.getTop(), props.getLeftCorner().left(), props.getLeftCorner().right(), 90+angle, -angle-1, props.getTop(), props.getLeft(), scaledOffset, true, widthScale);
-        
-        angle = 90 * props.getTop() / (props.getTop() + props.getRight());
+
+        angle = 90;
+        widthSum = props.getTop() + props.getRight();
+        if (widthSum != 0.0f) { // Avoid NaN
+        	angle = angle * props.getTop() / widthSum;
+        }
         appendPath(path, sideWidth+props.getRight(), 0-props.getTop(), props.getRightCorner().right(), props.getRightCorner().left(), 90, -angle-1, props.getTop(), props.getRight(), scaledOffset, false, widthScale);
         
         
@@ -124,8 +128,12 @@ public class BorderPainter {
             //props = new RelativeBorderProperties(bounds, border, 0f, side, 1+scaledOffset, 1);
             
             appendPath(path, sideWidth, 0, props.getRightCorner().right(), props.getRightCorner().left(), 90-angle, angle+1, props.getTop(), props.getRight(), scaledOffset+1, false, widthScale);
-            
-            angle = 90 * props.getTop() / (props.getTop() + props.getLeft());
+
+            angle = 90;
+            widthSum = props.getTop() + props.getLeft();
+            if (widthSum != 0.0f) { // Avoid NaN
+            	angle = angle * props.getTop() / widthSum;
+            }
             appendPath(path, 0, 0, props.getLeftCorner().left(), props.getLeftCorner().right(), 90, angle+1, props.getTop(), props.getLeft(), scaledOffset+1, true, widthScale);
             
             path.closePath();

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>flying-saucer-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/borderradius/BorderRadiusNonRegressionTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/borderradius/BorderRadiusNonRegressionTest.java
@@ -1,0 +1,42 @@
+package org.xhtmlrenderer.pdf.borderradius;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xhtmlrenderer.resource.FSEntityResolver;
+
+import junit.framework.TestCase;
+
+public class BorderRadiusNonRegressionTest extends TestCase {
+	
+	/**
+	 * This used to throw a ClassCastException (before this fix).
+	 */
+	public void testBorderRadiusWithBorderWidthZero() throws Exception {
+		testNoException("borderRadiusWithBorderWidthZero.html");
+	}
+	
+	private void testNoException(String htmlPath) throws Exception {
+		URL htmlUrl = getClass().getResource(htmlPath);
+		
+		DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+		builder.setEntityResolver(FSEntityResolver.instance());
+		
+		Document doc = builder.parse(htmlUrl.openStream());
+		
+		ITextRenderer renderer = new ITextRenderer();
+		renderer.getSharedContext().setMedia("pdf");
+		
+		renderer.setDocument(doc, htmlUrl.toString());
+		renderer.layout();
+		
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		renderer.createPDF(bos);
+	}
+
+}

--- a/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/borderradius/borderRadiusWithBorderWidthZero.html
+++ b/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/borderradius/borderRadiusWithBorderWidthZero.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Test</title>
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+</head>
+<body>
+	<div style="background-color: #eeeeee; border-radius: 5px 5px 0px 0px;">
+		Some content
+	</div>
+</body>
+</html>


### PR DESCRIPTION
Defining a border-radius and a zero-width border on a box allows to make the background of this box "round" on the corners.
Currently, if we have a box with border-radius, but the border has a zero-width, then we get a `ClassCastException` in `java.awt.geom.Area.intersect(Area) ` due to some paths being invalid.

Here are a JUnit test case (which fails before the fix) **and a fix.**
Could you please merge this and release a new version?

This isssue is rather blocking to my team, since we use the same CSS for both our web application and PDF rendering (with a few additions). Thus the new "border-radius" feature completely broke our PDF-generation, since there already is some CSS with "border-radius".