### PR TITLE
Default Accept header value is invalid according to RFC 7231

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -153,6 +153,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
      */
     protected URLConnection openConnection(String uri) throws IOException {
         URLConnection connection = new URL(uri).openConnection();
+		connection.setRequestProperty("Accept", "*/*");
         if (connection instanceof HttpURLConnection) {
             connection = onHttpConnection((HttpURLConnection) connection);
         }
@@ -181,6 +182,7 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
                 XRLog.load("Connection is redirected to: " + newUrl);
                 // open the new connnection again
                 connection = new URL(newUrl).openConnection();
+				connection.setRequestProperty("Accept", "*/*");
             } else {
                 XRLog.load("Redirect is required but not allowed to: " + newUrl);
             }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/IOUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/IOUtil.java
@@ -78,6 +78,8 @@ public class IOUtil {
             System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(10 * 1000));
             System.setProperty("sun.net.client.defaultReadTimeout", String.valueOf(30 * 1000));
 
+			uc.setRequestProperty("Accept", "*/*");
+
             uc.connect();
 
             is = uc.getInputStream();

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/StreamResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/StreamResource.java
@@ -41,6 +41,8 @@ public class StreamResource {
             System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(10 * 1000));
             System.setProperty("sun.net.client.defaultReadTimeout", String.valueOf(30 * 1000));
 
+			_conn.setRequestProperty("Accept", "*/*");
+
             _conn.connect();
             _slen = _conn.getContentLength();
         } catch (java.net.MalformedURLException e) {


### PR DESCRIPTION
Default Accept header value is invalid according to RFC 7231. 
https://bugs.openjdk.org/browse/JDK-8163921
Fixed in java 19 which sets its value to `*/*`

Requests got blocked after firewall upgrade with rule that checks Accept header.