### PR TITLE
Fixes some Maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+      </plugin>
     </plugins>
 
     <pluginManagement>


### PR DESCRIPTION
This fixes Maven warnings about missing versions for `maven-jar-plugin version` and `maven-deploy-plugin`.

The following warnings are still printed:
```
Some problems were encountered while building the effective model for org.xhtmlrenderer:flying-saucer-swt:jar:9.1.3-SNAPSHOT
'profiles.profile[windows].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/lib/swt/swt-3.6-win32.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt/pom.xml, line 58, column 23
'profiles.profile[mac].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/lib/swt/swt-3.6-osx.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt/pom.xml, line 78, column 23
'profiles.profile[linux].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/lib/swt/swt-3.6-linux.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt/pom.xml, line 97, column 23

Some problems were encountered while building the effective model for org.xhtmlrenderer:flying-saucer-swt-examples:jar:9.1.3-SNAPSHOT
'profiles.profile[windows].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/../flying-saucer-swt/lib/swt/swt-3.6-win32.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt-examples:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt-examples/pom.xml, line 60, column 23
'profiles.profile[mac].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/../flying-saucer-swt/lib/swt/swt-3.6-osx.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt-examples:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt-examples/pom.xml, line 80, column 23
'profiles.profile[linux].dependencies.dependency.systemPath' for org.eclipse:swt:jar should not point at files within the project directory, ${basedir}/../flying-saucer-swt/lib/swt/swt-3.6-linux.jar will be unresolvable by dependent projects @ org.xhtmlrenderer:flying-saucer-swt-examples:[unknown-version], /Users/huxi/Documents/Projects/misc/flyingsaucer/flying-saucer-swt-examples/pom.xml, line 99, column 25

It is highly recommended to fix these problems because they threaten the stability of your build.

For this reason, future Maven versions might no longer support building such malformed projects.
```

Unfortunately, I have no idea about how to get rid of them. Some SWT artifacts seem to be available at the `org.eclipse.swt` `groupId` but that would be a major version update and I have no idea if those are official at all. Just not enough SWT know-how on my part.