### PR TITLE
Add Maven profiles for choosing between OpenPDF or iText as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ New releases of Flying Saucer are distributed through Maven.  The available arti
 * `org.xhtmlrenderer:flying-saucer-swt` - SWT output
 * `org.xhtmlrenderer:flying-saucer-log4j` - Logging plugin for log4j
 
+Build with openpdf Maven profile to use OpenPDF.
+
 GETTING STARTED
 ---------------
 There is a large amount of sample code under the `flying-saucer-examples` directory.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ GETTING FLYING SAUCER
 New releases of Flying Saucer are distributed through Maven.  The available artifacts are:
 
 * `org.xhtmlrenderer:flying-saucer-core` - Core library and Java2D rendering
-* `org.xhtmlrenderer:flying-saucer-pdf` - PDF output using iText
+* `org.xhtmlrenderer:flying-saucer-pdf` - PDF output using iText or OpenPDF
 * `org.xhtmlrenderer:flying-saucer-swt` - SWT output
 * `org.xhtmlrenderer:flying-saucer-log4j` - Logging plugin for log4j
 

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -35,6 +35,45 @@
 		</repository>
 	</distributionManagement>
 
+	<profiles>
+		<profile>
+			<id>itext</id>
+			<activation>
+			<activeByDefault>true</activeByDefault>
+			</activation>
+			<dependencies>
+				<!-- IText used for test execution -->
+				<dependency>
+					<groupId>com.itextpdf</groupId>
+					<artifactId>itextpdf</artifactId>
+					<version>5.3.0</version>
+					<scope>test</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.xhtmlrenderer</groupId>
+					<artifactId>flying-saucer-pdf-itext5</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>openpdf</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.github.librepdf</groupId>
+					<artifactId>openpdf</artifactId>
+					<version>1.0.1</version>
+					<scope>test</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.xhtmlrenderer</groupId>
+					<artifactId>flying-saucer-pdf</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.xhtmlrenderer</groupId>
@@ -58,18 +97,6 @@
 			<artifactId>junit</artifactId>
 			<version>4.10</version>
 			<scope>test</scope>
-		</dependency>
-		<!-- IText used for test execution -->
-		<dependency>
-			<groupId>com.itextpdf</groupId>
-			<artifactId>itextpdf</artifactId>
-			<version>5.3.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.xhtmlrenderer</groupId>
-			<artifactId>flying-saucer-pdf-itext5</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -14,8 +14,8 @@
 
   <packaging>jar</packaging>
 
-  <name>Flying Saucer PDF Rendering (iText 5.x or OpenPDF)</name>
-  <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output with iText 5.x or OpenPDF https://github.com/LibrePDF/OpenPDF.</description>
+  <name>Flying Saucer PDF Rendering (iText 5.x)</name>
+  <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output with iText 5.x.</description>
 
   <licenses>
     <license>
@@ -31,41 +31,18 @@
     </repository>
   </distributionManagement>
 
-  <profiles>
-    <profile>
-        <id>itext</id>
-        <activation>
-          <activeByDefault>true</activeByDefault>
-        </activation>
-        <dependencies>
-          <dependency>
-            <groupId>com.itextpdf</groupId>
-            <artifactId>itextpdf</artifactId>
-            <version>5.3.0</version>
-          </dependency>
-          <dependency>
-            <groupId>org.xhtmlrenderer</groupId>
-            <artifactId>flying-saucer-core</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-    </profile>
-    <profile>
-      <id>openpdf</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.github.librepdf</groupId>
-          <artifactId>openpdf</artifactId>
-          <version>1.0.1</version>
-        </dependency>
-        <dependency>
-          <groupId>org.xhtmlrenderer</groupId>
-          <artifactId>flying-saucer-core</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
+  <dependencies>
+    <dependency>
+      <groupId>com.itextpdf</groupId>
+      <artifactId>itextpdf</artifactId>
+        <version>5.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xhtmlrenderer</groupId>
+      <artifactId>flying-saucer-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 
   <build>
     <resources>

