### PR TITLE
Fix absolute positioning

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
@@ -681,7 +681,7 @@ public class Layer {
     }
     
     private void layoutAbsoluteChildren(LayoutContext c) {
-        List children = getChildren();
+        List children = new ArrayList(getChildren());
         if (children.size() > 0) {
             LayoutState state = c.captureLayoutState();
             for (int i = 0; i < children.size(); i++) {


### PR DESCRIPTION
This solves the problem already described in #86.

Following function positions absolute children:
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java#L683-L690
However, the list of children is modified within the loop. Referring to the example in #86, the list `children` contains `[left, right]` in iteration 0, while it contains `[right, left]` in iteration 1. Because children are accessed by index, this effectively skips the positioning of the `right` element.

The `left` element is removed from the beginning of the list here:
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java#L729

And pushed again to the end of the list here:
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java#L737
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java#L787
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java#L797
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/LayoutContext.java#L218
https://github.com/flyingsaucerproject/flyingsaucer/blob/ccfadb606b4c8baae7fa91947f42685b0ce812f9/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java#L134

This pull request just copies the `children` list, so the order is not modified within the loop. For my tests this was the simplest solution that worked without significantly changing the layout logic.