### PR TITLE
Rounded corners without borders added twice into the path because of bad starting angle.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
@@ -107,18 +107,20 @@ public class BorderPainter {
             sideWidth = bounds.width-(1+scaledOffset)*(widthScale)*(border.left()+border.right());
         }
         Path2D path = new Path2D.Float();
-        
-        float angle = 90;
+
+        float fullAngle = 90;
+        float defaultAngle = fullAngle / 2;
+        float angle = defaultAngle;
         float widthSum = props.getTop() + props.getLeft();
         if (widthSum != 0.0f) { // Avoid NaN
-        	angle = angle * props.getTop() / widthSum;
+        	angle = fullAngle * props.getTop() / widthSum;
         }
         appendPath(path, 0-props.getLeft(), 0-props.getTop(), props.getLeftCorner().left(), props.getLeftCorner().right(), 90+angle, -angle-1, props.getTop(), props.getLeft(), scaledOffset, true, widthScale);
 
-        angle = 90;
+        angle = defaultAngle;
         widthSum = props.getTop() + props.getRight();
         if (widthSum != 0.0f) { // Avoid NaN
-        	angle = angle * props.getTop() / widthSum;
+        	angle = fullAngle * props.getTop() / widthSum;
         }
         appendPath(path, sideWidth+props.getRight(), 0-props.getTop(), props.getRightCorner().right(), props.getRightCorner().left(), 90, -angle-1, props.getTop(), props.getRight(), scaledOffset, false, widthScale);
         
@@ -129,10 +131,10 @@ public class BorderPainter {
             
             appendPath(path, sideWidth, 0, props.getRightCorner().right(), props.getRightCorner().left(), 90-angle, angle+1, props.getTop(), props.getRight(), scaledOffset+1, false, widthScale);
 
-            angle = 90;
+            angle = defaultAngle;
             widthSum = props.getTop() + props.getLeft();
             if (widthSum != 0.0f) { // Avoid NaN
-            	angle = angle * props.getTop() / widthSum;
+            	angle = fullAngle * props.getTop() / widthSum;
             }
             appendPath(path, 0, 0, props.getLeftCorner().left(), props.getLeftCorner().right(), 90, angle+1, props.getTop(), props.getLeft(), scaledOffset+1, true, widthScale);
             


### PR DESCRIPTION
The Flying Saucer was generating duplicate segments for rounded corners when border width was zero. Each side of the rectangle generated full 90 degrees rounded corner for both left and right side. This has caused significant performance issues in awt Area constructor sometimes. I have a simple layout where just creating single awt.Area from a shape took over 1500 ms! With multiple rounded elements per page this causes delays of multiple seconds.

The time was spent inside of function `sun.awt.geom.AreaOp.pruneEdges`  called  from `sun.awt.geom.AreaOp.calculate`. The function is probably unable to handle the path which contains duplicate segments properly.

I have changed the code so that only 45 degrees are generated in this case. I have checked the samples to verify it did not cause any new issues in the border or area rendering.