### PR TITLE
Added maxlength and multiline to text form field

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TextFormField.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TextFormField.java
@@ -40,6 +40,8 @@ public class TextFormField extends AbstractFormField
 
   private int _baseline;
 
+  private boolean multiline = false;
+
   public TextFormField(LayoutContext c, BlockBox box, int cssWidth, int cssHeight)
   {
     initDimensions(c, box, cssWidth, cssHeight);
@@ -66,6 +68,7 @@ public class TextFormField extends AbstractFormField
     if (cssHeight != -1)
     {
       setHeight(cssHeight);
+      multiline = true;
     }
     else
     {
@@ -90,12 +93,16 @@ public class TextFormField extends AbstractFormField
 
     String value = getValue(elem);
     field.setText(value);
+    field.setMaxCharacterLength(getMaxLength(elem));
 
     try
     {
       PdfFormField formField = field.getTextField();
+      if( multiline) {
+        formField.setFieldFlags(PdfFormField.FF_MULTILINE);
+      }
       createAppearance(c, outputDevice, box, formField, value);
-      //TODO add max length back in
+
       if (isReadOnly(elem))
       {
         formField.setFieldFlags(PdfFormField.FF_READ_ONLY);


### PR DESCRIPTION
Following two changes are added. Both were verified and are working

At the moment maxlength property is ignored and the resulting text areas have no limit to the text input. Added max length limit to text form field. This is a todo in this file.  

If a height is defined for text input, make it a multiline input. At the moment even if a area gets painted to match the height it's always a single line input.