### PR TITLE
#184 extract loading CJK fonts by default

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/AWTFontResolver.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/AWTFontResolver.java
@@ -193,7 +193,7 @@ public class AWTFontResolver implements FontResolver {
  * FindBugs: use "" instead of new String("")
  *
  * Revision 1.4  2009/04/25 11:09:32  pdoubleya
- * Case-insensitve checks for font name, fix by Peter Fassev in issue #263. Also, remove commented calls to Uu.p.
+ * Case-insensitive checks for font name, fix by Peter Fassev in issue #263. Also, remove commented calls to Uu.p.
  *
  * Revision 1.3  2008/01/22 21:25:40  pdoubleya
  * Fix: fonts not being keyed properly in font cache when a scaling factor was applied to the text renderer; scaled font size now used as part of the key.

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/FontResolver.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/FontResolver.java
@@ -25,6 +25,6 @@ import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.render.FSFont;
 
 public interface FontResolver {
-    public FSFont resolveFont(SharedContext renderingContext, FontSpecification spec);
-    public void flushCache();
+    FSFont resolveFont(SharedContext renderingContext, FontSpecification spec);
+    void flushCache();
 }

--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -315,26 +315,14 @@ public class ITextFontResolver implements FontResolver {
         File f = new File(path);
         if (f.exists()) {
             ByteArrayOutputStream result = new ByteArrayOutputStream((int)f.length());
-            InputStream is = null;
-            try {
-                is = newInputStream(Paths.get(path));
+            
+            try (InputStream is = newInputStream(Paths.get(path))) {
                 byte[] buf = new byte[10240];
                 int i;
                 while ( (i = is.read(buf)) != -1) {
                     result.write(buf, 0, i);
                 }
-                is.close();
-                is = null;
-
                 return result.toByteArray();
-            } finally {
-                if (is != null) {
-                    try {
-                        is.close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
             }
         } else {
             throw new IOException("File " + path + " does not exist or is not accessible");

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -21,6 +21,7 @@
     <junit.version>4.13.1</junit.version>
     <openpdf.version>1.3.30</openpdf.version>
     <itext.version>2.1.7</itext.version>
+    <slf4j.version>2.0.9</slf4j.version>
   </properties>
 
   <licenses>
@@ -35,6 +36,11 @@
       <groupId>org.xhtmlrenderer</groupId>
       <artifactId>flying-saucer-core</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/CJKFontResolver.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/CJKFontResolver.java
@@ -1,0 +1,103 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2006 Wisconsin Court System
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package org.xhtmlrenderer.pdf;
+
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.pdf.BaseFont;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xhtmlrenderer.css.constants.IdentValue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Use this class if you need to load iTextAsian fonts in addition to default fonts loaded by {@link ITextRenderer}
+ */
+public class CJKFontResolver extends ITextFontResolver {
+    private static final Logger log = LoggerFactory.getLogger(CJKFontResolver.class);
+    
+    @Override
+    protected Map<String, FontFamily> loadFonts() {
+        Map<String, FontFamily> result = super.loadFonts();
+        result.putAll(loadCJKFonts());
+        return result;
+    }
+
+    // fontFamilyName, fontName, encoding
+    private static final String[][] cjkFonts = {
+            {"STSong-Light-H", "STSong-Light", "UniGB-UCS2-H"},
+            {"STSong-Light-V", "STSong-Light", "UniGB-UCS2-V"},
+            {"STSongStd-Light-H", "STSongStd-Light", "UniGB-UCS2-H"},
+            {"STSongStd-Light-V", "STSongStd-Light", "UniGB-UCS2-V"},
+            {"MHei-Medium-H", "MHei-Medium", "UniCNS-UCS2-H"},
+            {"MHei-Medium-V", "MHei-Medium", "UniCNS-UCS2-V"},
+            {"MSung-Light-H", "MSung-Light", "UniCNS-UCS2-H"},
+            {"MSung-Light-V", "MSung-Light", "UniCNS-UCS2-V"},
+            {"MSungStd-Light-H", "MSungStd-Light", "UniCNS-UCS2-H"},
+            {"MSungStd-Light-V", "MSungStd-Light", "UniCNS-UCS2-V"},
+            {"HeiseiMin-W3-H", "HeiseiMin-W3", "UniJIS-UCS2-H"},
+            {"HeiseiMin-W3-V", "HeiseiMin-W3", "UniJIS-UCS2-V"},
+            {"HeiseiKakuGo-W5-H", "HeiseiKakuGo-W5", "UniJIS-UCS2-H"},
+            {"HeiseiKakuGo-W5-V", "HeiseiKakuGo-W5", "UniJIS-UCS2-V"},
+            {"KozMinPro-Regular-H", "KozMinPro-Regular", "UniJIS-UCS2-HW-H"},
+            {"KozMinPro-Regular-V", "KozMinPro-Regular", "UniJIS-UCS2-HW-V"},
+            {"HYGoThic-Medium-H", "HYGoThic-Medium", "UniKS-UCS2-H"},
+            {"HYGoThic-Medium-V", "HYGoThic-Medium", "UniKS-UCS2-V"},
+            {"HYSMyeongJo-Medium-H", "HYSMyeongJo-Medium", "UniKS-UCS2-H"},
+            {"HYSMyeongJo-Medium-V", "HYSMyeongJo-Medium", "UniKS-UCS2-V"},
+            {"HYSMyeongJoStd-Medium-H", "HYSMyeongJoStd-Medium", "UniKS-UCS2-H"},
+            {"HYSMyeongJoStd-Medium-V", "HYSMyeongJoStd-Medium", "UniKS-UCS2-V"}
+    };
+
+    /**
+     * Try and load the iTextAsian fonts
+     */
+    private Map<String, FontFamily> loadCJKFonts() {
+        Map<String, FontFamily> fontFamilyMap = new HashMap<>();
+
+        for (String[] cjkFont : cjkFonts) {
+            String fontFamilyName = cjkFont[0];
+            String fontName = cjkFont[1];
+            String encoding = cjkFont[2];
+
+            try {
+                FontFamily fontFamily = addCJKFont(fontFamilyName, fontName, encoding);
+                fontFamilyMap.put(fontFamilyName, fontFamily);
+            }
+            catch (DocumentException | IOException e) {
+                log.error("Failed to load font {} {} {}: {}", fontFamilyName, fontName, encoding, e.toString());
+            }
+        }
+        return fontFamilyMap;
+    }
+
+    private FontFamily addCJKFont(String fontFamilyName, String fontName, String encoding) throws DocumentException, IOException {
+        FontFamily fontFamily = new FontFamily(fontFamilyName);
+
+        fontFamily.addFontDescription(new FontDescription(BaseFont.createFont(fontName+",BoldItalic", encoding, false), IdentValue.OBLIQUE, 700));
+        fontFamily.addFontDescription(new FontDescription(BaseFont.createFont(fontName+",Italic", encoding, false), IdentValue.OBLIQUE, 400));
+        fontFamily.addFontDescription(new FontDescription(BaseFont.createFont(fontName+",Bold", encoding, false), IdentValue.NORMAL, 700));
+        fontFamily.addFontDescription(new FontDescription(BaseFont.createFont(fontName, encoding, false), IdentValue.NORMAL, 400));
+
+        return fontFamily;
+    }
+}

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/FontDescription.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/FontDescription.java
@@ -1,0 +1,114 @@
+package org.xhtmlrenderer.pdf;
+
+import com.lowagie.text.pdf.BaseFont;
+import org.xhtmlrenderer.css.constants.IdentValue;
+
+public class FontDescription {
+    private IdentValue _style;
+    private int _weight;
+
+    private BaseFont _font;
+
+    private float _underlinePosition;
+    private float _underlineThickness;
+
+    private float _yStrikeoutSize;
+    private float _yStrikeoutPosition;
+
+    private boolean _isFromFontFace;
+
+    public FontDescription() {
+    }
+
+    public FontDescription(BaseFont font) {
+        this(font, IdentValue.NORMAL, 400);
+    }
+
+    public FontDescription(BaseFont font, IdentValue style, int weight) {
+        _font = font;
+        _style = style;
+        _weight = weight;
+        setMetricDefaults();
+    }
+
+    public BaseFont getFont() {
+        return _font;
+    }
+
+    public void setFont(BaseFont font) {
+        _font = font;
+    }
+
+    public int getWeight() {
+        return _weight;
+    }
+
+    public void setWeight(int weight) {
+        _weight = weight;
+    }
+
+    public IdentValue getStyle() {
+        return _style;
+    }
+
+    public void setStyle(IdentValue style) {
+        _style = style;
+    }
+
+    public float getUnderlinePosition() {
+        return _underlinePosition;
+    }
+
+    /**
+     * This refers to the top of the underline stroke
+     */
+    public void setUnderlinePosition(float underlinePosition) {
+        _underlinePosition = underlinePosition;
+    }
+
+    public float getUnderlineThickness() {
+        return _underlineThickness;
+    }
+
+    public void setUnderlineThickness(float underlineThickness) {
+        _underlineThickness = underlineThickness;
+    }
+
+    public float getYStrikeoutPosition() {
+        return _yStrikeoutPosition;
+    }
+
+    public void setYStrikeoutPosition(float strikeoutPosition) {
+        _yStrikeoutPosition = strikeoutPosition;
+    }
+
+    public float getYStrikeoutSize() {
+        return _yStrikeoutSize;
+    }
+
+    public void setYStrikeoutSize(float strikeoutSize) {
+        _yStrikeoutSize = strikeoutSize;
+    }
+
+    private void setMetricDefaults() {
+        _underlinePosition = -50;
+        _underlineThickness = 50;
+
+        int[] box = _font.getCharBBox('x');
+        if (box != null) {
+            _yStrikeoutPosition = box[3] / 2 + 50;
+            _yStrikeoutSize = 100;
+        } else {
+            // Do what the JDK does, size will be calculated by ITextTextRenderer
+            _yStrikeoutPosition = _font.getFontDescriptor(BaseFont.BBOXURY, 1000.0f) / 3.0f;
+        }
+    }
+
+    public boolean isFromFontFace() {
+        return _isFromFontFace;
+    }
+
+    public void setFromFontFace(boolean isFromFontFace) {
+        _isFromFontFace = isFromFontFace;
+    }
+}

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/FontFamily.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/FontFamily.java
@@ -1,0 +1,110 @@
+package org.xhtmlrenderer.pdf;
+
+import org.xhtmlrenderer.css.constants.IdentValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Comparator.comparingInt;
+
+public class FontFamily {
+    private final String _name;
+    private final List<FontDescription> _fontDescriptions = new ArrayList<>();
+
+    FontFamily(String name) {
+        _name = name;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
+    public List<FontDescription> getFontDescriptions() {
+        return _fontDescriptions;
+    }
+
+    public void addFontDescription(FontDescription description) {
+        _fontDescriptions.add(description);
+        _fontDescriptions.sort(comparingInt(FontDescription::getWeight));
+    }
+
+    public FontDescription match(int desiredWeight, IdentValue style) {
+        List<FontDescription> candidates = new ArrayList<>();
+
+        for (FontDescription description : _fontDescriptions) {
+            if (description.getStyle() == style) {
+                candidates.add(description);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            if (style == IdentValue.ITALIC) {
+                return match(desiredWeight, IdentValue.OBLIQUE);
+            } else if (style == IdentValue.OBLIQUE) {
+                return match(desiredWeight, IdentValue.NORMAL);
+            } else {
+                candidates.addAll(_fontDescriptions);
+            }
+        }
+
+        FontDescription result = findByWeight(candidates, desiredWeight, SM_EXACT);
+
+        if (result != null) {
+            return result;
+        } else {
+            if (desiredWeight <= 500) {
+                return findByWeight(candidates, desiredWeight, SM_LIGHTER_OR_DARKER);
+            } else {
+                return findByWeight(candidates, desiredWeight, SM_DARKER_OR_LIGHTER);
+            }
+        }
+    }
+
+    private static final int SM_EXACT = 1;
+    private static final int SM_LIGHTER_OR_DARKER = 2;
+    private static final int SM_DARKER_OR_LIGHTER = 3;
+
+    private FontDescription findByWeight(List<FontDescription> matches, int desiredWeight, int searchMode) {
+        if (searchMode == SM_EXACT) {
+            for (FontDescription description : matches) {
+                if (description.getWeight() == desiredWeight) {
+                    return description;
+                }
+            }
+            return null;
+        } else if (searchMode == SM_LIGHTER_OR_DARKER) {
+            int offset;
+            FontDescription description = null;
+            for (offset = 0; offset < matches.size(); offset++) {
+                description = matches.get(offset);
+                if (description.getWeight() > desiredWeight) {
+                    break;
+                }
+            }
+
+            if (offset > 0 && description.getWeight() > desiredWeight) {
+                return matches.get(offset - 1);
+            } else {
+                return description;
+            }
+
+        } else if (searchMode == SM_DARKER_OR_LIGHTER) {
+            int offset;
+            FontDescription description = null;
+            for (offset = matches.size() - 1; offset >= 0; offset--) {
+                description = matches.get(offset);
+                if (description.getWeight() < desiredWeight) {
+                    break;
+                }
+            }
+
+            if (offset != matches.size() - 1 && description != null && description.getWeight() < desiredWeight) {
+                return matches.get(offset + 1);
+            } else {
+                return description;
+            }
+        }
+
+        return null;
+    }
+}

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFSFont.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFSFont.java
@@ -19,12 +19,11 @@
  */
 package org.xhtmlrenderer.pdf;
 
-import org.xhtmlrenderer.pdf.ITextFontResolver.FontDescription;
 import org.xhtmlrenderer.render.FSFont;
 
 public class ITextFSFont implements FSFont {
-    private FontDescription _font;
-    private float _size;
+    private final FontDescription _font;
+    private final float _size;
 
     public ITextFSFont(FontDescription font, float size) {
         _font = font;

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -52,7 +52,6 @@ import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.NamespaceHandler;
 import org.xhtmlrenderer.extend.OutputDevice;
 import org.xhtmlrenderer.layout.SharedContext;
-import org.xhtmlrenderer.pdf.ITextFontResolver.FontDescription;
 import org.xhtmlrenderer.render.AbstractOutputDevice;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.Box;

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xhtmlrenderer.context.StyleReference;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.extend.FontResolver;
 import org.xhtmlrenderer.extend.NamespaceHandler;
 import org.xhtmlrenderer.extend.UserInterface;
 import org.xhtmlrenderer.layout.BoxBuilder;
@@ -99,17 +100,32 @@ public class ITextRenderer {
         this(DEFAULT_DOTS_PER_POINT, DEFAULT_DOTS_PER_PIXEL);
     }
 
+    public ITextRenderer(FontResolver fontResolver) {
+        this(DEFAULT_DOTS_PER_POINT, DEFAULT_DOTS_PER_PIXEL, fontResolver);
+    }
+
     public ITextRenderer(float dotsPerPoint, int dotsPerPixel) {
         this(dotsPerPoint, dotsPerPixel, new ITextOutputDevice(dotsPerPoint));
+    }
+
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, FontResolver fontResolver) {
+        this(dotsPerPoint, dotsPerPixel, new ITextOutputDevice(dotsPerPoint), fontResolver);
     }
 
     public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice) {
         this(dotsPerPoint, dotsPerPixel, outputDevice, new ITextUserAgent(outputDevice));
     }
 
-    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice, ITextUserAgent userAgent) {
-        _dotsPerPoint = dotsPerPoint;
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice, FontResolver fontResolver) {
+        this(dotsPerPoint, dotsPerPixel, outputDevice, new ITextUserAgent(outputDevice), fontResolver);
+    }
 
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice, ITextUserAgent userAgent) {
+        this(dotsPerPoint, dotsPerPixel, outputDevice, userAgent, new ITextFontResolver());
+    }
+
+    public ITextRenderer(float dotsPerPoint, int dotsPerPixel, ITextOutputDevice outputDevice, ITextUserAgent userAgent, FontResolver fontResolver) {
+        _dotsPerPoint = dotsPerPoint;
         _outputDevice = outputDevice;
 
         _sharedContext = new SharedContext();
@@ -118,7 +134,6 @@ public class ITextRenderer {
         userAgent.setSharedContext(_sharedContext);
         _outputDevice.setSharedContext(_sharedContext);
 
-        ITextFontResolver fontResolver = new ITextFontResolver(_sharedContext);
         _sharedContext.setFontResolver(fontResolver);
 
         ITextReplacedElementFactory replacedElementFactory = new ITextReplacedElementFactory(_outputDevice);
@@ -184,7 +199,7 @@ public class ITextRenderer {
         _sharedContext.setBaseURL(url);
         _sharedContext.setNamespaceHandler(nsh);
         _sharedContext.getCss().setDocumentContext(_sharedContext, _sharedContext.getNamespaceHandler(), doc, new NullUserInterface());
-        getFontResolver().importFontFaces(_sharedContext.getCss().getFontFaceRules());
+        getFontResolver().importFontFaces(_sharedContext.getCss().getFontFaceRules(), _sharedContext.getUac());
     }
 
     public PDFEncryption getPDFEncryption() {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextTextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextTextRenderer.java
@@ -24,7 +24,6 @@ import org.xhtmlrenderer.extend.FSGlyphVector;
 import org.xhtmlrenderer.extend.FontContext;
 import org.xhtmlrenderer.extend.OutputDevice;
 import org.xhtmlrenderer.extend.TextRenderer;
-import org.xhtmlrenderer.pdf.ITextFontResolver.FontDescription;
 import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.render.FSFontMetrics;
 import org.xhtmlrenderer.render.JustificationInfo;

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TrueTypeUtil.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TrueTypeUtil.java
@@ -4,7 +4,6 @@ import com.lowagie.text.DocumentException;
 import com.lowagie.text.pdf.BaseFont;
 import com.lowagie.text.pdf.RandomAccessFileOrArray;
 import org.xhtmlrenderer.css.constants.IdentValue;
-import org.xhtmlrenderer.pdf.ITextFontResolver.FontDescription;
 
 import java.io.IOException;
 import java.lang.reflect.Field;


### PR DESCRIPTION
1. extracted CJK-specific part from ITextFontResolver to a subclass CJKFontResolver
2. Users can pass it to ITextRenderer, e.g. `new ITextRenderer(new CJKFontResolver())`

P.S. In fact, there is no more need to exclude CJK fonts after PR https://github.com/LibrePDF/OpenPDF/pull/955 gets merged in OpenPDF. This PR will fix loading speed of CJK fonts.

But anyway, I decided to make CJK fonts optional because they also consume some amount of memory (and probably not needed for most customers).