### PR TITLE
Fixed italic emulation applying to oblique fonts

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -507,7 +507,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                 resetMode = true;
                 ensureStrokeColor();
             }
-            if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC)) {
+            if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC) && (desc.getStyle() != IdentValue.OBLIQUE)) {
                 b = 0f;
                 c = 0.21256f;
             }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -510,7 +510,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                 resetMode = true;
                 ensureStrokeColor();
             }
-            if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC)) {
+            if ((fontSpec.fontStyle == IdentValue.ITALIC) && (desc.getStyle() != IdentValue.ITALIC) && (desc.getStyle() != IdentValue.OBLIQUE)) {
                 b = 0f;
                 c = 0.21256f;
             }


### PR DESCRIPTION
Like italic fonts, oblique fonts are already slanted, so there's no need to emulate the effect.

This will most commonly be an issue with Helvetica which is loaded internally in ITextFontResolver as the default Sans Serif font.