### PR TITLE
Fix behavior of :first pseudo selector on named pages

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
@@ -81,6 +81,8 @@ public class Layer {
     
     private Set _pageSequences;
     private List _sortedPageSequences;
+
+    private Map _pendingPagesMap = new HashMap();
     
     private Map _runningBlocks;
     
@@ -749,15 +751,34 @@ public class Layer {
     public boolean isLastPage(PageBox pageBox) {
         return _pages.get(_pages.size()-1) == pageBox;
     }
-    
+
     public void addPage(CssContext c) {
         String pseudoPage = null;
         if (_pages == null) {
             _pages = new ArrayList();
         }
         
-        List pages = getPages();
-        if (pages.size() == 0) {
+		String pendingPageName = null;
+		if (c instanceof LayoutContext) {
+			pendingPageName = ((LayoutContext) c).getPendingPageName();
+		}
+
+		if (pendingPageName != null) {
+			if (_pendingPagesMap.containsKey(pendingPageName)) {
+				Integer counter = (Integer) _pendingPagesMap.get(pendingPageName);
+				_pendingPagesMap.put(pendingPageName, counter + 1);
+			} else {
+				_pendingPagesMap.put(pendingPageName, 0);
+			}
+		}
+
+		int currentPendingPageNumber = -1;
+		if (_pendingPagesMap.containsKey(pendingPageName)) {
+			currentPendingPageNumber = (Integer) _pendingPagesMap.get(pendingPageName);
+		}
+
+		List pages = getPages();
+        if (pages.size() == 0 || currentPendingPageNumber == 1) {
             pseudoPage = "first";
         } else if (pages.size() % 2 == 0) {
             pseudoPage = "right";


### PR DESCRIPTION
Currently, `:first` pseudo selector is working ONLY on very first PDF page. But according to https://www.w3.org/TR/css-page-3/#syntax-page-selector :first pseudo selector should be applied also on first page of named pages (sections):

```
@page { ... }
@page :left { ... }
@page :right { ... }
@page LandscapeTable { ... }
@page CompanyLetterHead:first { ... } /*  identifier and pseudo page. */
```
Problem is only with `:first` selector. `:right` and `:left` are working fine.

Problem is described also here:
https://stackoverflow.com/questions/36737431/flying-saucer-pdf-using-first-with-a-named-page 

Solution is keep track of current page number of actual named page. For example, if we are on named page "section1" then start counting pages of this named pages block. If pending page number == 1 and there is rule `@page section1:first {...}`  it should apply. No matter what page number of whole PDF it is. 