### PR TITLE
Make CSSName.ALL_PROPERTIES non final and add a reload() static method to rebuild it

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -110,7 +110,7 @@ public final class CSSName implements Comparable {
     /**
      * Map of all CSS properties
      */
-    private static final CSSName[] ALL_PROPERTIES;
+    private static CSSName[] ALL_PROPERTIES;
 
     /**
      * Map of all CSS properties
@@ -1821,6 +1821,10 @@ public final class CSSName implements Comparable {
     }
 
     static {
+    	reload();
+    }
+    
+    public static void reload() {
         Iterator iter = ALL_PROPERTY_NAMES.values().iterator();
         ALL_PROPERTIES = new CSSName[ALL_PROPERTY_NAMES.size()];
         while (iter.hasNext()) {
@@ -2029,4 +2033,3 @@ public final class CSSName implements Comparable {
  *
  *
  */
-


### PR DESCRIPTION
I am the author of Icetone (https://github.com/rockfireredmoon/icetone), a UI toolkit for JMonkeyEngine (http://jmonkeyengine.org/) with its roots in a fork of a toolkit for the same engine, TonegodGUI. 

I started off by using Flying Saucer to provide an XHTML renderer for this toolkit, but soon realised that the CSS engine would make a great replacement for the limited XML based themes provided in TonegodGUI. 

This turned out REALLY well, but I do need to currently patch Flying Saucer to make CSSName.ALL_PROPERTIES non-final and provide a method to rebuild the array, as I have added quite a few of my own custom CSS tags to do things not covered by the standard ones. This PR makes that possible.

This seems to have no ill effects on Flying Saucer, but it is obviously a bit hacky. Longer term, I would love to see the CSS engine separated from the core and usable on it's own with or without the XHTML rendering core. I will see if I can get together a separate pull request for this if this sounds valuable to you.

On a side note, it would also be nice if some of the helper classes for creating CSSName objects were more visible, I have had to re-implement a lot of them when adding my CSS extensions because they are private.