### PR TITLE
Make CJKFont optional

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -42,11 +42,17 @@ import java.util.stream.Stream;
 public class ITextFontResolver implements FontResolver {
     private Map _fontFamilies = createInitialFontMap();
     private Map _fontCache = new HashMap();
-
+    private boolean withCJKFonts;
     private final SharedContext _sharedContext;
 
     public ITextFontResolver(SharedContext sharedContext) {
         _sharedContext = sharedContext;
+        this.withCJKFonts = true;
+    }
+    
+    public ITextFontResolver(SharedContext sharedContext, boolean withCjkfonts ) {
+        _sharedContext = sharedContext;
+        this.withCJKFonts = withCjkfonts;
     }
 
     /**
@@ -478,7 +484,7 @@ public class ITextFontResolver implements FontResolver {
             addZapfDingbats(result);
 
             // Try and load the iTextAsian fonts
-            if(ITextFontResolver.class.getClassLoader().getResource("com/lowagie/text/pdf/fonts/cjkfonts.properties") != null) {
+            if(withCJKFonts && ITextFontResolver.class.getClassLoader().getResource("com/lowagie/text/pdf/fonts/cjkfonts.properties") != null) {
                 addCJKFonts(result);
             }
         } catch (DocumentException e) {


### PR DESCRIPTION
ITextFontResolver init is very slow on my computer and server (8000ms). After some research, it seems that createInitialFontMap() method take too much time. The cause is the cjkfonts which I did not use.
Is it possible to make this loading optional ?
Thanks a lot