### PR TITLE
Replicating the commit 3e47546

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/EmptyReplacedElement.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/EmptyReplacedElement.java
@@ -43,6 +43,17 @@ public class EmptyReplacedElement extends AbstractFormField
     Element elem = box.getElement();
     String name = getFieldName(outputDevice, elem);
     String value = getValue(elem);
+    
+     /*
+     * ISO-32000-1 defines the limit for a name in a PDF file to be at maximum 127 bytes.
+     *Source(http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/PDF32000_2008.pdf) 
+     *  see Annex C § 2 Architectural limits "Table C.1" pages 649 and 650.
+     *iText stores the hidden field value as a PDFName 
+     */
+    if (value.length() > 127) {
+    	value = value.substring(0, 127);
+    }
+    
     acroForm.addHiddenField(name, value);
 
 


### PR DESCRIPTION
Replicating the commit 3e47546 from rafortis to this project. It is updated on flying-saucer-pdf but it wasn´t replicated into flying-saucer-pdf-itext5.
This change avoid an IllegalArgumentException thrown by PdfName in iTextpdf project when the element has more than 127 characters.