### PR TITLE
Give XMLResrouce.load(javax.xml.transform.Source) some credit

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
@@ -82,6 +82,42 @@ public class XMLResource extends AbstractResource {
         return XML_RESOURCE_BUILDER.createXMLResource(new XMLResource(new InputSource(reader)));
     }
 
+    /**
+     * Example usage for parsing real-world HTML (vs. well-formed XML/XHTML),
+     * using the TagSoup library:
+     * <pre>
+     * import org.xml.sax.InputSource;
+     * import org.xml.sax.XMLReader;
+     *
+     * import org.ccil.cowan.tagsoup.Parser;
+     *
+     * import javax.xml.transform.Source;
+     * import javax.xml.transform.sax.SAXSource;
+     *
+     * import org.w3c.dom.Document;
+     * import org.w3c.dom.Element;
+     * import org.w3c.dom.NodeList;
+     *
+     * import org.xhtmlrenderer.resource.XMLResource;
+     *
+     * ...
+     *
+     *         XMLReader xmlReader = new Parser();
+     *         xmlReader.setFeature(Parser.defaultAttributesFeature, false);
+     *         Source source = new SAXSource(xmlReader,
+     *                 new InputSource("https://www.w3.org/TR/REC-html32"));
+     *         Document document = XMLResource.load(source).getDocument();
+     *
+     *         Element root = document.getDocumentElement();
+     *         System.out.printf("{%s}%s%n", root.getNamespaceURI(), root.getLocalName());
+     *
+     *         NodeList elements = document.getElementsByTagName("p");
+     *         Node lastParagraph = elements.item(elements.getLength() - 1);
+     *         System.out.println(lastParagraph.getTextContent());
+     * </pre>
+     *
+     * @see     <a href="http://web.archive.org/web/20160415072307/http://home.ccil.org/~cowan/XML/tagsoup/">http://ccil.org/~cowan/XML/tagsoup/</a>
+     */
     public static XMLResource load(Source source) {
         return XML_RESOURCE_BUILDER.createXMLResource(source);
     }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
@@ -191,8 +191,19 @@ public class XMLResource extends AbstractResource {
             return target;
         }
 
-        public XMLResource createXMLResource(Source source) {
-            DOMResult output = new DOMResult();
+        private DOMResult newDOMResult() {
+            DocumentBuilder builder = parserPool.get();
+            try {
+                Document document = builder.newDocument();
+                document.setStrictErrorChecking(false);
+                return new DOMResult(document);
+            } finally {
+                parserPool.release(builder);
+            }
+        }
+
+        XMLResource createXMLResource(Source source) {
+            DOMResult output = newDOMResult();
 
             long st = System.currentTimeMillis();
             Transformer idTransform = traxPool.get();
@@ -213,7 +224,9 @@ public class XMLResource extends AbstractResource {
 
             XRLog.load("Loaded document in ~" + target.getElapsedLoadTime() + "ms");
 
-            target.setDocument((Document) output.getNode());
+            Document document = (Document) output.getNode();
+            document.setStrictErrorChecking(true);
+            target.setDocument(document);
             return target;
         }
     } // class XMLResourceBuilder


### PR DESCRIPTION
-   Provide basic "parser" caching with `XMLResrouce.load(javax.xml.transform.Source)` as for `XMLResource.load(org.xml.sax.InputSource)`
-   Document example usage of `XMLResrouce.load(javax.xml.transform.Source)` for parsing real-world HTML
