### PR TITLE
Remove profile definitions mistakenly reintroduced in merge

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -30,87 +30,24 @@
     </license>
   </licenses>
 
-  <profiles>
-    <profile>
-      <id>itext</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <!--
-          Note: The iText Bouncy Castle dependencies have been moved to a new group and version on maven central.
-          This caused some of the artifacts to be resolved twice. By excluding dependencies from the old group
-          and adding corresponding dependencies from the updated group, the artifacts are only resolved once.
-         -->
-        <dependency>
-          <groupId>com.lowagie</groupId>
-          <artifactId>itext</artifactId>
-          <version>${itext.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>bouncycastle</groupId>
-              <artifactId>bcmail-jdk14</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>bouncycastle</groupId>
-              <artifactId>bcprov-jdk14</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>bouncycastle</groupId>
-              <artifactId>bctsp-jdk14</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk14</artifactId>
-            <version>${bouncycastle.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bctsp-jdk14</artifactId>
-            <version>1.46</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk14</artifactId>
-            <version>${bouncycastle.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.xhtmlrenderer</groupId>
-          <artifactId>flying-saucer-core</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>openpdf</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.github.librepdf</groupId>
-          <artifactId>openpdf</artifactId>
-          <version>${openpdf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.xhtmlrenderer</groupId>
-            <artifactId>flying-saucer-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
+  <dependencies>
+    <dependency>
+        <groupId>com.github.librepdf</groupId>
+        <artifactId>openpdf</artifactId>
+        <version>${openpdf.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.xhtmlrenderer</groupId>
+        <artifactId>flying-saucer-core</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <resources>


### PR DESCRIPTION
This restores a 9.1.22 equivalent POM for flying-saucer-pdf-openpdf.

It appears the profile definitions may never have existed there and building with -P openpdf has been superfluous. It also appears that contrary to my assumption building with -P openpdf is not sufficient to only include the openpdf profile definitions.