### PR TITLE
Allow border collapse even on paginated tables.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -1116,7 +1116,7 @@ public class CalculatedStyle {
     }
 
     public boolean isCollapseBorders() {
-        return isIdent(CSSName.BORDER_COLLAPSE, IdentValue.COLLAPSE) && ! isPaginateTable();
+        return isIdent(CSSName.BORDER_COLLAPSE, IdentValue.COLLAPSE);
     }
 
     public int getBorderHSpacing(CssContext c) {


### PR DESCRIPTION
Inspired from https://github.com/danfickle/openhtmltopdf/issues/97, this simply removes an exception from the code and allows border collapse even on paginated tables.
It works and is much better looking / less of an unexpected change in output, at least to me.
(I wonder why that exception was in place in the first place, though)