### PR TITLE
Resolve uri regression fix

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -352,7 +352,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      */
     public String resolveURI(String uri) {
         if (uri == null) return null;
-        String ret = null;
+
         if (_baseURL == null) {//first try to set a base URL
             try {
                 URI result = new URI(uri);
@@ -369,18 +369,33 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
                 }
             }
         }
+
+        // _baseURL is guaranteed to be non-null at this point.
         // test if the URI is valid; if not, try to assign the base url as its parent
+	    Throwable t;
         try {
             URI result = new URI(uri);
-            if (!result.isAbsolute()) {
-                XRLog.load(uri + " is not a URL; may be relative. Testing using parent URL " + _baseURL);
-                result=new URI(_baseURL).resolve(result);
+	        if (result.isAbsolute()) {
+	        	return result.toString();
+	        }
+            XRLog.load(uri + " is not a URL; may be relative. Testing using parent URL " + _baseURL);
+            URI baseURI = new URI(_baseURL);
+            if(!baseURI.isOpaque()) {
+            	// uri.resolve(child) only works for opaque URIs.
+	            // Otherwise it would simply return child.
+	            return baseURI.resolve(result).toString();
             }
-            ret = result.toString();
+	        // Fall back to previous resolution using URL
+	        try {
+		        return new URL(new URL(_baseURL), uri).toExternalForm();
+	        } catch (MalformedURLException ex) {
+            	t = ex;
+	        }
         } catch (URISyntaxException e) {
-            XRLog.exception("The default NaiveUserAgent cannot resolve the URL " + uri + " with base URL " + _baseURL);
+        	t = e;
         }
-        return ret;
+	    XRLog.exception("The default NaiveUserAgent cannot resolve the URL " + uri + " with base URL " + _baseURL, t);
+        return null;
     }
 
     /**

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -131,75 +131,75 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         }
         return is;
     }
-	
-	protected InputStream openStream(String uri) throws MalformedURLException, IOException {
-		return openConnection(uri).getInputStream();
-	}
+    
+    protected InputStream openStream(String uri) throws MalformedURLException, IOException {
+        return openConnection(uri).getInputStream();
+    }
 
-	/**
-	 * Opens a connections to uri.
-	 * 
-	 * This can be overwritten to customize handling of connections by type.
-	 * 
-	 * @param uri the uri to connect to
-	 * @return URLConnection opened connection to uri
-	 * @throws IOException if an I/O exception occurs.
-	 */
-	protected URLConnection openConnection(String uri) throws IOException {
-		URLConnection connection = new URL(uri).openConnection();
-		if (connection instanceof HttpURLConnection) {
-			connection = onHttpConnection((HttpURLConnection) connection);
-		}
-		return connection;
-	}
+    /**
+     * Opens a connections to uri.
+     * 
+     * This can be overwritten to customize handling of connections by type.
+     * 
+     * @param uri the uri to connect to
+     * @return URLConnection opened connection to uri
+     * @throws IOException if an I/O exception occurs.
+     */
+    protected URLConnection openConnection(String uri) throws IOException {
+        URLConnection connection = new URL(uri).openConnection();
+        if (connection instanceof HttpURLConnection) {
+            connection = onHttpConnection((HttpURLConnection) connection);
+        }
+        return connection;
+    }
 
