### PR TITLE
Make VerifyGlyphExists compile using IntelliJ

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -37,6 +37,11 @@
       <version>4.10</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.w3c</groupId>
+      <artifactId>dom</artifactId>
+      <version>2.3.0-jaxb-1.0.6</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -82,6 +87,14 @@
             <Import-Package>!org.xhtmlrenderer.*</Import-Package>
             <Export-Package>org.xhtmlrenderer.*</Export-Package>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/derived/BorderPropertySet.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/derived/BorderPropertySet.java
@@ -1,18 +1,14 @@
 package org.xhtmlrenderer.css.style.derived;
 
-import java.awt.Rectangle;
-import java.util.List;
-
-import org.w3c.dom.css.CSSPrimitiveValue;
 import org.xhtmlrenderer.css.constants.CSSName;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.parser.FSColor;
-import org.xhtmlrenderer.css.style.BackgroundPosition;
 import org.xhtmlrenderer.css.style.BorderRadiusCorner;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.CssContext;
-import org.xhtmlrenderer.css.style.FSDerivedValue;
 import org.xhtmlrenderer.newtable.CollapsedBorderValue;
+
+import java.awt.*;
 
 /**
  * Created by IntelliJ IDEA.

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/FontUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/FontUtil.java
@@ -15,7 +15,7 @@ public class FontUtil {
         int b64Index = (uri!= null)? uri.indexOf("base64,") : -1;
         if (b64Index != -1) {
             String b64encoded = uri.substring(b64Index + "base64,".length());
-            return new ByteArrayInputStream(Base64.getDecoder().decode(b64encoded));
+            return new ByteArrayInputStream( Base64.getDecoder().decode( b64encoded));
         } else {
             XRLog.load(Level.SEVERE, "Embedded css fonts must be encoded in base 64.");
             return null;

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -37,7 +37,6 @@ import org.xhtmlrenderer.util.XRRuntimeException;
 
 import java.io.*;
 import java.util.*;
-import java.util.stream.Stream;
 
 public class ITextFontResolver implements FontResolver {
     private Map _fontFamilies = createInitialFontMap();

--- a/pom.xml
+++ b/pom.xml
@@ -96,10 +96,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.2</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Changes:

* Add reference to `org.w3c.dom` in pom.
* **BorderPropertySet.java** -- Organize imports (had compile issues without org.w3c.dom).
* **VerifyGlyphExists.java** -- Compare line 100 (old) and line 110 (PR); the codepoint was always 0, which looks like a bug. Other updates modernize the syntax and apply IDE-recommended changes, including try-with-resources. This closes the opened font's file stream, which is technically another bug but one that would never affect the application in practice.
* **ITextFontResolver.java** -- Organize imports.
