### PR TITLE
Swt output device nullcheck bugfix

### DIFF
--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
@@ -303,13 +303,13 @@ public class SWTOutputDevice extends AbstractOutputDevice {
 
         float d[] = bs.getDashArray();
         int[] dashes = null;
-		if (d != null) {
-			dashes = new int[d.length];
-			for (int i = 0; i < d.length; i++) {
-				dashes[i] = (int) d[i];
-			}
-		}
-		_gc.setLineDash(dashes);
+        if (d != null) {
+            dashes = new int[d.length];
+            for (int i = 0; i < d.length; i++) {
+                dashes[i] = (int) d[i];
+            }
+        }
+        _gc.setLineDash(dashes);
     }
 
     public void translate(double tx, double ty) {

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
@@ -302,11 +302,14 @@ public class SWTOutputDevice extends AbstractOutputDevice {
         _gc.setLineJoin(gcJoin);
 
         float d[] = bs.getDashArray();
-        int[] dashes = new int[d.length];
-        for (int i = 0; i < d.length; i++) {
-            dashes[i] = (int) d[i];
-        }
-        _gc.setLineDash(dashes);
+        int[] dashes = null;
+		if (d != null) {
+			dashes = new int[d.length];
+			for (int i = 0; i < d.length; i++) {
+				dashes[i] = (int) d[i];
+			}
+		}
+		_gc.setLineDash(dashes);
     }
 
     public void translate(double tx, double ty) {


### PR DESCRIPTION
The `dash` array in `java.awt.BasicStroke` can be `null`, and a corresponding nullcheck should be done in `SwtOutputDevice.setStroke` to avoid `NPE`:s.