### PR TITLE
Replaced javax.xml.bind.DatatypeConverter with java.util.Base64

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/FontUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/FontUtil.java
@@ -1,8 +1,8 @@
 package org.xhtmlrenderer.util;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Base64;
 import java.util.logging.Level;
 
 public class FontUtil {
@@ -15,7 +15,7 @@ public class FontUtil {
         int b64Index = (uri!= null)? uri.indexOf("base64,") : -1;
         if (b64Index != -1) {
             String b64encoded = uri.substring(b64Index + "base64,".length());
-            return new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(b64encoded));
+            return new ByteArrayInputStream(Base64.getDecoder().decode(b64encoded));
         } else {
             XRLog.load(Level.SEVERE, "Embedded css fonts must be encoded in base 64.");
             return null;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ImageUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ImageUtil.java
@@ -24,12 +24,12 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Static utility methods for working with images. Meant to suggest "best practices" for the most straightforward
@@ -290,7 +290,7 @@ public class ImageUtil {
         int b64Index = imageDataUri.indexOf("base64,");
         if (b64Index != -1) {
             String b64encoded = imageDataUri.substring(b64Index + "base64,".length());
-            return DatatypeConverter.parseBase64Binary(b64encoded);
+            return Base64.getDecoder().decode(b64encoded);
         } else {
             XRLog.load(Level.SEVERE, "Embedded XHTML images must be encoded in base 64.");
         }


### PR DESCRIPTION
The jaxb APIs which include `javax.xml.bind.DatatypeConverter` are considered "Java EE" and are no longer contained by default in Java 9+. Since `DatatypeConverter` was only used for Base64 decoding, I've replaced it with `java.util.Base64` which should always exist.