### PR TITLE
Implemented css3 word-wrap capability

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -1070,6 +1070,18 @@ public final class CSSName implements Comparable {
                     INHERITS,
                     new PrimitivePropertyBuilders.WordWrap()
             );
+    
+    /**
+     * Unique CSSName instance for CSS3 property.
+     */
+    public final static CSSName HYPHENS =
+            addProperty(
+                    "hyphens",
+                    PRIMITIVE,
+                    "none",
+                    INHERITS,
+                    new PrimitivePropertyBuilders.Hyphens()
+            );
 
     /**
      * Unique CSSName instance for CSS2 property.
@@ -1588,8 +1600,7 @@ public final class CSSName implements Comparable {
                     NOT_INHERITED,
                     new OneToFourPropertyBuilders.Padding()
             );
-
-
+    
     /**
      * Unique CSSName instance for CSS2 property.
      */

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
@@ -216,6 +216,7 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue X_SMALL = addValue("x-small");
     public final static IdentValue XX_LARGE = addValue("xx-large");
     public final static IdentValue XX_SMALL = addValue("xx-small");
+	public final static IdentValue MANUAL = addValue("manual");
 
     /**
      * Description of the Field

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -1529,7 +1529,17 @@ public class PrimitivePropertyBuilders {
             return ALLOWED;
         }
     }
+    
+    public static class Hyphens extends SingleIdent {
+        // none | manual | auto
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.NONE, IdentValue.MANUAL, IdentValue.AUTO});
 
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
 
     public static class Widows extends PlainInteger {
         protected boolean isNegativeValuesAllowed() {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -773,6 +773,10 @@ public class CalculatedStyle {
     public IdentValue getWordWrap() {
         return getIdent(CSSName.WORD_WRAP);
     }
+    
+    public IdentValue getHyphens() {
+        return getIdent(CSSName.HYPHENS);
+    }
 
     public boolean isClearLeft() {
         IdentValue clear = getIdent(CSSName.CLEAR);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
@@ -32,6 +32,7 @@ import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.CssContext;
 import org.xhtmlrenderer.css.style.derived.BorderPropertySet;
 import org.xhtmlrenderer.css.style.derived.RectPropertySet;
+import org.xhtmlrenderer.layout.breaker.Breaker;
 import org.xhtmlrenderer.render.AnonymousBlockBox;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.Box;
@@ -237,6 +238,9 @@ public class InlineBoxing {
                     }
 
                     if (lbContext.isNeedsNewLine()) {
+                    	if (iB.getStyle().isTextJustify()) {
+                    		currentLine.trimTrailingSpace(c);
+                    	}
                         saveLine(currentLine, c, box, minimumLineHeight,
                                 maxAvailableWidth, pendingFloats,
                                 hasFirstLinePEs, pendingInlineLayers, markerData,
@@ -844,7 +848,7 @@ public class InlineBoxing {
             Breaker.breakText(c, lbContext, remainingWidth, style);
         }
 
-        result.setMasterText(masterText);
+        result.setMasterText(lbContext.getMaster());
         result.setTextNode(lbContext.getTextNode());
         result.setSubstring(lbContext.getStart(), lbContext.getEnd());
         result.setWidth(lbContext.getWidth());

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
@@ -42,6 +42,8 @@ import org.xhtmlrenderer.extend.NamespaceHandler;
 import org.xhtmlrenderer.extend.ReplacedElementFactory;
 import org.xhtmlrenderer.extend.TextRenderer;
 import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.layout.breaker.DefaultLineBreakingStrategy;
+import org.xhtmlrenderer.layout.breaker.LineBreakingStrategy;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.render.FSFontMetrics;
@@ -94,6 +96,8 @@ public class SharedContext {
 
     private ReplacedElementFactory replacedElementFactory;
     private Rectangle temp_canvas;
+    
+    private LineBreakingStrategy lineBreakingStrategy = new DefaultLineBreakingStrategy();
 
     public SharedContext() {
     }
@@ -618,6 +622,14 @@ public class SharedContext {
             }
         }
     }
+
+	public LineBreakingStrategy getLineBreakingStrategy() {
+		return lineBreakingStrategy;
+	}
+
+	public void setLineBreakingStrategy(LineBreakingStrategy lineBreakingStrategy) {
+		this.lineBreakingStrategy = lineBreakingStrategy;
+	}
 }
 
 /*

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakAnywhereLineBreakStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakAnywhereLineBreakStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ * All Rights Reserved.  No use, copying or distribution of this
+ * work may be made except in accordance with a valid license
+ * agreement from MEDIA SOLUTIONS. This notice must be
+ * included on all copies, modifications and derivatives of this
+ * work.
+ *
+ * MEDIA SOLUTIONS MAKES NO REPRESENTATIONS OR WARRANTIES
+ * ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER EXPRESSED OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+ * MEDIA SOLUTIONS SHALL NOT BE LIABLE FOR ANY DAMAGES
+ * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
+ * THIS SOFTWARE OR ITS DERIVATIVES.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class BreakAnywhereLineBreakStrategy implements BreakPointsProvider {
+
+	private String currentString;
+	int position = 0;
+
+	public BreakAnywhereLineBreakStrategy(String currentString) {
+		this.currentString = currentString;
+	}
+
+	@Override
+	public BreakPoint next() {
+		if (position + 1 > currentString.length()) return BreakPoint.getDonePoint();
+		return new BreakPoint(position++);
+	}
+
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakAnywhereLineBreakStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakAnywhereLineBreakStrategy.java
@@ -1,24 +1,25 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
- * All Rights Reserved.  No use, copying or distribution of this
- * work may be made except in accordance with a valid license
- * agreement from MEDIA SOLUTIONS. This notice must be
- * included on all copies, modifications and derivatives of this
- * work.
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
- * MEDIA SOLUTIONS MAKES NO REPRESENTATIONS OR WARRANTIES
- * ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER EXPRESSED OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
- * MEDIA SOLUTIONS SHALL NOT BE LIABLE FOR ANY DAMAGES
- * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
- * THIS SOFTWARE OR ITS DERIVATIVES.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
  */
 package org.xhtmlrenderer.layout.breaker;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class BreakAnywhereLineBreakStrategy implements BreakPointsProvider {
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPoint.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPoint.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+import java.text.BreakIterator;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class BreakPoint implements Comparable<BreakPoint> {
+	
+	private int position;
+	private String hyphen;
+	
+	public BreakPoint(int position) {
+		this.position = position;
+	}
+
+	public int getPosition() {
+		return position;
+	}
+
+	public void setPosition(int position) {
+		this.position = position;
+	}
+
+	@Override
+	public String toString() {
+		return "BreakPoint [position=" + position + "]";
+	}
+
+	@Override
+	public int compareTo(BreakPoint o) {
+		return Integer.compare(position, o.position);
+	}
+
+	public void setHyphen(String hyphen) {
+		this.hyphen = hyphen;
+	}
+
+	public String getHyphen() {
+		if (hyphen == null) return "";
+		return hyphen;
+	}
+	
+	public static BreakPoint getDonePoint() {
+		return new BreakPoint(BreakIterator.DONE);
+	}
+	
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPoint.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -21,7 +21,7 @@ package org.xhtmlrenderer.layout.breaker;
 import java.text.BreakIterator;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class BreakPoint implements Comparable<BreakPoint> {
 	

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPointsProvider.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPointsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -21,7 +21,7 @@ package org.xhtmlrenderer.layout.breaker;
 import java.text.BreakIterator;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public interface BreakPointsProvider {
 	

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPointsProvider.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/BreakPointsProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+import java.text.BreakIterator;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public interface BreakPointsProvider {
+	
+	/**
+	 * return next breaking point if available.
+	 * If there are no more breaking points, return BreakPoint with position == {@link BreakIterator#DONE} (-1)
+	 */
+	BreakPoint next();
+
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
@@ -18,12 +18,18 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
  */
-package org.xhtmlrenderer.layout;
+package org.xhtmlrenderer.layout.breaker;
 
 import java.text.BreakIterator;
 
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.layout.LayoutContext;
+import org.xhtmlrenderer.layout.LineBreakContext;
+import org.xhtmlrenderer.layout.TextUtil;
+import org.xhtmlrenderer.layout.WhitespaceStripper;
 import org.xhtmlrenderer.render.FSFont;
 
 /**
@@ -33,7 +39,9 @@ import org.xhtmlrenderer.render.FSFont;
  */
 public class Breaker {
 
-    public static void breakFirstLetter(LayoutContext c, LineBreakContext context,
+    private static final String DEFAULT_LANGUAGE = System.getProperty("org.xhtmlrenderer.layout.breaker.default-language", "en");
+
+	public static void breakFirstLetter(LayoutContext c, LineBreakContext context,
             int avail, CalculatedStyle style) {
         FSFont font = style.getFSFont(c);
         context.setEnd(getFirstLetterEnd(context.getMaster(), context.getStart()));
@@ -103,96 +111,89 @@ public class Breaker {
         context.setEndsOnNL(false);
         doBreakText(c, context, avail, style, false);
     }
+    
+    private static int getWidth(LayoutContext c, FSFont f, String text) {
+    	return c.getTextRenderer().getWidth(c.getFontContext(), f, text);
+    }
+    
+    public static BreakPointsProvider getBreakPointsProvider(String text, LayoutContext c, Element element, CalculatedStyle style) {
+    	return c.getSharedContext().getLineBreakingStrategy().getBreakPointsProvider(text, getLanguage(c, element), style);
+    }
+    
+    public static BreakPointsProvider getBreakPointsProvider(String text, LayoutContext c, Text textNode, CalculatedStyle style) {
+    	return c.getSharedContext().getLineBreakingStrategy().getBreakPointsProvider(text, getLanguage(c, textNode), style);
+    }
+    
+    private static String getLanguage(LayoutContext c, Element element) {
+    	String language = c.getNamespaceHandler().getLang(element);
+    	if (language == null || language.isEmpty()) {
+    		language = DEFAULT_LANGUAGE; 
+    	}
+    	return language;
+    }
+    
+    private static String getLanguage(LayoutContext c, Text textNode) {
+    	if (textNode.getParentNode() instanceof Element) {
+    		return getLanguage(c, (Element) textNode.getParentNode()); 
+    	}
+    	return DEFAULT_LANGUAGE;
+    }
 
     private static void doBreakText(LayoutContext c,
             LineBreakContext context, int avail, CalculatedStyle style,
             boolean tryToBreakAnywhere) {
-        FSFont font = style.getFSFont(c);
+        FSFont f = style.getFSFont(c);
         String currentString = context.getStartSubstring();
-        BreakIterator iterator = getWordStream(currentString);
-        int left = 0;
-        int right = tryToBreakAnywhere ? 1 : iterator.next();
-        int lastWrap = 0;
-        int graphicsLength = 0;
-        int lastGraphicsLength = 0;
-        int lastTokenLength = 0;
-        String currentToken = "";
+        BreakPointsProvider iterator = getBreakPointsProvider(currentString, c, context.getTextNode(), style);
+        if (tryToBreakAnywhere) {
+        	iterator = new BreakAnywhereLineBreakStrategy(currentString);
+        }
+        BreakPoint bp = iterator.next();
+        BreakPoint lastBreakPoint = null;
+        int right = -1;
+        while (bp != null && bp.getPosition() != BreakIterator.DONE) {
+        	int widthWithHyphen = getWidth(c, f, currentString.substring(0, bp.getPosition()) + bp.getHyphen());
+        	if (widthWithHyphen > avail) break;
+        	right = bp.getPosition();
+        	lastBreakPoint = bp;
+        	bp = iterator.next();
+        };
         
-        while (right > 0 && graphicsLength <= avail) {
-            lastGraphicsLength = graphicsLength;
-            currentToken = currentString.substring(left, right);
-            lastTokenLength = c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentToken);
-            graphicsLength += lastTokenLength;
-            lastWrap = left;
-            left = right;
-            if ( tryToBreakAnywhere ) {
-                right = ( right + 1 ) % currentString.length();
-            }
-            else { // break relies on BreakIterator
-                right = iterator.next();
-            }
+        // add hyphen if needed
+        if (bp != null && bp.getPosition() != BreakIterator.DONE // it fits 
+        		&& right >= 0 // some break point found
+        		&& !lastBreakPoint.getHyphen().isEmpty()) {
+        	context.setMaster(new StringBuilder(context.getMaster()).insert(context.getStart() + right, lastBreakPoint.getHyphen()).toString());
+        	right += lastBreakPoint.getHyphen().length();
         }
         
-        //try to see if trimming last spaces pushes content inside, browsers trim last spaces to flow the content
-        if (graphicsLength > avail) {
-            int allowanceOnTokenLength = c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentToken.replaceFirst("\\s+$", ""));
-            if((graphicsLength - lastTokenLength + allowanceOnTokenLength) < avail) {
-                graphicsLength = graphicsLength - lastTokenLength + allowanceOnTokenLength;
-            }
-        }
-
-
-        if (graphicsLength <= avail) {
-            //try for the last bit too!
-            lastWrap = left;
-            lastGraphicsLength = graphicsLength;
-            graphicsLength += c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, currentString.substring(left));
-        }
-
-        if (graphicsLength <= avail) {
-            context.setWidth(graphicsLength);
+        if (bp != null && bp.getPosition() == BreakIterator.DONE) {
+            context.setWidth(getWidth(c, f, currentString));
             context.setEnd(context.getMaster().length());
-            //It fit!
+            //It fits!
             return;
         }
 
         context.setNeedsNewLine(true);
-        if ( lastWrap == 0 && style.getWordWrap() == IdentValue.BREAK_WORD ) {
-            if ( ! tryToBreakAnywhere ) {
+        if (right < 0 && style.getWordWrap() == IdentValue.BREAK_WORD) {
+            if (!tryToBreakAnywhere) {
                 doBreakText(c, context, avail, style, true);
                 return;
             }
         }
 
-        if (lastWrap != 0) {//found a place to wrap
-            context.setEnd(context.getStart() + lastWrap);
-            context.setWidth(lastGraphicsLength);
-        } else {//unbreakable string
-            if (left == 0) {
-                left = currentString.length();
-            }
-
-            context.setEnd(context.getStart() + left);
-            context.setUnbreakable(true);
-
-            if (left == currentString.length()) {
-                context.setWidth(c.getTextRenderer().getWidth(
-                        c.getFontContext(), font, context.getCalculatedSubstring()));
-            } else {
-                context.setWidth(graphicsLength);
-            }
+        if (right >= 0) { // found a place to wrap
+            context.setEnd(context.getStart() + right);
+            context.setWidth(getWidth(c, f, context.getMaster().substring(context.getStart(), context.getStart() + right)));
+            return;
         }
-        return;
+        
+       	// unbreakable string
+        context.setEnd(context.getStart() + currentString.length());
+        context.setUnbreakable(true);
+        context.setWidth(getWidth(c, f, context.getCalculatedSubstring()));
     }
 
-	public static BreakIterator getWordStream(String s) {
-		BreakIterator i = new UrlAwareLineBreakIterator();
-		i.setText(s);
-		return i;
-	}
-
 }
+
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+import java.text.BreakIterator;
+
+import org.xhtmlrenderer.css.style.CalculatedStyle;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class DefaultLineBreakingStrategy implements LineBreakingStrategy {
+
+	@Override
+	public BreakPointsProvider getBreakPointsProvider(String text, String lang, CalculatedStyle style) {
+		BreakIterator i = new UrlAwareLineBreakIterator();
+		i.setText(text);
+		
+		return new BreakPointsProvider() {
+			
+			@Override
+			public BreakPoint next() {
+				int next = i.next();
+				if (next < 0) return BreakPoint.getDonePoint();
+				return new BreakPoint(next);
+			}
+		};
+	}
+	
+	
+
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
@@ -29,7 +29,7 @@ public class DefaultLineBreakingStrategy implements LineBreakingStrategy {
 
 	@Override
 	public BreakPointsProvider getBreakPointsProvider(String text, String lang, CalculatedStyle style) {
-		BreakIterator i = new UrlAwareLineBreakIterator();
+		final BreakIterator i = new UrlAwareLineBreakIterator();
 		i.setText(text);
 		
 		return new BreakPointsProvider() {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/DefaultLineBreakingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -23,7 +23,7 @@ import java.text.BreakIterator;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class DefaultLineBreakingStrategy implements LineBreakingStrategy {
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/LineBreakingStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/LineBreakingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -21,7 +21,7 @@ package org.xhtmlrenderer.layout.breaker;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public interface LineBreakingStrategy {
 	

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/LineBreakingStrategy.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/LineBreakingStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+import org.xhtmlrenderer.css.style.CalculatedStyle;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public interface LineBreakingStrategy {
+	
+	BreakPointsProvider getBreakPointsProvider(String text, String lang, CalculatedStyle style);
+
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/ListBreakPointsProvider.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/ListBreakPointsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.layout.breaker;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class ListBreakPointsProvider implements BreakPointsProvider {
+	
+	private Iterator<BreakPoint> breakPoints;
+
+	public ListBreakPointsProvider(List<BreakPoint> breakPoints) {
+		this.breakPoints = breakPoints.iterator();
+	}
+
+	@Override
+	public BreakPoint next() {
+		if (!breakPoints.hasNext()) return BreakPoint.getDonePoint();
+		return breakPoints.next();
+	}
+
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/ListBreakPointsProvider.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/ListBreakPointsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class ListBreakPointsProvider implements BreakPointsProvider {
 	

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/UrlAwareLineBreakIterator.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/UrlAwareLineBreakIterator.java
@@ -1,4 +1,4 @@
-package org.xhtmlrenderer.layout;
+package org.xhtmlrenderer.layout.breaker;
 
 import java.text.BreakIterator;
 import java.text.CharacterIterator;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -1666,7 +1666,6 @@ public class BlockBox extends Box implements InlinePaintable {
             } else { /* child.getStyle().isInline() */
                 InlineBox iB = (InlineBox) child;
                 IdentValue whitespace = iB.getStyle().getWhitespace();
-
                 iB.calcMinMaxWidth(c, getContentWidth(), lineWidth == 0);
 
                 if (whitespace == IdentValue.NOWRAP) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
@@ -26,11 +26,12 @@ import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.extend.ContentFunction;
 import org.xhtmlrenderer.css.parser.FSFunction;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
-import org.xhtmlrenderer.layout.Breaker;
 import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.layout.Styleable;
 import org.xhtmlrenderer.layout.TextUtil;
 import org.xhtmlrenderer.layout.WhitespaceStripper;
+import org.xhtmlrenderer.layout.breaker.BreakPointsProvider;
+import org.xhtmlrenderer.layout.breaker.Breaker;
 
 /**
  * A class which reprsents a portion of an inline element. If an inline element
@@ -228,10 +229,11 @@ public class InlineBox implements Styleable {
         int lastWord = 0;
 
         String text = getText(trimLeadingSpace);
-        BreakIterator breakIterator = Breaker.getWordStream(text);
+        
+        BreakPointsProvider breakIterator = Breaker.getBreakPointsProvider(text, c, getElement(), getStyle());
 
         // Breaker should be used
-        while ( (current = breakIterator.next()) != BreakIterator.DONE) {
+        while ( (current = breakIterator.next().getPosition()) != BreakIterator.DONE) {
             String currentWord = text.substring(last, current);
             int wordWidth = getTextWidth(c, currentWord);
             int minWordWidth;

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/breaker/UrlAwareLineBreakIteratorTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/breaker/UrlAwareLineBreakIteratorTest.java
@@ -1,6 +1,8 @@
-package org.xhtmlrenderer.layout;
+package org.xhtmlrenderer.layout.breaker;
 
 import java.text.BreakIterator;
+
+import org.xhtmlrenderer.layout.breaker.UrlAwareLineBreakIterator;
 
 import junit.framework.TestCase;
 

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.xhtmlrenderer</groupId>
+		<artifactId>flying-saucer-parent</artifactId>
+		<version>9.1.2-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flying-saucer-fop</artifactId>
+
+	<packaging>jar</packaging>
+
+	<name>Flying Saucer FOP for word-break capability</name>
+	<description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact provides implementation of the word-break capability using Apache FOP library</description>
+
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License (LGPL), version 2.1 or later</name>
+			<url>http://www.gnu.org/licenses/lgpl.html</url>
+		</license>
+		<license>
+			<name>Apache License, Version 2.0, January 2004</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
+		</license>
+	</licenses>
+
+	<distributionManagement>
+		<repository>
+			<id>bintray</id>
+			<url>https://api.bintray.com/maven/flyingsaucerproject/maven/org.xhtmlrenderer:flying-saucer-fop</url>
+		</repository>
+	</distributionManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.xhtmlrenderer</groupId>
+			<artifactId>flying-saucer-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/fop -->
+		<dependency>
+			<groupId>org.apache.xmlgraphics</groupId>
+			<artifactId>fop</artifactId>
+			<version>2.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/net.sf.offo/fop-hyph -->
+		<dependency>
+			<groupId>net.sf.offo</groupId>
+			<artifactId>fop-hyph</artifactId>
+			<version>2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- IText used for test execution -->
+		<dependency>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itextpdf</artifactId>
+			<version>5.3.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.xhtmlrenderer</groupId>
+			<artifactId>flying-saucer-pdf-itext5</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>../</directory>
+				<targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+				<includes>
+					<include>LICENSE*</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.fop</Bundle-SymbolicName>
+						<Bundle-Version>${project.version}</Bundle-Version>
+						<!-- Dependency resolution seems not to work properly with default 
+							behavior of importing the exported packages. -->
+						<Import-Package>!org.xhtmlrenderer.*,*</Import-Package>
+						<!-- Do not export package org.xhtmlrenderer.simple as it is already 
+							exported by flying-saucer-core and this would lead to a split package without 
+							correctly marking it as such. -->
+						<Export-Package>!org.xhtmlrenderer.simple,org.xhtmlrenderer.*</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -82,6 +82,9 @@
 					<include>LICENSE*</include>
 				</includes>
 			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
 		</resources>
 		<plugins>
 			<plugin>

--- a/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/FOPLineBreakingStrategy.java
+++ b/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/FOPLineBreakingStrategy.java
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
  */
-package org.xhtmlrenderer.pdf;
+package org.xhtmlrenderer.fop;
 
 import java.text.BreakIterator;
 import java.util.Arrays;
@@ -27,11 +27,11 @@ import org.apache.fop.hyphenation.HyphenationTree;
 import org.apache.fop.hyphenation.Hyphenator;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
-import org.xhtmlrenderer.layout.BreakPoint;
-import org.xhtmlrenderer.layout.BreakPointsProvider;
-import org.xhtmlrenderer.layout.LineBreakingStrategy;
-import org.xhtmlrenderer.layout.ListBreakPointsProvider;
-import org.xhtmlrenderer.layout.UrlAwareLineBreakIterator;
+import org.xhtmlrenderer.layout.breaker.BreakPoint;
+import org.xhtmlrenderer.layout.breaker.BreakPointsProvider;
+import org.xhtmlrenderer.layout.breaker.LineBreakingStrategy;
+import org.xhtmlrenderer.layout.breaker.ListBreakPointsProvider;
+import org.xhtmlrenderer.layout.breaker.UrlAwareLineBreakIterator;
 
 /**
  * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
@@ -40,10 +40,10 @@ public class FOPLineBreakingStrategy implements LineBreakingStrategy {
 	
 	private static final int SOFT_HYPHEN = '\u00AD';
 	
-	private TreeSet<BreakPoint> getPoints(String text, CalculatedStyle style) {
+	private TreeSet<BreakPoint> getPoints(String text, String lang, CalculatedStyle style) {
 		BreakIterator breakIt = new UrlAwareLineBreakIterator();
 		breakIt.setText(text);
-		TreeSet<BreakPoint> points = new TreeSet<>();
+		TreeSet<BreakPoint> points = new TreeSet<BreakPoint>();
 		int p = BreakIterator.DONE;
 		while ((p = breakIt.next()) != BreakIterator.DONE) {
 			points.add(new BreakPoint(p));
@@ -62,7 +62,7 @@ public class FOPLineBreakingStrategy implements LineBreakingStrategy {
 			return points;
 		}
 		if (style.getHyphens() == IdentValue.AUTO) {
-			HyphenationTree tree = Hyphenator.getFopHyphenationTree("cs");
+			HyphenationTree tree = Hyphenator.getFopHyphenationTree(lang);
 			Hyphenation s = tree.hyphenate(text, 2, 2);
 			if (s == null) return points;
 			for (int i = 0; i < s.getHyphenationPoints().length; i++) {
@@ -76,8 +76,8 @@ public class FOPLineBreakingStrategy implements LineBreakingStrategy {
 	}
 
 	@Override
-	public BreakPointsProvider getBreakPointsProvider(String text, CalculatedStyle style) {
-		return new ListBreakPointsProvider(Arrays.asList(getPoints(text, style).toArray(new BreakPoint[0])));
+	public BreakPointsProvider getBreakPointsProvider(String text, String lang, CalculatedStyle style) {
+		return new ListBreakPointsProvider(Arrays.asList(getPoints(text, lang, style).toArray(new BreakPoint[0])));
 	}
 	
 	private void addHyphen(BreakPoint p) {

--- a/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/FOPLineBreakingStrategy.java
+++ b/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/FOPLineBreakingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -27,6 +27,7 @@ import org.apache.fop.hyphenation.HyphenationTree;
 import org.apache.fop.hyphenation.Hyphenator;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.fop.nbsp.NonBreakPointsEnhancer;
 import org.xhtmlrenderer.layout.breaker.BreakPoint;
 import org.xhtmlrenderer.layout.breaker.BreakPointsProvider;
 import org.xhtmlrenderer.layout.breaker.LineBreakingStrategy;
@@ -34,13 +35,14 @@ import org.xhtmlrenderer.layout.breaker.ListBreakPointsProvider;
 import org.xhtmlrenderer.layout.breaker.UrlAwareLineBreakIterator;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class FOPLineBreakingStrategy implements LineBreakingStrategy {
 	
 	private static final int SOFT_HYPHEN = '\u00AD';
 	
 	private TreeSet<BreakPoint> getPoints(String text, String lang, CalculatedStyle style) {
+		text = new NonBreakPointsEnhancer().enhance(text, lang);
 		BreakIterator breakIt = new UrlAwareLineBreakIterator();
 		breakIt.setText(text);
 		TreeSet<BreakPoint> points = new TreeSet<BreakPoint>();

--- a/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsEnhancer.java
+++ b/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsEnhancer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Processes text and replaces spaces by non-break spaces (\u00A0) 
+ * on places designated by the language definition file.
+ * 
+ * Language definition files should be located on classpath in the directory
+ * "non-break-spaces/${langKey}.nbsp". If lang key contains '_', in first run
+ * we search for whole lang key and if not found for part of the lang key before '_'.
+ * Encoding of the nbsp file must be utf8.
+ * 
+ * Language definition file consist of line per each rule. Line contains regexp pattern with
+ * three groups. Second group will be reaplaced by \u00A0. First and second will be copied and are used
+ * to match the selection properly. 
+ * Ex.: "([\\s]+and)( )([^\\s]+)" will replace "this and something else" with "this and\u00A0something else" 
+ * so and will not be left hanging at the end of the line.
+ * 
+ * Rules are applied to the content in the order as they appear in the file and result of one rule run is used
+ * as input for the next run.
+ * 
+ * Lines starting with '#' and empty lines are skipped and can be used as comments.
+ * 
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public class NonBreakPointsEnhancer {
+	
+	private NonBreakPointsLoader loader;
+	
+	public NonBreakPointsEnhancer() {
+		this(new NonBreakPointsLoaderImpl());
+	}
+	
+	/**
+	 * For test only
+	 */
+	/*package*/ NonBreakPointsEnhancer(NonBreakPointsLoader loader) {
+		this.loader = loader;
+	}
+	
+	public String enhance(String input, String lang) {
+		if (input == null) return null;
+		if (input.isEmpty()) return "";
+		if (lang == null || lang.isEmpty()) return input;
+		List<String> rules = loader.loadNBSP(lang);
+		if (rules == null) return input;
+		for (String r : rules) {
+			Matcher m = Pattern.compile(r).matcher(input);
+			if (m.groupCount() != 3) {
+				throw new IllegalArgumentException("Expression must contain exactly 3 groups! " + r);
+			}
+			if (m.find()) {
+				input = m.replaceAll("$1\u00A0$3");
+			}
+		}
+		return input;
+	}
+
+}

--- a/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoader.java
+++ b/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import java.util.List;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public interface NonBreakPointsLoader {
+
+	
+	List<String> loadNBSP(String lang);
+
+}

--- a/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoaderImpl.java
+++ b/flying-saucer-fop/src/main/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoaderImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public class NonBreakPointsLoaderImpl implements NonBreakPointsLoader {
+	
+	@Override
+	public List<String> loadNBSP(String lang) {
+		if (lang == null || lang.isEmpty()) {
+			throw new IllegalArgumentException("Lang must be filled to search for file!");
+		}
+		List<String> result = loadForKey(lang);
+		if (result == null) {
+			int index = lang.indexOf('_');
+			if (index < 0) return null; // cannot split key
+			result = loadForKey(lang.substring(0, index));
+		}
+		return result;
+	}
+	
+	private List<String> loadForKey(String lang) {
+		String path = "non-break-spaces/" + lang + ".nbsp";
+		InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+		if (is == null) return null;
+		try {
+			BufferedReader r = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+			List<String> result = new ArrayList<String>();
+			String line = null;
+			while ((line = r.readLine()) != null) {
+				if (line.isEmpty() || line.startsWith("#")) continue;
+				result.add(line);
+			}
+			return result;
+		} catch (IOException e) {
+			throw new RuntimeException("Error while loading nbsp file from path " + path, e);
+		} finally {
+			try {
+				is.close();
+			} catch (IOException e1) {
+				// ignore
+			}
+		}
+	}
+
+}

--- a/flying-saucer-fop/src/main/resources/non-break-spaces/cs.nbsp
+++ b/flying-saucer-fop/src/main/resources/non-break-spaces/cs.nbsp
@@ -1,0 +1,23 @@
+# Definice nezalomitelnych pripadu castecne dle http://prirucka.ujc.cas.cz/?id=880
+# (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+# License LGPL 2.1
+#
+
+([\s]+k)( )([^\s]+)
+([\s]+s)( )([^\s]+)
+([\s]+v)( )([^\s]+)
+([\s]+z)( )([^\s]+)
+([\s]+o)( )([^\s]+)
+([\s]+u)( )([^\s]+)
+([\s]+a)( )([^\s]+)
+([\s]+i)( )([^\s]+)
+([\s]+[\d]+\.)( )([^\s]+)
+([\d]{1})( )([\d]{1})
+(\*)( )([\d]+)
+(†)( )([\d]+)
+(§)( )([\d]+)
+(#)( )([\d]+)
+([\d]+)( )(€)
+([\d]+)( )(Kč)
+([\d]+)( )(kč)
+([\d]+)( )(%)

--- a/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/PDFHyphenationTest.java
+++ b/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/PDFHyphenationTest.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (C) 2017 MEDIA SOLUTIONS
- * All Rights Reserved.  No use, copying or distribution of this
- * work may be made except in accordance with a valid license
- * agreement from MEDIA SOLUTIONS. This notice must be
- * included on all copies, modifications and derivatives of this
- * work.
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- * MEDIA SOLUTIONS MAKES NO REPRESENTATIONS OR WARRANTIES
- * ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER EXPRESSED OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
- * MEDIA SOLUTIONS SHALL NOT BE LIABLE FOR ANY DAMAGES
- * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
- * THIS SOFTWARE OR ITS DERIVATIVES.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
  */
 package org.xhtmlrenderer.fop;
@@ -29,7 +30,7 @@ import org.xhtmlrenderer.pdf.ITextUserAgent;
 import com.itextpdf.text.DocumentException;
 
 /**
- * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
  */
 public class PDFHyphenationTest {
 	

--- a/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/PDFHyphenationTest.java
+++ b/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/PDFHyphenationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ * All Rights Reserved.  No use, copying or distribution of this
+ * work may be made except in accordance with a valid license
+ * agreement from MEDIA SOLUTIONS. This notice must be
+ * included on all copies, modifications and derivatives of this
+ * work.
+ *
+ * MEDIA SOLUTIONS MAKES NO REPRESENTATIONS OR WARRANTIES
+ * ABOUT THE SUITABILITY OF THE SOFTWARE, EITHER EXPRESSED OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+ * MEDIA SOLUTIONS SHALL NOT BE LIABLE FOR ANY DAMAGES
+ * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
+ * THIS SOFTWARE OR ITS DERIVATIVES.
+ *
+ */
+package org.xhtmlrenderer.fop;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xhtmlrenderer.pdf.ITextUserAgent;
+
+import com.itextpdf.text.DocumentException;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class PDFHyphenationTest {
+	
+	private static final String XML = 
+			"<html>\n" + 
+			"	<head>\n" + 
+			"		<meta http-equiv=\"Content-Language\" content=\"cs\"/>" +
+			"		<style media=\"print\" type=\"text/css\">\n" + 
+			"			body {\n" + 
+			"				background: gray;\n" + 
+			"				margin:0;\n" + 
+			"				word-wrap: break-word; \n" + 
+			"				text-align: justify;\n" + 
+			"				font-size: 7.5pt;\n" + 
+			"				line-height: 1;\n" + 
+			"               hyphens: auto\n" +		
+			"			}\n" + 
+			"\n" + 
+			"			@page {\n" + 
+			"				size: 43mm 25mm;\n" + 
+			"				margin-top:0cm; \n" + 
+			"			    margin-left:0cm; \n" + 
+			"			    margin-right:0cm; \n" + 
+			"			    margin-bottom:0cm; \n" + 
+			"			}\n" + 
+			"		</style>\n" + 
+			"	</head>\n" + 
+			"	<body>\n" + 
+			"		Velice dlouhy text, ktery bude mit problemy se zalamovanim, pokud nebude perfektne nastaveno." +  
+			"	</body>\n" + 
+			"</html>";
+	
+	@Test
+	public void testGenerator() throws Exception {
+		Path temp = Files.createTempFile("pdfTest", ".pdf");
+		OutputStream os = Files.newOutputStream(temp);
+		generatePDF(XML, os);
+		System.out.println(temp);
+	}
+	
+	private void generatePDF(String xml, OutputStream os) throws DocumentException, IOException {
+		ITextRenderer renderer = new ITextRenderer();
+		ITextUserAgent ua = new ITextUserAgent(renderer.getOutputDevice());
+		ua.setSharedContext(renderer.getSharedContext());
+		renderer.getSharedContext().setUserAgentCallback(ua);
+		renderer.getSharedContext().setLineBreakingStrategy(new FOPLineBreakingStrategy());
+		
+		renderer.setDocumentFromString(xml);
+		renderer.layout();
+		renderer.createPDF(os);
+	}
+
+}

--- a/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsEnhancerTest.java
+++ b/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsEnhancerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public class NonBreakPointsEnhancerTest {
+	
+	@Test
+	public void testNullInput() throws Exception {
+		assertNull(new NonBreakPointsEnhancer().enhance(null, "cs"));
+	}
+	
+	@Test
+	public void testNullLang() throws Exception {
+		assertEquals("some input", new NonBreakPointsEnhancer().enhance("some input", null));
+	}
+	
+	@Test
+	public void testEmptyLang() throws Exception {
+		assertEquals("some input", new NonBreakPointsEnhancer().enhance("some input", ""));
+	}
+	
+	@Test
+	public void testEmptyInput() throws Exception {
+		assertEquals("", new NonBreakPointsEnhancer().enhance("", "en"));
+	}
+	
+	@Test
+	public void noDefinition() throws Exception {
+		NonBreakPointsLoader nullLoader = new NonBreakPointsLoader() {
+			
+			@Override
+			public List<String> loadNBSP(String lang) {
+				return null;
+			}
+		};
+		assertEquals("some text with spaces", new NonBreakPointsEnhancer(nullLoader).enhance("some text with spaces", "cs"));
+	}
+	
+	@Test
+	public void testLoaderConfiguration() throws Exception {
+		final String[] c = new String[] {null};
+		NonBreakPointsLoader capturingLoader = new NonBreakPointsLoader() {
+			
+			@Override
+			public List<String> loadNBSP(String lang) {
+				c[0] = lang;
+				return null;
+			}
+		};
+		new NonBreakPointsEnhancer(capturingLoader).enhance("some text with spaces", "cs");
+		assertEquals("cs", c[0]);
+	}
+	
+	@Test
+	public void emptyRules() throws Exception {
+		testRulesInternal("some text", "some text");
+	}
+	
+	@Test
+	public void rules1() throws Exception {
+		testRulesInternal("prselo a potom kousek", "prselo a\u00A0potom kousek", "([\\s]+a)( )([^\\s]+)");
+	}
+	
+	@Test
+	public void rules2() throws Exception {
+		testRulesInternal("prselo a potom se to cele stalo a sli jsme domu", "prselo a\u00A0potom se to cele stalo a\u00A0sli jsme domu", "([\\s]+a)( )([^\\s]+)");
+	}
+	
+	@Test
+	public void rules3() throws Exception {
+		testRulesInternal("prselo a potom jsme sli domu s kamarady a povidali si", "prselo a\u00A0potom jsme sli domu s\u00A0kamarady a\u00A0povidali si", "([\\s]+a)( )([^\\s]+)", "([\\s]+s)( )([^\\s]+)");
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void invalidRuleGroups() throws Exception {
+		testRulesInternal("a potom", "a\u00A0potom", "a( )[^\\s]{1,}");
+	}
+	
+	@Test
+	public void czechRules() throws Exception {
+		assertCzech("byli jsme u babicky", "byli jsme u\u00A0babicky");
+		assertCzech("byli jsme k babicky", "byli jsme k\u00A0babicky");
+		assertCzech("byli jsme s babicky", "byli jsme s\u00A0babicky");
+		assertCzech("byli jsme v babicky", "byli jsme v\u00A0babicky");
+		assertCzech("byli jsme z babicky", "byli jsme z\u00A0babicky");
+		assertCzech("byli jsme o babicky", "byli jsme o\u00A0babicky");
+		assertCzech("byli jsme u babicky", "byli jsme u\u00A0babicky");
+		assertCzech("byli jsme a babicky", "byli jsme a\u00A0babicky");
+		assertCzech("byli jsme i babicky", "byli jsme i\u00A0babicky");
+		assertCzech("50 %", "50\u00A0%");
+		assertCzech("§ 50", "§\u00A050");
+		assertCzech("# 50", "#\u00A050");
+		assertCzech("* 50", "*\u00A050");
+		assertCzech("† 50", "†\u00A050");
+		assertCzech("50 000", "50\u00A0000");
+		assertCzech("50 000 000", "50\u00A0000\u00A0000");
+		assertCzech("+420 800 123 987", "+420\u00A0800\u00A0123\u00A0987");
+		assertCzech(" 21. 3. 2017", " 21.\u00A03. 2017");
+	}
+	
+	private void assertCzech(String text, String expected) {
+		assertEquals(expected, new NonBreakPointsEnhancer().enhance(text, "cs"));
+	}
+	
+	private void testRulesInternal(String text, String expected, final String ... rules) {
+		NonBreakPointsLoader dummyLoader = new NonBreakPointsLoader() {
+			
+			@Override
+			public List<String> loadNBSP(String lang) {
+				return Arrays.asList(rules);
+			}
+		};
+		assertEquals(expected, new NonBreakPointsEnhancer(dummyLoader).enhance(text, "en"));
+	}
+
+}

--- a/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoaderImplTest.java
+++ b/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsLoaderImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.xhtmlrenderer.fop.nbsp.NonBreakPointsLoaderImpl;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public class NonBreakPointsLoaderImplTest {
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void nullLang() throws Exception {
+		new NonBreakPointsLoaderImpl().loadNBSP(null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void emptyLang() throws Exception {
+		new NonBreakPointsLoaderImpl().loadNBSP("");
+	}
+	
+	@Test
+	public void loadExactMatch() throws Exception {
+		List<String> lines = new NonBreakPointsLoaderImpl().loadNBSP("de");
+		assertEquals(1, lines.size());
+		assertEquals("deRuleščřžýá", lines.get(0)); // tests also UTF-8 chars
+	}
+	
+	@Test
+	public void loadNonExactMatch() throws Exception {
+		List<String> lines = new NonBreakPointsLoaderImpl().loadNBSP("de_DE");
+		assertEquals(1, lines.size());
+		assertEquals("deRuleščřžýá", lines.get(0)); // tests also UTF-8 chars
+	}
+	
+	@Test
+	public void nonExisting() throws Exception {
+		assertNull(new NonBreakPointsLoaderImpl().loadNBSP("es"));
+	}
+	
+	@Test
+	public void loadExactMatch2() throws Exception {
+		List<String> lines = new NonBreakPointsLoaderImpl().loadNBSP("en_GB");
+		assertEquals(2, lines.size());
+		assertEquals("enGBRule1", lines.get(0));
+		assertEquals("enGBRule2", lines.get(1));
+	}
+
+}

--- a/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsTest.java
+++ b/flying-saucer-fop/src/test/java/org/xhtmlrenderer/fop/nbsp/NonBreakPointsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.fop.nbsp;
+
+import static org.junit.Assert.assertEquals;
+
+import java.text.BreakIterator;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.TreeSet;
+
+import org.junit.Test;
+import org.xhtmlrenderer.layout.breaker.BreakPoint;
+import org.xhtmlrenderer.layout.breaker.UrlAwareLineBreakIterator;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@gmail.com
+ */
+public class NonBreakPointsTest {
+	
+	@Test
+	public void testGeneral() throws Exception {
+		test("text s mezerami", 5, 7, 15);
+	}
+	
+	@Test
+	public void testNBSP() throws Exception {
+		test("text s\u00A0mezerami", 5, 15);
+	}
+	
+	private void test(String text, int ... expected) {
+		BreakIterator breakIt = new UrlAwareLineBreakIterator();
+		breakIt.setText(text);
+		TreeSet<BreakPoint> points = new TreeSet<BreakPoint>();
+		int p = BreakIterator.DONE;
+		while ((p = breakIt.next()) != BreakIterator.DONE) {
+			points.add(new BreakPoint(p));
+		}
+		assertBreakPoints(points, expected);
+	}
+	
+	private void assertBreakPoints(Collection<BreakPoint> calculated, int ... expected) {
+		if (calculated.size() != expected.length) throw new AssertionError("Expected " + expected.length + 
+				" break points, got " + calculated.size() + ": " + calculated);
+		Iterator<BreakPoint> it = calculated.iterator();
+		for (int point : expected) {
+			assertEquals(point, it.next().getPosition());
+		}
+	}
+	
+	
+
+}

--- a/flying-saucer-fop/src/test/resources/non-break-spaces/cs.nbsp
+++ b/flying-saucer-fop/src/test/resources/non-break-spaces/cs.nbsp
@@ -1,0 +1,24 @@
+# Definice nezalomitelnych pripadu castecne dle http://prirucka.ujc.cas.cz/?id=880
+# (C) 2017 Lukas Zaruba, lukas.zaruba@gmail.com
+# License LGPL 2.1
+#
+# Copy for testing
+
+([\s]+k)( )([^\s]+)
+([\s]+s)( )([^\s]+)
+([\s]+v)( )([^\s]+)
+([\s]+z)( )([^\s]+)
+([\s]+o)( )([^\s]+)
+([\s]+u)( )([^\s]+)
+([\s]+a)( )([^\s]+)
+([\s]+i)( )([^\s]+)
+([\s]+[\d]+\.)( )([^\s]+)
+([\d]{1})( )([\d]{1})
+(\*)( )([\d]+)
+(†)( )([\d]+)
+(§)( )([\d]+)
+(#)( )([\d]+)
+([\d]+)( )(€)
+([\d]+)( )(Kč)
+([\d]+)( )(kč)
+([\d]+)( )(%)

--- a/flying-saucer-fop/src/test/resources/non-break-spaces/de.nbsp
+++ b/flying-saucer-fop/src/test/resources/non-break-spaces/de.nbsp
@@ -1,0 +1,2 @@
+#thisIsComment
+deRuleščřžýá

--- a/flying-saucer-fop/src/test/resources/non-break-spaces/en_GB.nbsp
+++ b/flying-saucer-fop/src/test/resources/non-break-spaces/en_GB.nbsp
@@ -1,0 +1,4 @@
+#thisIsComment
+enGBRule1
+
+enGBRule2

--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/FOPLineBreakingStrategy.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/FOPLineBreakingStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 MEDIA SOLUTIONS
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+package org.xhtmlrenderer.pdf;
+
+import java.text.BreakIterator;
+import java.util.Arrays;
+import java.util.TreeSet;
+
+import org.apache.fop.hyphenation.Hyphenation;
+import org.apache.fop.hyphenation.HyphenationTree;
+import org.apache.fop.hyphenation.Hyphenator;
+import org.xhtmlrenderer.css.constants.IdentValue;
+import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.layout.BreakPoint;
+import org.xhtmlrenderer.layout.BreakPointsProvider;
+import org.xhtmlrenderer.layout.LineBreakingStrategy;
+import org.xhtmlrenderer.layout.ListBreakPointsProvider;
+import org.xhtmlrenderer.layout.UrlAwareLineBreakIterator;
+
+/**
+ * @author Lukas Zaruba, lukas.zaruba@media-sol.com, MEDIA SOLUTIONS
+ */
+public class FOPLineBreakingStrategy implements LineBreakingStrategy {
+	
+	private static final int SOFT_HYPHEN = '\u00AD';
+	
+	private TreeSet<BreakPoint> getPoints(String text, CalculatedStyle style) {
+		BreakIterator breakIt = new UrlAwareLineBreakIterator();
+		breakIt.setText(text);
+		TreeSet<BreakPoint> points = new TreeSet<>();
+		int p = BreakIterator.DONE;
+		while ((p = breakIt.next()) != BreakIterator.DONE) {
+			points.add(new BreakPoint(p));
+		}
+		if (style.getHyphens() == IdentValue.NONE) {
+			return points;
+		}
+		if (style.getHyphens() == IdentValue.MANUAL) {
+			int index = text.indexOf(SOFT_HYPHEN);
+			while (index >= 0) {
+				BreakPoint point = new BreakPoint(index);
+				addHyphen(point);
+				points.add(point);
+			    index = text.indexOf(SOFT_HYPHEN, index + 1);
+			}
+			return points;
+		}
+		if (style.getHyphens() == IdentValue.AUTO) {
+			HyphenationTree tree = Hyphenator.getFopHyphenationTree("cs");
+			Hyphenation s = tree.hyphenate(text, 2, 2);
+			if (s == null) return points;
+			for (int i = 0; i < s.getHyphenationPoints().length; i++) {
+				int position = s.getHyphenationPoints()[i];
+				BreakPoint point = new BreakPoint(position);
+				addHyphen(point);
+				points.add(point);
+			}
+		}
+		return points;
+	}
+
+	@Override
+	public BreakPointsProvider getBreakPointsProvider(String text, CalculatedStyle style) {
+		return new ListBreakPointsProvider(Arrays.asList(getPoints(text, style).toArray(new BreakPoint[0])));
+	}
+	
+	private void addHyphen(BreakPoint p) {
+		p.setHyphen("\u002D");
+	}
+	
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <module>flying-saucer-swt</module>
     <module>flying-saucer-swt-examples</module>
     <module>flying-saucer-examples</module>
+    <module>flying-saucer-fop</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
Hi,
I have redesigned Breaker to allow usage of pluggable text breakers. Default behaviour mostly copies original state. There is difference in the Breaker though - original code was trying to squeeze text by removing trailing spaces. New code doesn't do that anymore.

To leverage described modularity I have created new module flying-saucer-fop which implements text breaker using Apache FOP library with included word wrapping dictionaries from project OFFO. I am bit unsure about licence compatibility so please verify that. flying-saucer-fop module contains test that shows usage including language definition. I will be happy to provide snippets for the project documentation if needed.

As a step in the process of solving my issue with text layout I came across spaces being left at the end of the line after wrapping which caused text-align: justify to work poorly. I've fixed that in [InlineBoxing](https://github.com/LZaruba/flyingsaucer/blob/master.word-wrap/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java#L241-L243) but I am not really sure about the solution - if this is the right place and what about text-align: right and maybe others. I can strip trailing spaces inside of the Breaker. Anyway it works now as you can see in the example.

Feel free to contact me for further improvements and information as this is the first version.

Thanks for the great library!
Cheers
LZ