### PR TITLE
Update to OpenPDF 1.2.0 and Bouncy Castle 1.60.

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -17,7 +17,7 @@
   <description>Flying Saucer is a CSS 2.1 renderer written in Java.  This artifact supports PDF output. (OpenPDF)</description>
 
   <properties>
-    <bouncycastle.version>1.59</bouncycastle.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <junit.version>4.12</junit.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <openpdf.version>1.0.5</openpdf.version>
+    <openpdf.version>1.2.0</openpdf.version>
   </properties>
 
 </project>


### PR DESCRIPTION
Update to OpenPDF 1.2.0 and Bouncy Castle 1.60.

A new version of OpenPDF has been released: https://github.com/LibrePDF/OpenPDF