### PR TITLE
Element can be null in getLang calls.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/NoNamespaceHandler.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/NoNamespaceHandler.java
@@ -86,6 +86,9 @@ public class NoNamespaceHandler implements NamespaceHandler {
     }
 
     public String getLang(org.w3c.dom.Element e) {
+        if(e == null) {
+            return "";
+        }
         return e.getAttribute("lang");
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -458,8 +458,11 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
     }
 
     public String getLang(org.w3c.dom.Element e) {
+        if(e == null) {
+            return "";
+        }
         String lang = e.getAttribute("lang");
-        if(lang.equals("")) {
+        if("".equals(lang)) {
             lang = (String) this.getMetaInfo(e.getOwnerDocument()).get("Content-Language");
             if(lang == null) {
                 lang = "";


### PR DESCRIPTION
This fixes the following `NullPointerException` that was introduced after 9.1.1 release:

```
java.lang.NullPointerException
	at org.xhtmlrenderer.simple.extend.XhtmlCssOnlyNamespaceHandler.getLang(XhtmlCssOnlyNamespaceHandler.java:461)
	at org.xhtmlrenderer.layout.breaker.Breaker.getLanguage(Breaker.java:128)
	at org.xhtmlrenderer.layout.breaker.Breaker.getBreakPointsProvider(Breaker.java:120)
	at org.xhtmlrenderer.render.InlineBox.calcMinWidthFromWordLength(InlineBox.java:233)
	at org.xhtmlrenderer.render.InlineBox.calcMinMaxWidth(InlineBox.java:361)
	at org.xhtmlrenderer.render.BlockBox.calcMinMaxWidthInlineChildren(BlockBox.java:1669)
	at org.xhtmlrenderer.render.BlockBox.calcMinMaxWidth(BlockBox.java:1544)
	at org.xhtmlrenderer.render.BlockBox.calcShrinkToFitWidth(BlockBox.java:1421)
	at org.xhtmlrenderer.render.BlockBox.calcShrinkToFitWidthIfNeeded(BlockBox.java:913)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:810)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:776)
	at org.xhtmlrenderer.layout.LayoutUtil.layoutFloated(LayoutUtil.java:83)
	at org.xhtmlrenderer.layout.InlineBoxing.processOutOfFlowContent(InlineBoxing.java:868)
	at org.xhtmlrenderer.layout.InlineBoxing.layoutContent(InlineBoxing.java:306)
	at org.xhtmlrenderer.render.BlockBox.layoutInlineChildren(BlockBox.java:983)
	at org.xhtmlrenderer.render.BlockBox.layoutChildren(BlockBox.java:964)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:847)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:776)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutBlockChild0(BlockBoxing.java:321)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutBlockChild(BlockBoxing.java:299)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutContent(BlockBoxing.java:90)
	at org.xhtmlrenderer.render.BlockBox.layoutChildren(BlockBox.java:967)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:847)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:776)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutBlockChild0(BlockBoxing.java:321)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutBlockChild(BlockBoxing.java:299)
	at org.xhtmlrenderer.layout.BlockBoxing.layoutContent(BlockBoxing.java:90)
	at org.xhtmlrenderer.render.BlockBox.layoutChildren(BlockBox.java:967)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:847)
	at org.xhtmlrenderer.render.BlockBox.layout(BlockBox.java:776)
	at org.xhtmlrenderer.swing.RootPanel.doDocumentLayout(RootPanel.java:319)
	at org.xhtmlrenderer.swing.BasicPanel.paintComponent(BasicPanel.java:138)
```