### PR TITLE
Yet another RootPanel NPE fix. And general bonus-cleanup.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -9,7 +9,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
@@ -40,6 +40,7 @@ import java.util.logging.Level;
 
 import javax.swing.JOptionPane;
 
+import javax.swing.JScrollBar;
 import org.w3c.dom.Document;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.derived.RectPropertySet;
@@ -554,10 +555,10 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
     public Rectangle getFixedRectangle() {
         if (enclosingScrollPane != null) {
             return enclosingScrollPane.getViewportBorderBounds();
-        } else {
-            Dimension dim = getSize();
-            return new Rectangle(0, 0, dim.width, dim.height);
         }
+
+        Dimension dim = getSize();
+        return new Rectangle(0, 0, dim.width, dim.height);
     }
 
     private boolean isAnchorInCurrentDocument(String str) {
@@ -573,8 +574,11 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
      * this will scroll the screen down to the y component of the point.
      */
     public void scrollTo(Point pt) {
-        if (this.enclosingScrollPane != null) {
-            this.enclosingScrollPane.getVerticalScrollBar().setValue(pt.y);
+        if (enclosingScrollPane != null) {
+            JScrollBar scrollBar = enclosingScrollPane.getVerticalScrollBar();
+            if(scrollBar != null) {
+                scrollBar.setValue(pt.y);
+            }
         }
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -477,32 +477,7 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
         XMLResource xmlResource = sharedContext.getUac().getXMLResource(uri);
         return xmlResource.getDocument();
     }
-
-    /* ====== hover and active utility methods
-========= */
-
-    public boolean isHover(org.w3c.dom.Element e) {
-        if (e == hovered_element) {
-            return true;
-        }
-        return false;
-    }
-
-    public boolean isActive(org.w3c.dom.Element e) {
-        if (e == active_element) {
-            return true;
-        }
-        return false;
-    }
-
-    public boolean isFocus(org.w3c.dom.Element e) {
-        if (e == focus_element) {
-            return true;
-        }
-        return false;
-    }
-
-
+    
     /**
      * Returns whether the background of this <code>BasicPanel</code> will
      * be painted when it is rendered.

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -37,14 +37,11 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
-
 import javax.swing.JOptionPane;
-
 import javax.swing.JScrollBar;
 import org.w3c.dom.Document;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.derived.RectPropertySet;
-import org.xhtmlrenderer.event.DocumentListener;
 import org.xhtmlrenderer.extend.NamespaceHandler;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.layout.Layer;
@@ -105,28 +102,6 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
         init();
     }
 
-    /**
-     * Adds the specified Document listener to receive Document events from this
-     * component. If listener l is null, no exception is thrown and no action is
-     * performed.
-     *
-     * @param listener Contains the DocumentListener for DocumentEvent data.
-     */
-    public void addDocumentListener(DocumentListener listener) {
-        this.documentListeners.put(listener, listener);
-    }
-
-    /**
-     * Removes the specified Document listener from receive Document events from this
-     * component. If listener l is null, no exception is thrown and no action is
-     * performed.
-     *
-     * @param listener Contains the DocumentListener to remove.
-     */
-    public void removeDocumentListener(DocumentListener listener) {
-        this.documentListeners.remove(listener);
-    }
-
     public void paintComponent(Graphics g) {
         if (doc == null) {
             paintDefaultBackground(g);
@@ -179,7 +154,7 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
         } catch (ThreadDeath t) {
             throw t;
         } catch (Throwable t) {
-            if (documentListeners.size() > 0) {
+            if (hasDocumentListeners()) {
                 fireOnRenderException(t);
             } else {
                 if (t instanceof Error) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
 import org.w3c.dom.Document;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.derived.RectPropertySet;
@@ -136,7 +137,8 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
 
             paintDefaultBackground(g);
 
-            if (enclosingScrollPane == null) {
+            JScrollPane scrollPane = getEnclosingScrollPane();
+            if (scrollPane == null) {
                 Insets insets = getInsets();
                 g.translate(insets.left, insets.top);
             }
@@ -502,15 +504,6 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
         return sharedContext;
     }
 
-    public Rectangle getFixedRectangle() {
-        if (enclosingScrollPane != null) {
-            return enclosingScrollPane.getViewportBorderBounds();
-        }
-
-        Dimension dim = getSize();
-        return new Rectangle(0, 0, dim.width, dim.height);
-    }
-
     private boolean isAnchorInCurrentDocument(String str) {
         return str.charAt(0) == '#';
     }
@@ -524,8 +517,9 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
      * this will scroll the screen down to the y component of the point.
      */
     public void scrollTo(Point pt) {
-        if (enclosingScrollPane != null) {
-            JScrollBar scrollBar = enclosingScrollPane.getVerticalScrollBar();
+        JScrollPane scrollPane = getEnclosingScrollPane();
+        if (scrollPane != null) {
+            JScrollBar scrollBar = scrollPane.getVerticalScrollBar();
             if(scrollBar != null) {
                 scrollBar.setValue(pt.y);
             }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
@@ -77,7 +77,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     private boolean defaultFontFromComponent;
     protected SharedContext sharedContext;
     private volatile LayoutContext layoutContext;
-    protected JScrollPane enclosingScrollPane;
+    private JScrollPane enclosingScrollPane;
     private boolean viewportMatchWidth = true;
 
     // initialize to JViewport default mode
@@ -182,6 +182,10 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
         }
     }
 
+    protected JScrollPane getEnclosingScrollPane() {
+        return enclosingScrollPane;
+    }
+
     /**
      * Gets the fixedRectangle attribute of the BasicPanel object
      *
@@ -190,10 +194,9 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     public Rectangle getFixedRectangle() {
         if (enclosingScrollPane != null) {
             return enclosingScrollPane.getViewportBorderBounds();
-        } else {
-            Dimension dim = getSize();
-            return new Rectangle(0, 0, dim.width, dim.height);
         }
+        Dimension dim = getSize();
+        return new Rectangle(0, 0, dim.width, dim.height);
     }
 
     /**

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
@@ -502,24 +502,15 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     public Element focus_element = null;
 
     public boolean isHover(org.w3c.dom.Element e) {
-        if (e == hovered_element) {
-            return true;
-        }
-        return false;
+        return e == hovered_element;
     }
 
     public boolean isActive(org.w3c.dom.Element e) {
-        if (e == active_element) {
-            return true;
-        }
-        return false;
+        return e == active_element;
     }
 
     public boolean isFocus(org.w3c.dom.Element e) {
-        if (e == focus_element) {
-            return true;
-        }
-        return false;
+        return e == focus_element;
     }
 
     protected void relayout() {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
@@ -28,11 +28,10 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
-
 import javax.swing.CellRendererPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
@@ -40,7 +39,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JViewport;
 import javax.swing.Scrollable;
 import javax.swing.SwingConstants;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSPrimitiveValue;
@@ -75,7 +73,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     private Box rootBox = null;
     private boolean needRelayout = false;
     private CellRendererPane cellRendererPane;
-    protected Map documentListeners;
+    private final Set<DocumentListener> documentListeners = new HashSet<DocumentListener>();
     private boolean defaultFontFromComponent;
     protected SharedContext sharedContext;
     private volatile LayoutContext layoutContext;
@@ -224,7 +222,6 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     }
 
     protected void init() {
-        documentListeners = new HashMap();
         setBackground(Color.white);
         super.setLayout(null);
     }
@@ -397,7 +394,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
         } catch (ThreadDeath t) {
             throw t;
         } catch (Throwable t) {
-            if (documentListeners.size() > 0) {
+            if (hasDocumentListeners()) {
                 fireOnLayoutException(t);
             } else {
                 if (t instanceof Error) {
@@ -437,10 +434,40 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
         }
     }
 
+    /**
+     * Adds the specified Document listener to receive Document events from this
+     * component. If listener l is null, no exception is thrown and no action is
+     * performed.
+     *
+     * @param listener Contains the DocumentListener for DocumentEvent data.
+     */
+    public void addDocumentListener(DocumentListener listener) {
+        if(listener == null) {
+            return;
+        }
+        documentListeners.add(listener);
+    }
+
+    /**
+     * Removes the specified Document listener from receive Document events from this
+     * component. If listener l is null, no exception is thrown and no action is
+     * performed.
+     *
+     * @param listener Contains the DocumentListener to remove.
+     */
+    public void removeDocumentListener(DocumentListener listener) {
+        if(listener == null) {
+            return;
+        }
+        documentListeners.remove(listener);
+    }
+
+    protected boolean hasDocumentListeners() {
+        return !documentListeners.isEmpty();
+    }
+
     protected void fireDocumentStarted() {
-        Iterator it = this.documentListeners.keySet().iterator();
-        while (it.hasNext()) {
-            DocumentListener list = (DocumentListener) it.next();
+        for (DocumentListener list : documentListeners) {
             try {
                 list.documentStarted();
             } catch (Exception e) {
@@ -450,9 +477,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     }
 
     protected void fireDocumentLoaded() {
-        Iterator it = this.documentListeners.keySet().iterator();
-        while (it.hasNext()) {
-            DocumentListener list = (DocumentListener) it.next();
+        for (DocumentListener list : documentListeners) {
             try {
                 list.documentLoaded();
             } catch (Exception e) {
@@ -462,9 +487,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     }
 
     protected void fireOnLayoutException(Throwable t) {
-        Iterator it = this.documentListeners.keySet().iterator();
-        while (it.hasNext()) {
-            DocumentListener list = (DocumentListener) it.next();
+        for (DocumentListener list : documentListeners) {
             try {
                 list.onLayoutException(t);
             } catch (Exception e) {
@@ -474,9 +497,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
     }
 
     protected void fireOnRenderException(Throwable t) {
-        Iterator it = this.documentListeners.keySet().iterator();
-        while (it.hasNext()) {
-            DocumentListener list = (DocumentListener) it.next();
+        for (DocumentListener list : documentListeners) {
             try {
                 list.onRenderException(t);
             } catch (Exception e) {


### PR DESCRIPTION
Unfortunately, another NPE lurked in `getScrollableTracksViewportHeight()`.

I didn't immediately spot it because those happen in `addNotify`/`removeNotify` context and are thus easy to miss.

I have taken the opportunity to sanity-check every single usage of `enclosingScrollPane` and identified some more places that didn't perform necessary null checks. Fixed them.

Since FS requires Java 6 anyway, I also streamlined handling of `documentListeners` in 9078cf8d5567fd516ab5d1163de14005ee1aed72, preventing more potential NPEs (according to documentation) and cleaning up the code in the process.

Access to `documentListeners` and `enclosingScrollPane` has been locked down. This introduces potential compile-time compatibility issues for people extending `RootPanel`/`BasicPanel` but changes necessary to fix them are very straightforward.

@pbrant My previous PR aimed to be minimal. This one aims to be thorough. Sorry for the hassle.