### PR TITLE
Fix for CVE-2017-9096

### DIFF
--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.itextpdf</groupId>
       <artifactId>itextpdf</artifactId>
-        <version>5.5.11</version>
+        <version>5.5.12</version>
     </dependency>
     <dependency>
       <groupId>org.xhtmlrenderer</groupId>


### PR DESCRIPTION
Updated itextpdf library version to 5.5.12 to address https://nvd.nist.gov/vuln/detail/CVE-2017-9096