### PR TITLE
Set OpenPDF profile active by default in flying-saucer-pdf. 

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -41,9 +41,6 @@
   <profiles>
     <profile>
       <id>itext</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <dependencies>
       	<!-- 
       		Note: The iText Bouncy Castle dependencies have been moved to a new group and version on maven central.
@@ -99,6 +96,9 @@
     </profile>
     <profile>
       <id>openpdf</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>com.github.librepdf</groupId>


### PR DESCRIPTION
Set OpenPDF profile active by default in flying-saucer-pdf. 

The iText profile specifies iText version 2.1.7, which is no longer maintained.