### PR TITLE
Support box-sizing border-box

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -1613,6 +1613,18 @@ public final class CSSName implements Comparable {
                     new SizePropertyBuilder()
             );
 
+    /**
+     * Unique CSSName instance for CSS2 property.
+     */
+    public final static CSSName BOX_SIZING =
+            addProperty(
+                    "box-sizing",
+                    PRIMITIVE,
+                    "content-box",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.BoxSizing()
+            );
+
     public final static CSSSideProperties MARGIN_SIDE_PROPERTIES =
             new CSSSideProperties(
                     CSSName.MARGIN_TOP,

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
@@ -72,6 +72,7 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue BLOCK = addValue("block");
     public final static IdentValue BOLD = addValue("bold");
     public final static IdentValue BOLDER = addValue("bolder");
+    public static final IdentValue BORDER_BOX = addValue("border-box");
     public final static IdentValue BOTH = addValue("both");
     public final static IdentValue BOTTOM = addValue("bottom");
     public final static IdentValue CAPITALIZE = addValue("capitalize");
@@ -82,6 +83,7 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue COLLAPSE = addValue("collapse");
     public final static IdentValue COMPACT = addValue("compact");
     public final static IdentValue CONTAIN = addValue("contain");
+    public static final IdentValue CONTENT_BOX = addValue("content-box");
     public final static IdentValue COVER = addValue("cover");
     public final static IdentValue CREATE = addValue("create");
     public final static IdentValue DASHED = addValue("dashed");

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -1541,6 +1541,17 @@ public class PrimitivePropertyBuilders {
         }
     }
 
+    public static class BoxSizing extends SingleIdent {
+        // border-box | content-box
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.BORDER_BOX, IdentValue.CONTENT_BOX});
+
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
     public static class Widows extends PlainInteger {
         protected boolean isNegativeValuesAllowed() {
             return false;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -117,7 +117,7 @@ public class CalculatedStyle {
      * this for class instantiation externally.
      */
     protected CalculatedStyle() {
-        _derivedValuesById = new FSDerivedValue[CSSName.countCSSPrimitiveNames()];
+        _derivedValuesById = new FSDerivedValue[CSSName.countCSSNames()];
     }
 
 
@@ -1093,6 +1093,10 @@ public class CalculatedStyle {
 
     public boolean isMaxHeightNone() {
         return isIdent(CSSName.MAX_HEIGHT, IdentValue.NONE);
+    }
+
+    public boolean isBorderBox() {
+        return isIdent(CSSName.BOX_SIZING, IdentValue.BORDER_BOX);
     }
 
     public int getMinWidth(CssContext c, int cbWidth) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -669,6 +669,7 @@ public class BlockBox extends Box implements InlinePaintable {
     protected void calcDimensions(LayoutContext c, int cssWidth) {
         if (! isDimensionsCalculated()) {
             CalculatedStyle style = getStyle();
+            boolean borderBox = style.isBorderBox();
 
             RectPropertySet padding = getPadding(c);
             BorderPropertySet border = getBorder(c);
@@ -689,16 +690,20 @@ public class BlockBox extends Box implements InlinePaintable {
             if (c.isPrint() && getStyle().isDynamicAutoWidth()) {
                 setContentWidth(calcEffPageRelativeWidth(c));
             } else {
-                setContentWidth((getContainingBlockWidth() - getLeftMBP() - getRightMBP()));
+                int proporcionalContainingBlockWidth = cssWidth != -1 ? cssWidth : getContainingBlockWidth();
+
+                if (borderBox) {
+                    setContentWidth((proporcionalContainingBlockWidth - (int)border.width() - (int)padding.width()));
+                } else {
+                    setContentWidth((proporcionalContainingBlockWidth) - getLeftMBP() - getRightMBP());
+                }
             }
             setHeight(0);
 
             if (! isAnonymous() || (isFromCaptionedTable() && isFloated())) {
                 int pinnedContentWidth = -1;
 
-                if (cssWidth != -1) {
-                    setContentWidth(cssWidth);
-                } else if (getStyle().isAbsolute() || getStyle().isFixed()) {
+                if (getStyle().isAbsolute() || getStyle().isFixed()) {
                     pinnedContentWidth = calcPinnedContentWidth(c);
                     if (pinnedContentWidth != -1) {
                         setContentWidth(pinnedContentWidth);
@@ -707,7 +712,12 @@ public class BlockBox extends Box implements InlinePaintable {
 
                 int cssHeight = getCSSHeight(c);
                 if (cssHeight != -1) {
-                    setHeight(cssHeight);
+                    if (borderBox) {
+                        setHeight(cssHeight - (int)padding.height() - (int)border.height());
+                    } else {
+                        setHeight(cssHeight);
+                    }
+
                 }
 
                 //check if replaced


### PR DESCRIPTION
This is the copy of [the commit](https://github.com/danfickle/openhtmltopdf/pull/143/commits/15dfb2833fed10ba79f63219be62b4dd8ece4291) of the [openhtmltopdf ](https://github.com/danfickle/openhtmltopdf) project. 

I think supporting "box-sizing: border-box" is very important as all CSS libraries start with this setting on every HTML element. Without that, it is almost impossible to set sizes with non-px value (percentage, inch, etc.) and use border or padding anywhere. 