### PR TITLE
Create bookmarks from HTML outline automatically

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/HTMLOutline.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/HTMLOutline.java
@@ -1,0 +1,145 @@
+package org.xhtmlrenderer.pdf;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.traversal.DocumentTraversal;
+import org.w3c.dom.traversal.NodeFilter;
+import org.w3c.dom.traversal.NodeIterator;
+
+import org.xhtmlrenderer.pdf.ITextOutputDevice.Bookmark;
+import org.xhtmlrenderer.render.Box;
+
+class HTMLOutline {
+
+    private static final Pattern HEADING =
+            Pattern.compile("h([1-6])", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern WS = Pattern.compile("\\s+");
+
+    private final HTMLOutline parent;
+
+    private final int rank;
+
+    private final Bookmark bookmark;
+
+    private HTMLOutline() {
+        this(0, "root", null);
+    }
+
+    private HTMLOutline(int rank, String title, HTMLOutline parent) {
+        this.rank = rank;
+        this.bookmark = new Bookmark(title, "");
+        this.parent = parent;
+        if (parent != null) {
+            parent.bookmark.addChild(bookmark);
+        }
+    }
+
+    /**
+     * Include non-heading element as bookmark:
+     * <pre>
+     * &lt;strong data-pdf-bookmark="4">...&lt;/strong></pre>
+     * <p>
+     * Specify bookmark name:</p>
+     * <pre>
+     * &lt;tr data-pdf-bookmark="4" data-pdf-bookmark-name="Bar baz">...&lt;/tr></pre>
+     * <p>
+     * Exclude individual heading from bookmarks:</p>
+     * <pre>
+     * &lt;h3 data-pdf-bookmark="none">Baz qux&lt;/h3></pre>
+     * <p>
+     * Prevent automatic bookmarks for the whole of the document:</p>
+     * <pre>
+     * &lt;html data-pdf-bookmark="none">...&lt;/html></pre>
+     */
+    public static List<Bookmark> generate(Element context, Box box) {
+        if (context.getAttribute("data-pdf-bookmark").trim().equalsIgnoreCase("none")) {
+            return new ArrayList<Bookmark>(0);
+        }
+
+        NodeIterator iterator = ((DocumentTraversal) context.getOwnerDocument())
+                .createNodeIterator(context, NodeFilter.SHOW_ELEMENT,
+                                    NestedSectioningFilter.INSTANCE, true);
+
+        HTMLOutline root = new HTMLOutline();
+        HTMLOutline current = root;
+        Map<Element,Bookmark> map = new IdentityHashMap();
+
+        for (Element element = (Element) iterator.nextNode();
+                element != null; element = (Element) iterator.nextNode()) {
+            String bookmark = element.getAttribute("data-pdf-bookmark").trim();
+            Matcher matcher = HEADING.matcher(element.getTagName());
+            if (bookmark.isEmpty()) {
+                bookmark = matcher.matches() ? matcher.group(1) : "none";
+            }
+            if (bookmark.equalsIgnoreCase("none")) {
+                continue;
+            }
+
+            int rank;
+            try {
+                rank = Integer.parseInt(bookmark);
+                if (rank < 1) {
+                    continue; // Illegal value
+                }
+            } catch (NumberFormatException e) {
+                continue; // Invalid value
+            }
+
+            String name = element.getAttribute("data-pdf-bookmark-name").trim();
+            if (name.isEmpty()) {
+                name = element.getTextContent();
+            }
+            name = WS.matcher(name.trim()).replaceAll(" ");
+
+            while (current.rank >= rank) {
+                current = current.parent;
+            }
+            current = new HTMLOutline(rank, name, current);
+            map.put(element, current.bookmark);
+        }
+        initBoxPositions(map, box);
+        return root.bookmark.getChildren();
+    }
+
+    private static void initBoxPositions(Map<Element,Bookmark> map, Box box) {
+        Bookmark bookmark = map.get(box.getElement());
+        if (bookmark != null) {
+            bookmark.setBox(box);
+        }
+        for (int i = 0, len = box.getChildCount(); i < len; i++) {
+            initBoxPositions(map, box.getChild(i));
+        }
+    }
+
+
+    private static class NestedSectioningFilter implements NodeFilter {
+
+        static final NestedSectioningFilter INSTANCE = new NestedSectioningFilter();
+
+        // https://www.w3.org/TR/html51/sections.html#sectioning-roots
+        private static final Pattern ROOTS = Pattern
+                .compile("blockquote|details|fieldset|figure|td",
+                         Pattern.CASE_INSENSITIVE);
+
+        @Override
+        public short acceptNode(Node n) {
+            if (((Element) n).getAttribute("data-pdf-bookmark").equalsIgnoreCase("none")) {
+                return FILTER_REJECT;
+            }
+            // REVISIT: May be use another control "data-pdf-bookmark" value
+            // to indicate force traversing into "blockquote" and similar.
+            return ROOTS.matcher(n.getNodeName()).matches() ? FILTER_REJECT
+                                                            : FILTER_ACCEPT;
+        }
+
+    } // class NestedSectioningFilter
+
+}

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -35,8 +35,6 @@ import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -67,7 +65,6 @@ import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.pdf.ITextFontResolver.FontDescription;
 import org.xhtmlrenderer.render.AbstractOutputDevice;
 import org.xhtmlrenderer.render.BlockBox;
-import org.xhtmlrenderer.render.BorderPainter;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.render.InlineLayoutBox;
@@ -910,6 +907,9 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
     }
 
     private void writeOutline(RenderingContext c, Box root) {
+        if (_bookmarks.isEmpty()) {
+            _bookmarks = HTMLOutline.generate(root.getElement(), root);
+        }
         if (_bookmarks.size() > 0) {
             _writer.setViewerPreferences(PdfWriter.PageModeUseOutlines);
             writeBookmarks(c, root, _writer.getRootOutline(), _bookmarks);
@@ -975,15 +975,16 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
     private void writeBookmark(RenderingContext c, Box root, PdfOutline parent, Bookmark bookmark) {
         String href = bookmark.getHRef();
         PdfDestination target = null;
+        Box box = bookmark.getBox();
         if (href.length() > 0 && href.charAt(0) == '#') {
-            Box box = _sharedContext.getBoxById(href.substring(1));
-            if (box != null) {
-                PageBox page = root.getLayer().getPage(c, getPageRefY(box));
-                int distanceFromTop = page.getMarginBorderPadding(c, CalculatedStyle.TOP);
-                distanceFromTop += box.getAbsY() - page.getTop();
-                target = new PdfDestination(PdfDestination.XYZ, 0, normalizeY(distanceFromTop / _dotsPerPoint), 0);
-                target.addPage(_writer.getPageReference(_startPageNo + page.getPageNo() + 1));
-            }
+            box = _sharedContext.getBoxById(href.substring(1));
+        }
+        if (box != null) {
+            PageBox page = root.getLayer().getPage(c, getPageRefY(box));
+            int distanceFromTop = page.getMarginBorderPadding(c, CalculatedStyle.TOP);
+            distanceFromTop += box.getAbsY() - page.getTop();
+            target = new PdfDestination(PdfDestination.XYZ, 0, normalizeY(distanceFromTop / _dotsPerPoint), 0);
+            target.addPage(_writer.getPageReference(_startPageNo + page.getPageNo() + 1));
         }
         if (target == null) {
             target = _defaultDestination;
@@ -1024,9 +1025,10 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
         }
     }
 
-    private static class Bookmark {
+    static class Bookmark {
         private String _name;
         private String _HRef;
+        private Box    _box;
 
         private List _children;
 
@@ -1036,6 +1038,14 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
         public Bookmark(String name, String href) {
             _name = name;
             _HRef = href;
+        }
+
+        public Box getBox() {
+            return _box;
+        }
+
+        public void setBox(Box box) {
+            _box = box;
         }
 
         public String getHRef() {


### PR DESCRIPTION
1. Doesn't need non-standard elements in the `<head>` which most likely duplicate the HTML outline
2. Doesn't require explicit anchors present
3. Simple usage – automatic, and allows for fine customization with `data-pdf-bookmark` attribute hints

When bookmarks have been already defined using `<bookmarks>` – no result change.  To suppress the automatic bookmarks generation completely one could specify:

```html
<html data-pdf-bookmark="none">...
```
