### PR TITLE
do not expose JSR 302 as transitive dependency to other projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
FlyingSaucer uses JSR 302 for compilation, but end-users don't need it.