### PR TITLE
[add_osgi_support] Adding OSGi support

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -51,5 +52,38 @@
         </includes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.core</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Dependency resolution seems not to work properly with default 
+              behavior of importing the exported packages. -->
+            <Import-Package>!org.xhtmlrenderer.*</Import-Package>
+            <Export-Package>org.xhtmlrenderer.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/flying-saucer-log4j/pom.xml
+++ b/flying-saucer-log4j/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -32,26 +33,59 @@
 
   <dependencies>
     <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
-        <groupId>org.xhtmlrenderer</groupId>
-        <artifactId>flying-saucer-core</artifactId>
-        <version>${project.version}</version>
+      <groupId>org.xhtmlrenderer</groupId>
+      <artifactId>flying-saucer-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
   <build>
-	  <resources>
-	    <resource>
-	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
-	      <includes>
-	        <include>LICENSE*</include>
-	      </includes>
-	    </resource>
-	  </resources>
+    <resources>
+      <resource>
+        <directory>../</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.pdf.itext5</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Dependency resolution seems not to work properly with default 
+              behavior of importing the exported packages. -->
+            <Import-Package>!org.xhtmlrenderer.*,*</Import-Package>
+            <Export-Package>org.xhtmlrenderer.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -44,14 +45,50 @@
   </dependencies>
 
   <build>
-	  <resources>
-	    <resource>
-	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
-	      <includes>
-	        <include>LICENSE*</include>
-	      </includes>
-	    </resource>
-	  </resources>
+    <resources>
+      <resource>
+        <directory>../</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.pdf.itext5</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Dependency resolution seems not to work properly with default 
+              behavior of importing the exported packages. -->
+            <Import-Package>!org.xhtmlrenderer.*,*</Import-Package>
+            <!-- Do not export package org.xhtmlrenderer.simple as it is 
+              already exported by flying-saucer-core and this would lead to a split package 
+              without correctly marking it as such. -->
+            <Export-Package>!org.xhtmlrenderer.simple,org.xhtmlrenderer.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/flying-saucer-pdf-osgi/pom.xml
+++ b/flying-saucer-pdf-osgi/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.xhtmlrenderer</groupId>
+    <artifactId>flying-saucer-parent</artifactId>
+    <version>9.1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>flying-saucer-pdf-osgi</artifactId>
+  <packaging>bundle</packaging>
+  <name>Flying Saucer PDF Rendering (OSGi bundle)</name>
+  <description>This artifacts rebundles the flying-saucer-pdf artifact to make it available in OSGi context.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.xhtmlrenderer</groupId>
+      <artifactId>flying-saucer-pdf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.pdf.osgi</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- This bundle re-bundles the original flying-saucer-pdf artifact 
+              and only needs to import packages from flying-saucer-core. -->
+            <Import-Package>org.xhtmlrenderer.*</Import-Package>
+            <!-- Do not export package org.xhtmlrenderer.simple as it is 
+              already exported by flying-saucer-core and this would lead to a split package 
+              without correctly marking it as such. -->
+            <Export-Package>!org.xhtmlrenderer.simple,org.xhtmlrenderer.*</Export-Package>
+            <Embed-Dependency>*;scope=compile|runtime;artifactId=!flying-saucer-core</Embed-Dependency>
+            <Embed-Directory>.</Embed-Directory>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flying-saucer-swt/pom.xml
+++ b/flying-saucer-swt/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -63,7 +64,7 @@
       <id>mac</id>
       <activation>
         <os>
-            <!-- TODO handle 32 bit and 64 bit procs differently -->
+          <!-- TODO handle 32 bit and 64 bit procs differently -->
           <family>Mac</family>
         </os>
       </activation>
@@ -80,35 +81,71 @@
       </dependencies>
     </profile>
     <profile>
-        <id>linux</id>
-        <activation>
-          <os>
-            <name>Linux</name>
-          </os>
-        </activation>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>swt</artifactId>
-            <version>3.6</version>
-            <type>jar</type>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/swt/swt-3.6-linux.jar</systemPath>
-            <optional>true</optional>
-          </dependency>
-        </dependencies>
+      <id>linux</id>
+      <activation>
+        <os>
+          <name>Linux</name>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse</groupId>
+          <artifactId>swt</artifactId>
+          <version>3.6</version>
+          <type>jar</type>
+          <scope>system</scope>
+          <systemPath>${basedir}/lib/swt/swt-3.6-linux.jar</systemPath>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 
   <build>
-	  <resources>
-	    <resource>
-	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
-	      <includes>
-	        <include>LICENSE*</include>
-	      </includes>
-	    </resource>
-	  </resources>
+    <resources>
+      <resource>
+        <directory>../</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.swt</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Dependency resolution seems not to work properly with default 
+              behavior of importing the exported packages. -->
+            <Import-Package>!org.xhtmlrenderer.*,*</Import-Package>
+            <!-- Do not export package org.xhtmlrenderer.simple as it is 
+              already exported by flying-saucer-core and this would lead to a split package 
+              without correctly marking it as such. -->
+            <Export-Package>!org.xhtmlrenderer.simple,org.xhtmlrenderer.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -24,6 +25,7 @@
   <modules>
     <module>flying-saucer-core</module>
     <module>flying-saucer-pdf</module>
+    <module>flying-saucer-pdf-osgi</module>
     <module>flying-saucer-pdf-itext5</module>
     <module>flying-saucer-log4j</module>
     <module>flying-saucer-swt</module>
@@ -121,6 +123,16 @@
         </executions>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <properties>


### PR DESCRIPTION
Adding OSGi Support to Flying Saucer

The goal of these changes were to enable the consumption of the flying saucer libraries within an OSGi context. For having full information about dependencies, OSGi needs some additional meta-data in the MANIFEST.MF files (i.e. Bundle-SymbolicName, Export-Package, Import-Package, etc.). With that meta-data in place, one can but the Maven artifacts into a p2 repository (e.g. via Package Drone) and consume the flying saucer libraries in a Maven/Tycho build for example.

For almost all artifacts - apart from the flying-saucer-pdf one - adding the required meta-data could be achieved by adding the maven-bundle-plugin to the build execution in the pom.xml. With a little tweaking this bundle generates the required meta-data into the MANIFEST.MF files without touching the existing build configuration.

However, for the flying-saucer-pdf artifact this approach did not work since that one declares a dependency to a very old version of itest due to licensing requirements. This dependency would have to be reflected as an Import-Package statement which would require the itext library of that very old version also OSGi-aware. Since the latter was not possible to be done, another approach has been chosen: A new artifact flying-saucer-pdf-osgi has been created that re-bundles the original flying-saucer-pdf artifact as an OSGi bundle. OSGi users just use that new artifact instead of the original one and in fact are consuming the same binary result as if they would consume the flying-saucer-pdf artifact directly. All Maven users can still use the original flying-saucer-pdf artifact.

Remark: I'm not completely sure about the details of the tweaking of the maven-bundle-plugin in the individual pom.xml files. However, the current state works for us in a product building on top of Eclipse Equinox and built with Maven/Tycho. I'm of course open to discussions about changing that configuration. Please feel free to push any changes you think are reasonable or get in touch with me via discussion.