-	/**
-	 * Customized handling of @link{HttpUrlConnection}.
-	 * 
-	 * 
-	 * @param origin the original connection
-	 * @return @link{URLConnection} 
-	 * 
-	 * @throws MalformedURLException if an unknown protocol is specified.
-	 * @throws IOException if an I/O exception occurs.
-	 */
-	protected URLConnection onHttpConnection(HttpURLConnection origin) throws MalformedURLException, IOException {
-		URLConnection connection = origin;
-		int status = origin.getResponseCode();
+    /**
+     * Customized handling of @link{HttpUrlConnection}.
+     * 
+     * 
+     * @param origin the original connection
+     * @return @link{URLConnection} 
+     * 
+     * @throws MalformedURLException if an unknown protocol is specified.
+     * @throws IOException if an I/O exception occurs.
+     */
+    protected URLConnection onHttpConnection(HttpURLConnection origin) throws MalformedURLException, IOException {
+        URLConnection connection = origin;
+        int status = origin.getResponseCode();
 
-		if (needsRedirect(status)) {
-			// get redirect url from "location" header field
-			String newUrl = origin.getHeaderField("Location");
-			
-			if (origin.getInstanceFollowRedirects()) {
-				XRLog.load("Connection is redirected to: " + newUrl);
-				// open the new connnection again
-				connection = new URL(newUrl).openConnection();
-			} else {
-				XRLog.load("Redirect is required but not allowed to: " + newUrl);
-			}
-		}
-		return connection;
-	}
+        if (needsRedirect(status)) {
+            // get redirect url from "location" header field
+            String newUrl = origin.getHeaderField("Location");
+            
+            if (origin.getInstanceFollowRedirects()) {
+                XRLog.load("Connection is redirected to: " + newUrl);
+                // open the new connnection again
+                connection = new URL(newUrl).openConnection();
+            } else {
+                XRLog.load("Redirect is required but not allowed to: " + newUrl);
+            }
+        }
+        return connection;
+    }
 
