### PR TITLE
remove absolute path prefix for licenses

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -46,7 +46,7 @@
       </resource>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>
@@ -57,7 +57,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/flying-saucer-examples/pom.xml
+++ b/flying-saucer-examples/pom.xml
@@ -65,7 +65,7 @@
       </resource>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -104,7 +104,7 @@
 		<resources>
 			<resource>
 				<directory>../</directory>
-				<targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+				<targetPath>META-INF</targetPath>
 				<includes>
 					<include>LICENSE*</include>
 				</includes>
@@ -118,7 +118,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
-						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestFile>/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>
 			</plugin>

--- a/flying-saucer-log4j/pom.xml
+++ b/flying-saucer-log4j/pom.xml
@@ -48,7 +48,7 @@
     <resources>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>
@@ -59,7 +59,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/flying-saucer-pdf-itext5/pom.xml
+++ b/flying-saucer-pdf-itext5/pom.xml
@@ -48,7 +48,7 @@
     <resources>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>
@@ -59,7 +59,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -123,7 +123,7 @@
     <resources>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>

--- a/flying-saucer-swt-examples/pom.xml
+++ b/flying-saucer-swt-examples/pom.xml
@@ -116,7 +116,7 @@
 	<resources>
 	    <resource>
 	      <directory>../</directory>
-	      <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+	      <targetPath>META-INF</targetPath>
 	      <includes>
 	        <include>LICENSE*</include>
 	      </includes>

--- a/flying-saucer-swt/pom.xml
+++ b/flying-saucer-swt/pom.xml
@@ -105,7 +105,7 @@
     <resources>
       <resource>
         <directory>../</directory>
-        <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+        <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE*</include>
         </includes>
@@ -116,7 +116,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
when copied into source jar target by maven resources plugin

