### PR TITLE
Improve table layout

### DIFF
--- a/flying-saucer-examples/src/main/resources/demos/file-list.txt
+++ b/flying-saucer-examples/src/main/resources/demos/file-list.txt
@@ -10,6 +10,8 @@ Z-index,demo:demos/zindex.xhtml
 Cursors,demo:demos/cursors.xhtml
 Report,demo:demos/report.xhtml
 Forms,demo:demos/forms.xhtml
+Legacy Tables,demo:demos/fullscreen-table.xhtml
+CSS Tables,demo:demos/fullscreen-css-table.xhtml
 Recipe in XML,demo:demos/cream-chicken-rice.xml
 Centered Fluid,demo:demos/centered-fluid.xhtml
 Centered Fluid Auto Margin,demo:demos/centered-fluid-automargin.xhtml

--- a/flying-saucer-examples/src/main/resources/demos/fullscreen-css-table.xhtml
+++ b/flying-saucer-examples/src/main/resources/demos/fullscreen-css-table.xhtml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Layout using CSS Table</title>
+  <style>
+      html, body {
+          margin: 0;
+          padding: 0;
+          height: 100%;
+      }
+      .wrapper {
+          display: table;
+          width: 100%;
+          height: 100%;
+      }
+      .row {
+          display: table-row;
+      }
+      .cell {
+          display: table-cell;
+      }
+      .header {
+          background-color: lightblue;
+      }
+      .main {
+          background-color: lightgreen;
+      }
+      .footer {
+          background-color: lightcoral;
+      }
+  </style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="row header">
+    <div class="cell">Header</div>
+  </div>
+  <div class="row main">
+    <div class="cell">Main content area</div>
+  </div>
+  <div class="row footer">
+    <div class="cell">Footer</div>
+  </div>
+</div>
+</body>
+</html>

--- a/flying-saucer-examples/src/main/resources/demos/fullscreen-css-table.xhtml
+++ b/flying-saucer-examples/src/main/resources/demos/fullscreen-css-table.xhtml
@@ -12,6 +12,7 @@
       }
       .wrapper {
           display: table;
+          table-layout: fixed;
           width: 100%;
           height: 100%;
       }
@@ -20,6 +21,12 @@
       }
       .cell {
           display: table-cell;
+      }
+      .narrow {
+          width: 10%;
+      }
+      .wide {
+          width: 60%;
       }
       .header {
           background-color: lightblue;
@@ -35,10 +42,14 @@
 <body>
 <div class="wrapper">
   <div class="row header">
-    <div class="cell">Header</div>
+    <div class="cell narrow">Header A</div>
+    <div class="cell wide">Header B </div>
+    <div class="cell">Header C</div>
   </div>
   <div class="row main">
-    <div class="cell">Main content area</div>
+    <div class="cell">Main content area A</div>
+    <div class="cell">Main content area B</div>
+    <div class="cell">Main content area C</div>
   </div>
   <div class="row footer">
     <div class="cell">Footer</div>

--- a/flying-saucer-examples/src/main/resources/demos/fullscreen-table.xhtml
+++ b/flying-saucer-examples/src/main/resources/demos/fullscreen-table.xhtml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Layout using Table</title>
+  <style>
+      html, body {
+          margin: 0;
+          padding: 0;
+          height: 100%;
+      }
+      table {
+          border-collapse: collapse;
+          width: 100%;
+          height: 100%;
+      }
+      .header {
+          background-color: lightblue;
+      }
+      .main {
+          background-color: lightgreen;
+      }
+      .footer {
+          background-color: lightcoral;
+      }
+  </style>
+</head>
+<body>
+<table border="true">
+  <tbody>
+    <tr><td class="header">Header</td></tr>
+    <tr><td class="main">Main content area</td></tr>
+    <tr><td class="footer">Footer</td></tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
I would like to improve layouting for tables. In particular I want to be able to use tables so that one row uses all available space not used by the others. At the moment, when I tell table to use 100% of the height, it is always the last table row which get all space not used by previous rows.

Individual rows accept absolute dimensions (px or em), but relative dimensions, like 50% or 100% are ignored.

I guess classes which need adjusting are perhaps `TableRowBox` and `TableCellBox`.

Would you give me any hints how can be a task like this acomplished, or if there is something similar done in other areas of Flying Saucer?

In this PR I have added two examples demonstrating the issue, using different ways how to create the tables, both with the same result:

![image](https://user-images.githubusercontent.com/6927223/234832657-d07dcebc-aefa-40a3-9ef4-ce487fe18225.png)