-	/**
-	 * Verify that return code of connection represents a redirection.
-	 * 
-	 * But it is final because redirection processing is determined.
-	 * 
-	 * @param status return code of connection
-	 * @return boolean true if return code is a 3xx
-	 */
-	protected final boolean needsRedirect(int status) {
-		return 
-				status != HttpURLConnection.HTTP_OK
-				&& (
-					status == HttpURLConnection.HTTP_MOVED_TEMP
-					|| status == HttpURLConnection.HTTP_MOVED_PERM
-					|| status == HttpURLConnection.HTTP_SEE_OTHER
-				);
-	}
-	
+    /**
+     * Verify that return code of connection represents a redirection.
+     * 
+     * But it is final because redirection processing is determined.
+     * 
+     * @param status return code of connection
+     * @return boolean true if return code is a 3xx
+     */
+    protected final boolean needsRedirect(int status) {
+        return 
+                status != HttpURLConnection.HTTP_OK
+                && (
+                    status == HttpURLConnection.HTTP_MOVED_TEMP
+                    || status == HttpURLConnection.HTTP_MOVED_PERM
+                    || status == HttpURLConnection.HTTP_SEE_OTHER
+                );
+    }
+    
     /**
      * Retrieves the CSS located at the given URI.  It's assumed the URI does point to a CSS file--the URI will
      * be accessed (using java.io or java.net), opened, read and then passed into the CSS parser.
@@ -372,29 +372,29 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
 
         // _baseURL is guaranteed to be non-null at this point.
         // test if the URI is valid; if not, try to assign the base url as its parent
-	    Throwable t;
+        Throwable t;
         try {
             URI result = new URI(uri);
-	        if (result.isAbsolute()) {
-	        	return result.toString();
-	        }
+            if (result.isAbsolute()) {
+                return result.toString();
+            }
             XRLog.load(uri + " is not a URL; may be relative. Testing using parent URL " + _baseURL);
             URI baseURI = new URI(_baseURL);
             if(!baseURI.isOpaque()) {
-            	// uri.resolve(child) only works for opaque URIs.
-	            // Otherwise it would simply return child.
-	            return baseURI.resolve(result).toString();
+                // uri.resolve(child) only works for opaque URIs.
+                // Otherwise it would simply return child.
+                return baseURI.resolve(result).toString();
             }
-	        // Fall back to previous resolution using URL
-	        try {
-		        return new URL(new URL(_baseURL), uri).toExternalForm();
-	        } catch (MalformedURLException ex) {
-            	t = ex;
-	        }
+            // Fall back to previous resolution using URL
+            try {
+                return new URL(new URL(_baseURL), uri).toExternalForm();
+            } catch (MalformedURLException ex) {
+                t = ex;
+            }
         } catch (URISyntaxException e) {
-        	t = e;
+            t = e;
         }
-	    XRLog.exception("The default NaiveUserAgent cannot resolve the URL " + uri + " with base URL " + _baseURL, t);
+        XRLog.exception("The default NaiveUserAgent cannot resolve the URL " + uri + " with base URL " + _baseURL, t);
         return null;
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -34,10 +34,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-
 import javax.imageio.ImageIO;
-import javax.net.ssl.HttpsURLConnection;
-
 import org.xhtmlrenderer.event.DocumentListener;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.resource.CSSResource;

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
@@ -1,10 +1,9 @@
-package eeze;
+package org.xhtmlrenderer.swing;
 
 import junit.framework.TestCase;
 
-import org.xhtmlrenderer.swing.NaiveUserAgent;
-
-public class TestNaiveUserAgentUrlResolver extends TestCase
+public class NaiveUserAgentTest
+        extends TestCase
 {
     protected String resolve(String uri)
     {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
@@ -5,48 +5,44 @@ import junit.framework.TestCase;
 public class NaiveUserAgentTest
         extends TestCase
 {
-    protected String resolve(String uri)
-    {
-        return resolve(null,uri);
-    }
-    protected String resolve(String baseUri, String uri)
+    private static String resolve(String baseUri, String uri)
     {
         NaiveUserAgent userAgent=new NaiveUserAgent();
         userAgent.setBaseURL(baseUri);
         return userAgent.resolveURI(uri);
     }
-    
+
     public void testBasicResolve()
     {
-        // absolut uris shold be unchanged
-        assertEquals("http://www.example.com", resolve("http://www.example.com"));
+        // absolute uris should be unchanged
+        assertEquals("http://www.example.com", resolve(null, "http://www.example.com"));
         assertEquals("http://www.example.com", resolve("ftp://www.example.com/other","http://www.example.com"));
-        
-        // by default relative uris resolves as file 
-        assertNotNull(resolve("www.example.com"));
-        assertTrue(resolve("www.example.com").startsWith("file:"));
-        
+
+        // by default relative uris resolves as file
+        assertNotNull(resolve(null, "www.example.com"));
+        assertTrue(resolve(null, "www.example.com").startsWith("file:"));
+
         // relative uris without slash
         assertEquals("ftp://www.example.com/test", resolve("ftp://www.example.com/other","test"));
-        
+
         // relative uris with slash
         assertEquals("ftp://www.example.com/other/test", resolve("ftp://www.example.com/other/","test"));
         assertEquals("ftp://www.example.com/test", resolve("ftp://www.example.com/other/","/test"));
     }
-    
+
     public void testCustomProtocolResolve()
     {
-        // absolut uris shold be unchanged
-        assertEquals("custom://www.example.com", resolve("custom://www.example.com"));
+        // absolute uris should be unchanged
+        assertEquals("custom://www.example.com", resolve(null, "custom://www.example.com"));
         assertEquals("custom://www.example.com", resolve("ftp://www.example.com/other","custom://www.example.com"));
-        
+
         // relative uris without slash
         assertEquals("custom://www.example.com/test", resolve("custom://www.example.com/other","test"));
-        
+
         // relative uris with slash
         assertEquals("custom://www.example.com/other/test", resolve("custom://www.example.com/other/","test"));
         assertEquals("custom://www.example.com/test", resolve("custom://www.example.com/other/","/test"));
     }
-    
+
 
 }

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/swing/NaiveUserAgentTest.java
@@ -44,5 +44,23 @@ public class NaiveUserAgentTest
         assertEquals("custom://www.example.com/test", resolve("custom://www.example.com/other/","/test"));
     }
 
+    /**
+     * This reproduces https://code.google.com/archive/p/flying-saucer/issues/262
+     * 
+     * Below test was green with 9.0.6 and turned red in 9.0.7
+     */
+    public void testJarFileUriResolve()
+    {
+        // absolute uris should be unchanged
+        assertEquals("jar:file:/path/jarfile.jar!/foo/index.xhtml", resolve(null, "jar:file:/path/jarfile.jar!/foo/index.xhtml"));
+        assertEquals("jar:file:/path/jarfile.jar!/foo/index.xhtml", resolve("ftp://www.example.com/other","jar:file:/path/jarfile.jar!/foo/index.xhtml"));
+
+        // relative uris without slash
+        assertEquals("jar:file:/path/jarfile.jar!/foo/other.xhtml", resolve("jar:file:/path/jarfile.jar!/foo/index.xhtml","other.xhtml"));
+
+        // relative uris with slash
+        assertEquals("jar:file:/path/jarfile.jar!/foo/other.xhtml", resolve("jar:file:/path/jarfile.jar!/foo/","other.xhtml"));
+        assertEquals("jar:file:/path/jarfile.jar!/other.xhtml", resolve("jar:file:/path/jarfile.jar!/foo/","/other.xhtml"));
+    }
 
 }

