### PR TITLE
Specifying the charset name used for reading/parsing stylesheets

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/StylesheetFactoryImpl.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/StylesheetFactoryImpl.java
@@ -34,6 +34,7 @@ import org.xhtmlrenderer.css.sheet.Stylesheet;
 import org.xhtmlrenderer.css.sheet.StylesheetInfo;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.resource.CSSResource;
+import org.xhtmlrenderer.util.Configuration;
 import org.xhtmlrenderer.util.XRLog;
 import org.xml.sax.InputSource;
 
@@ -97,7 +98,7 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
         InputStream is = inputSource.getByteStream();
         if (is==null) return null;
         try {
-            return parse(new InputStreamReader(is, "UTF-8"), info);
+            return parse(new InputStreamReader(is, Configuration.valueFor("xr.stylesheets.charset-name", "UTF-8")), info);
         } catch (UnsupportedEncodingException e) {
             // Shouldn't happen
             throw new RuntimeException(e.getMessage(), e);

--- a/flying-saucer-core/src/main/resources/resources/conf/xhtmlrenderer.conf
+++ b/flying-saucer-core/src/main/resources/resources/conf/xhtmlrenderer.conf
@@ -180,6 +180,10 @@ xr.text.aa-rendering-hint=RenderingHints.VALUE_TEXT_ANTIALIAS_HGRB
 # stylesheets from the cache
 xr.cache.stylesheets=false
 
+# encoding used for reading/parsing stylesheets
+# default/fallback is UTF-8
+#xr.stylesheets.charset-name=UTF-8
+
 ### a bunch of properties used to turn on and off the incremental
 ###layout features
 xr.incremental.enabled=false


### PR DESCRIPTION
Due to legacy stuff at a client's that won't be changed, I would like to be able to specify the charset used for reading and parsing stylesheets instead of assuming UTF-8. Instead of passing the charset name through and changing the code tree accordingly, my suggestion is to try to use a configuration option, `xr.stylesheets.charset-name`, and falling back on UTF-8 if it's missing.