### PR TITLE
Allows dynamic height rendering from Document

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
@@ -164,6 +164,9 @@ public class Java2DRenderer {
             this.height = height;
         }
 
+	public Java2DRenderer(Document doc, int width) {
+		this(doc, width, NO_HEIGHT);
+	}
 
         /**
          * Creates a new instance pointing to the given Document. Does not render until {@link #getImage(int)} is called for


### PR DESCRIPTION
My team is using Flying Saucer for XHTML rendering in a homegrown visual assertion library. We were having some trouble creating dynamic-heighted images from a W3C DOM Document as we could from File or URLs (more info at [this StackOverflow question](http://stackoverflow.com/questions/38145101/how-to-create-a-java2drenderer-from-a-xhtml-string)).

I've added this new constructor (based on the working ones for File or URLs) for use with Documents.

This pull request is intentionally left incomplete. We are willing to add docs, tests, etc. as needed.