### PR TITLE
Extract page number from image src URIs

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -850,14 +850,16 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
     private void drawPDFAsImage(PDFAsImage image, int x, int y) {
         URI uri = image.getURI();
         PdfReader reader = null;
+        int pageNumber = 1;
 
         try {
             reader = getReader(uri);
+            pageNumber = PDFAsImage.pageNumberFromURI(uri);
         } catch (IOException e) {
             throw new XRRuntimeException("Could not load " + uri + ": " + e.getMessage(), e);
         }
 
-        PdfImportedPage page = getWriter().getImportedPage(reader, 1);
+        PdfImportedPage page = getWriter().getImportedPage(reader, pageNumber);
 
         AffineTransform at = AffineTransform.getTranslateInstance(x, y);
         at.translate(0, image.getHeightAsFloat());
@@ -880,10 +882,10 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
     }
 
     public PdfReader getReader(URI uri) throws IOException {
-        PdfReader result = (PdfReader) _readerCache.get(uri);
+        PdfReader result = (PdfReader) _readerCache.get(uri.getPath());
         if (result == null) {
             result = new PdfReader(getSharedContext().getUserAgentCallback().getBinaryResource(uri.toString()));
-            _readerCache.put(uri, result);
+            _readerCache.put(uri.getPath(), result);
         }
         return result;
     }

--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -83,7 +83,7 @@ public class ITextUserAgent extends NaiveUserAgent {
                             URI uri = new URI(uriStr);
                             PdfReader reader = _outputDevice.getReader(uri);
                             PDFAsImage image = new PDFAsImage(uri);
-                            Rectangle rect = reader.getPageSizeWithRotation(1);
+                            Rectangle rect = reader.getPageSizeWithRotation(PDFAsImage.pageNumberFromURI(uri));
                             image.setInitialWidth(rect.getWidth() * _outputDevice.getDotsPerPoint());
                             image.setInitialHeight(rect.getHeight() * _outputDevice.getDotsPerPoint());
                             resource = new ImageResource(uriStr, image);

--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/PDFAsImage.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/PDFAsImage.java
@@ -21,6 +21,8 @@ package org.xhtmlrenderer.pdf;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.xhtmlrenderer.extend.FSImage;
 
@@ -109,6 +111,18 @@ public class PDFAsImage implements FSImage {
     
     public float scaleWidth() {
         return _width / _unscaledWidth;
+    }
+
+    private static Pattern pageUriPattern = Pattern.compile("page=(\\d+)");
+
+    public static int pageNumberFromURI(URI uri) {
+        String fragment = uri.getFragment();
+        int pageNumber = 1;
+        Matcher pageMatcher = pageUriPattern.matcher(fragment);
+        if(!fragment.isEmpty() && pageMatcher.find()) {
+            pageNumber = Integer.parseInt(pageMatcher.group(1));
+        }
+        return pageNumber;
     }
 
 }


### PR DESCRIPTION
When PDFs are included as images, optionally specify the page number
as a URI fragment in the form "page=<number>".
This follows the convention specified in RFC 3778 [1].

[1] https://tools.ietf.org/html/rfc3778