### PR TITLE
Add support for relative links to filesystem resources

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -281,7 +281,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                         annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
                         _writer.addAnnotation(annot);
                     }
-                } else if (uri.indexOf("://") != -1) {
+                } else {
                     int boxTop = box.getAbsY();
                     int boxBottom = boxTop + box.getHeight();
                     int pageTop = c.getPage().getTop();

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -288,7 +288,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                             _writer.addAnnotation(annot);
                         }
                     }
-                } else if (uri.indexOf("://") != -1 || uri.startsWith("mailto:")) {
+                } else {
                     PdfAction action = new PdfAction(uri);
 
                     com.lowagie.text.Rectangle targetArea = checkLinkArea(c, box);


### PR DESCRIPTION
Flying Saucer is not generating relative links in the form of:

``<a href="documents/mydoc.txt">doc</a>``

(We are generating a PDF linking to relative non-embedded assets)

I found the same issue raised here:
https://groups.google.com/forum/#!searchin/flying-saucer-users/$20links%7Csort:date/flying-saucer-users/zbGoaROnY34/bKtpNCi1K5QJ
but the suggested solution is not supported by the current implementation.

Checking the source, I saw a 
```
if (uri.length() > 1 && uri.charAt(0) == '#') {
...
} else if (uri.indexOf("://") != -1 || uri.startsWith("mailto:")) {
...
}
```

I'd like to suggest fixing the ``else if`` to just a `else` to support any uri input form including relative paths.

