### PR TITLE
Fix infinite loop when using float and word-wrap:word

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/InlineBoxing.java
@@ -45,6 +45,7 @@ import org.xhtmlrenderer.render.LineBox;
 import org.xhtmlrenderer.render.MarkerData;
 import org.xhtmlrenderer.render.StrutMetrics;
 import org.xhtmlrenderer.render.TextDecoration;
+import org.xhtmlrenderer.util.XRRuntimeException;
 
 /**
  * This class is responsible for flowing inline content into lines.  Block
@@ -52,6 +53,9 @@ import org.xhtmlrenderer.render.TextDecoration;
  * here as well as floating and absolutely positioned content.
  */
 public class InlineBoxing {
+
+    private static final int MAX_ITERATION_COUNT = 100000;
+
     private InlineBoxing() {
     }
 
@@ -161,7 +165,12 @@ public class InlineBoxing {
                     lbContext.setMaster(iB.getContentFunction().getLayoutReplacementText());
                 }
 
+                int q = 0;
                 do {
+                    if (q++ > MAX_ITERATION_COUNT) {
+                        throw new XRRuntimeException("Too many iterations (" + q + ") in InlineBoxing, giving up.");
+                    }
+
                     lbContext.reset();
 
                     int fit = 0;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
@@ -179,14 +179,14 @@ public class Breaker {
         }
 
         context.setNeedsNewLine(true);
-        if (right < 0 && style.getWordWrap() == IdentValue.BREAK_WORD) {
+        if (right <= 0 && style.getWordWrap() == IdentValue.BREAK_WORD) {
             if (!tryToBreakAnywhere) {
                 doBreakText(c, context, avail, style, true);
                 return;
             }
         }
 
-        if (right >= 0) { // found a place to wrap
+        if (right > 0) { // found a place to wrap
             context.setEnd(context.getStart() + right);
             context.setWidth(getWidth(c, f, context.getMaster().substring(context.getStart(), context.getStart() + right)));
             return;

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/EndlessLoopTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/EndlessLoopTest.java
@@ -1,0 +1,19 @@
+package org.xhtmlrenderer.pdf.bug;
+
+import org.junit.Test;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import java.io.File;
+import java.net.URL;
+
+public class EndlessLoopTest {
+
+  @Test(timeout = 3000L)
+  public void testWordwrap() throws Exception {
+    URL htmlUrl = getClass().getResource("EndlessLoopTest_wordwrap.html");
+    File htmlFile = new File(htmlUrl.toURI());
+    ITextRenderer renderer = new ITextRenderer();
+    renderer.setDocument(htmlFile);
+    renderer.layout();
+  }
+}

--- a/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/bug/EndlessLoopTest_wordwrap.html
+++ b/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/bug/EndlessLoopTest_wordwrap.html
@@ -1,6 +1,4 @@
 <body>
-<div style="width: 100px; word-wrap: break-word">
-  <div style="width: 100px; float: left;">div with similar width than container and is floated</div>
-  b
-</div>
+  <div style="width: 100px; float: left; background-color: darkorange">floated</div>
+  <div style="width: 101px; word-wrap: break-word; background-color: lavender">word wrapped</div>
 </body>

--- a/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/bug/EndlessLoopTest_wordwrap.html
+++ b/flying-saucer-pdf/src/test/resources/org/xhtmlrenderer/pdf/bug/EndlessLoopTest_wordwrap.html
@@ -1,0 +1,6 @@
+<body>
+<div style="width: 100px; word-wrap: break-word">
+  <div style="width: 100px; float: left;">div with similar width than container and is floated</div>
+  b
+</div>
+</body>


### PR DESCRIPTION
This fixes two issues:
1) Calculating where word-wrapped content should go.
2) Relying on do-while loop having successful end condition - now limiting iterations to 100 000 for inline element parsing.

Discussion here: https://groups.google.com/forum/#!topic/flying-saucer-users/0b98p88ZxQc

I made an educated guess with the fix, not really sure how the existing codebase should work, so please review the change.