### PR TITLE
Create links also for URLs starting with 'mailto:'

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -288,7 +288,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                             _writer.addAnnotation(annot);
                         }
                     }
-                } else if (uri.indexOf("://") != -1) {
+                } else if (uri.indexOf("://") != -1 || uri.startsWith("mailto:")) {
                     PdfAction action = new PdfAction(uri);
 
                     com.lowagie.text.Rectangle targetArea = checkLinkArea(c, box);


### PR DESCRIPTION
When creating a pdf `<a href="https://example.com">click me</a>` gets rendered as a link.
Unfortunately this doesn't work for `<a href="mailto:contact@example.com">contact me</a>`.

This pull request changes this behaviour to allow rendering of links with URLs starting with `mailto:`.