### PR TITLE
Fix NPE when special symbols ('&', '>') is at the end of td

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BoxBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BoxBuilder.java
@@ -1225,6 +1225,15 @@ public class BoxBuilder {
                 } else if(nodeType == Node.ENTITY_REFERENCE_NODE) {
                     EntityReference entityReference = (EntityReference)working;
                     child = createInlineBox(entityReference.getTextContent(), parent, parentStyle, null);
+
+                    InlineBox iB = (InlineBox) child;
+                    iB.setEndsHere(true);
+                    if (previousIB == null) {
+                        iB.setStartsHere(true);
+                    } else {
+                        previousIB.setEndsHere(false);
+                    }
+                    previousIB = iB;
                 }
 
                 if (child != null) {


### PR DESCRIPTION
Sample html that fails without this fix:

```
<table>
  <tr>
  <td>foo&</td>
</tr>
</table>
```