### PR TITLE
Removed print stack trace

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
@@ -176,7 +176,6 @@ public abstract class AbstractOutputDevice implements OutputDevice {
             try {
                 return c.getUac().getImageResource(uri).getImage();
             } catch (Exception ex) {
-                ex.printStackTrace();
                 Uu.p(ex);
             }
         }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -67,8 +67,8 @@ import com.lowagie.text.pdf.PdfWriter;
 public class ITextRenderer {
     // These two defaults combine to produce an effective resolution of 96 px to
     // the inch
-    private static final float DEFAULT_DOTS_PER_POINT = 20f * 4f / 3f;
-    private static final int DEFAULT_DOTS_PER_PIXEL = 20;
+    public static final float DEFAULT_DOTS_PER_POINT = 20f * 4f / 3f;
+    public static final int DEFAULT_DOTS_PER_PIXEL = 20;
 
     private final SharedContext _sharedContext;
     private final ITextOutputDevice _outputDevice;


### PR DESCRIPTION
Hi,

We use this project in our production environment to allow users to define PDF templates, render them and send to their customers. 

Since users can define PDF templates, our log and inbox gets spammed with messages which are caused by printStackTrace call.

I see you have already made a release yesterday, but is there any chance this request gets merged and released soon? I would really appreciate it.