--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -14,8 +14,8 @@
 
   <packaging>jar</packaging>
 
-  <name>Flying Saucer PDF Rendering (iText 5.x)</name>
-  <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output with iText 5.x.</description>
+  <name>Flying Saucer PDF Rendering (iText 5.x or OpenPDF)</name>
+  <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output with iText 5.x or OpenPDF https://github.com/LibrePDF/OpenPDF.</description>
 
   <licenses>
     <license>
@@ -31,18 +31,41 @@
     </repository>
   </distributionManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.itextpdf</groupId>
-      <artifactId>itextpdf</artifactId>
-      <version>5.3.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xhtmlrenderer</groupId>
-      <artifactId>flying-saucer-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-  </dependencies>
+  <profiles>
+    <profile>
+        <id>itext</id>
+        <activation>
+          <activeByDefault>true</activeByDefault>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.3.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-core</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+    </profile>
+    <profile>
+      <id>openpdf</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.librepdf</groupId>
+          <artifactId>openpdf</artifactId>
+          <version>1.0.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.xhtmlrenderer</groupId>
+          <artifactId>flying-saucer-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <resources>

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -30,24 +30,47 @@
     </repository>
   </distributionManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.lowagie</groupId>
-      <artifactId>itext</artifactId>
-      <version>2.1.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xhtmlrenderer</groupId>
-      <artifactId>flying-saucer-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.10</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+  <profiles>
+    <profile>
+      <id>itext</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.lowagie</groupId>
+          <artifactId>itext</artifactId>
+          <version>2.1.7</version>
+        </dependency>
+        <dependency>
+          <groupId>org.xhtmlrenderer</groupId>
+          <artifactId>flying-saucer-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.10</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>openpdf</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.librepdf</groupId>
+          <artifactId>openpdf</artifactId>
+          <version>1.0.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.xhtmlrenderer</groupId>
+          <artifactId>flying-saucer-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
 	  <resources>

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -68,6 +68,12 @@
           <artifactId>flying-saucer-core</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.10</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <module>flying-saucer-core</module>
     <module>flying-saucer-pdf</module>
     <module>flying-saucer-pdf-osgi</module>
-    <module>flying-saucer-pdf-itext5</module>
     <module>flying-saucer-log4j</module>
     <module>flying-saucer-swt</module>
     <module>flying-saucer-swt-examples</module>
@@ -63,6 +62,15 @@
 
   <profiles>
     <profile>
+      <id>itext</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>flying-saucer-pdf-itext5</module>
+      </modules>
+    </profile>
+    <profile>
       <id>doclint-java8-disable</id>
       <activation>
         <jdk>[1.8,)</jdk>
@@ -70,6 +78,12 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
+    </profile>
+    <profile>
+      <id>openpdf</id>
+      <modules>
+        <module>flying-saucer-pdf</module>
+      </modules>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>flying-saucer-core</module>
     <module>flying-saucer-pdf</module>
     <module>flying-saucer-pdf-osgi</module>
+    <module>flying-saucer-pdf-itext5</module>
     <module>flying-saucer-log4j</module>
     <module>flying-saucer-swt</module>
     <module>flying-saucer-swt-examples</module>
@@ -62,15 +63,6 @@
 
   <profiles>
     <profile>
-      <id>itext</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <modules>
-        <module>flying-saucer-pdf-itext5</module>
-      </modules>
-    </profile>
-    <profile>
       <id>doclint-java8-disable</id>
       <activation>
         <jdk>[1.8,)</jdk>
@@ -78,12 +70,6 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
-    </profile>
-    <profile>
-      <id>openpdf</id>
-      <modules>
-        <module>flying-saucer-pdf</module>
-      </modules>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Add Maven profiles for choosing between OpenPDF or iText as dependency.

OpenPDF is a Java library for creating and editing PDF files with a LGPL and MPL open source license. OpenPDF is based on a fork of iText 4.  https://github.com/LibrePDF/OpenPDF

iText has a AGPL license, but is sold as a commercial product.  http://itextpdf.com/

