### PR TITLE
Maven compiler plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Increase Maven Compiler Plugin version to prevent build failures on recent versions of Java and Maven.