### PR TITLE
Update to OpenPDF 1.2.0 and Bouncy Castle 1.60.

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -17,9 +17,9 @@
   <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output.</description>
 
   <properties>
-    <bouncycastle.version>1.59</bouncycastle.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <junit.version>4.12</junit.version>
-    <openpdf.version>1.0.1</openpdf.version>
+    <openpdf.version>1.2.0</openpdf.version>
     <itext.version>2.1.7</itext.version>
   </properties>
 


### PR DESCRIPTION
Update to OpenPDF 1.2.0 and Bouncy Castle 1.60.

A new version of OpenPDF has been released: https://github.com/LibrePDF/OpenPDF