### PR TITLE
added detection for server relative URLs

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -1951,6 +1951,12 @@ public class CSSParser {
                     if (lastSlash != -1) {
                         uriResult = _URI.substring(0, lastSlash+1) + uriResult;
                     }
+                } else if (isServerRelativeURI(uriResult)) {
+                    int uriOffset = _URI.indexOf("://") + 3;
+                    int firstSlashAfterProtocol = _URI.substring(uriOffset).indexOf('/');
+                    if (firstSlashAfterProtocol != -1) {
+                        uriResult = _URI.substring(0, uriOffset + firstSlashAfterProtocol) + uriResult;
+                    }
                 }
 
                 return uriResult;
@@ -1975,6 +1981,14 @@ public class CSSParser {
     private boolean isRelativeURI(String uri) {
         try {
             return uri.length() > 0 && (uri.charAt(0) != '/' && ! new URI(uri).isAbsolute());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    private boolean isServerRelativeURI(String uri) {
+        try {
+            return uri.length() > 0 && uri.charAt(0) == '/' && !new URI(uri).isAbsolute();
         } catch (URISyntaxException e) {
             return false;
         }


### PR DESCRIPTION
I had a problem with css background properties with relative URIs (i.e. `background: url('/image/background.jpg');`).

Flying saucer was trying to load `/image/background.jpg` instead of `http://myserver.com/image/background.jpg` when loading the CSS containing the property from `http://myserver.com/style/print.css`.

I added a method to detect these "server" relative URIs and prefixed the URIs with the host part of the CSS-File URI.