--- a/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/BrowserUserAgent.java
+++ b/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/BrowserUserAgent.java
@@ -28,22 +28,19 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.logging.Level;
-
 import javax.xml.transform.sax.SAXSource;
-
 import org.eclipse.swt.graphics.Device;
+import org.xhtmlrenderer.demo.browser.DemoMarker;
 import org.xhtmlrenderer.demo.browser.DirectoryLister;
 import org.xhtmlrenderer.demo.browser.PlainTextXMLReader;
-import org.xhtmlrenderer.demo.browser.DemoMarker;
 import org.xhtmlrenderer.demo.browser.swt.DemosNavigation.Demo;
 import org.xhtmlrenderer.resource.CSSResource;
 import org.xhtmlrenderer.resource.ImageResource;
 import org.xhtmlrenderer.resource.XMLResource;
 import org.xhtmlrenderer.swt.NaiveUserAgent;
 import org.xhtmlrenderer.util.GeneralUtil;
-import org.xhtmlrenderer.util.XRLog;
 import org.xhtmlrenderer.util.Uu;
+import org.xhtmlrenderer.util.XRLog;
 import org.xml.sax.InputSource;
 
 public class BrowserUserAgent extends NaiveUserAgent {
@@ -57,41 +54,6 @@ public class BrowserUserAgent extends NaiveUserAgent {
         _history = new History();
     }
 
-    public String resolveURIX(String uri) {
-        final String burl = getBaseURL();
-
-        if (uri == null) {
-            return null;
-        }
-        try {
-            URI base;
-            if (burl == null || burl.length() == 0) {
-                base = new File(".").toURI();
-            } else {
-                base = new URI(burl);
-            }
-            uri = base.resolve(new URI(uri)).toString();
-        } catch (URISyntaxException e) {
-            XRLog.general(Level.WARNING, "URI is malformed: " + burl + " or "
-                    + uri);
-            return null;
-        }
-
-        if (uri.startsWith("demoNav:")) {
-            String action = uri.substring(8);
-            Demo demo = null;
-            if (action.equalsIgnoreCase("back")) {
-                demo = _demos.previous();
-            } else if (action.equalsIgnoreCase("forward")) {
-                demo = _demos.next();
-            }
-            if (demo != null) {
-                uri = demo.getUrl();
-            }
-        }
-
-        return uri;
-    }
     public String resolveURI(String uri) {
         final String burl = getBaseURL();
 


### PR DESCRIPTION
This PR fixes the regression described in https://code.google.com/archive/p/flying-saucer/issues/262

`baseURI` handling for URIs like `jar:file:/path/jarfile.jar!/foo/index.xhtml` used to work in flyingsaucer <= 9.0.6 but stopped working with 9.0.7.

On a side note:
What is the proper way to get in touch with the people working on flyingsaucer? I can't find an active issue tracker anywhere.
- https://xhtmlrenderer.java.net/ is outdated.
  - The mailinglists at https://java.net/projects/xhtmlrenderer/lists/users/archive and https://java.net/projects/xhtmlrenderer/lists/dev/archive seem to be inactive.
- https://code.google.com/archive/p/flying-saucer/ is archived but the only link given in `README.md`.
- The issue tracker at https://code.google.com/archive/p/flying-saucer/issues is also archived.
- https://github.com/flyingsaucerproject/flyingsaucer/ does only allow pull requests but not issues.
- https://flyingsaucerproject.github.io/flyingsaucer/ says "test page".
- https://flyingsaucerproject.github.io/ is entirely empty.

I think I just found out that https://groups.google.com/forum/#!forum/flying-saucer-users would be the correct place but that info was hidden *really* good.