### PR TITLE
Avoid artifacts due to missing antialiasing

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
@@ -228,14 +228,14 @@ public abstract class AbstractOutputDevice implements OutputDevice {
         	borderBounds.intersect(new Area(oldclip));
         }
         
-        setClip(borderBounds);
-        
         if (backgroundColor != null && backgroundColor != FSRGBColor.TRANSPARENT) {
             setColor(backgroundColor);
             fill(borderBounds);
         }
 
         if (backgroundImage != null) {
+            setClip(borderBounds);
+
             Rectangle localBGImageContainer = bgImageContainer;
             if (style.isFixedBackground()) {
                 localBGImageContainer = c.getViewportRectangle();
@@ -297,8 +297,8 @@ public abstract class AbstractOutputDevice implements OutputDevice {
                 }
             }
 
+            setClip(oldclip);
         }
-        setClip(oldclip);
     }
 
     private int adjustTo(int target, int current, int imageDim) {


### PR DESCRIPTION
Setting the clip prior to fill() with the background color results in pixel artifacts for
elements with e.g. border-radius.
Clipping is now only applied when a background image is rendered. 
Without a background image the library will render smooth edges with the Java2DRenderer. 