### PR TITLE
Fixed unnecessary line break in tables

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -703,7 +703,9 @@ public class BlockBox extends Box implements InlinePaintable {
             if (! isAnonymous() || (isFromCaptionedTable() && isFloated())) {
                 int pinnedContentWidth = -1;
 
-                if (getStyle().isAbsolute() || getStyle().isFixed()) {
+                if (cssWidth != -1 && !borderBox) {
+                    setContentWidth(cssWidth);
+                } else if (getStyle().isAbsolute() || getStyle().isFixed()) {
                     pinnedContentWidth = calcPinnedContentWidth(c);
                     if (pinnedContentWidth != -1) {
                         setContentWidth(pinnedContentWidth);


### PR DESCRIPTION
With flyingsaucer v9.1.14 the table rendering is broken for some use-cases.
I use this project to render markdown documents within a eclipse application so this is a essential use-case.

Example html document:
[table.zip](https://github.com/flyingsaucerproject/flyingsaucer/files/2930165/table.zip)

Rendering result in v9.1.13:
![after](https://user-images.githubusercontent.com/2879650/53794545-7aa31900-3f30-11e9-8084-18ff59b2922a.png)

Rendering result in v9.1.14 (and following):
![before](https://user-images.githubusercontent.com/2879650/53794519-737c0b00-3f30-11e9-9e01-1c2d2fb5016d.png)

Rendering result in Chrome (for reference):
![chrome](https://user-images.githubusercontent.com/2879650/53794615-9c9c9b80-3f30-11e9-8040-6fba9a104ec5.png)

The issue was introduced with the following change:
https://github.com/flyingsaucerproject/flyingsaucer/commit/e8a5b35fd9b56481a68d38e101728ce1f1e30269

The idea of the patch is to restore the original behavior when not using "border box".