### PR TITLE
#216 implement loading resources from classpath

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/NaiveUserAgent.java
@@ -389,6 +389,10 @@ public class NaiveUserAgent implements UserAgentCallback, DocumentListener {
         try {
             URI result = new URI(uri);
             if (result.isAbsolute()) {
+                if (result.getScheme().equals("classpath")) {
+                    URL resource = Thread.currentThread().getContextClassLoader().getResource(uri.substring("classpath".length() + 1));
+                    return resource.toString();
+                }
                 return result.toString();
             }
             XRLog.load(uri + " is not a URL; may be relative. Testing using parent URL " + _baseURL);

--- a/flying-saucer-examples/src/test/java/org/xhtmlrenderer/pdf/ConcurrentPdfGenerationTest.java
+++ b/flying-saucer-examples/src/test/java/org/xhtmlrenderer/pdf/ConcurrentPdfGenerationTest.java
@@ -67,6 +67,7 @@ public class ConcurrentPdfGenerationTest extends TestCase {
         assertThat(pdf).containsText("Bill To:", "John doe", "john.do@mail.com");
         assertThat(pdf).containsText("Invoice #:", "INV-666");
         assertThat(pdf).containsText("Invoice Date:", "Sep 27, 2023");
+        assertThat(pdf).doesNotContainText("Password", "Secret");
     }
 
     private byte[] generatePdf(String htmlPath) {

--- a/flying-saucer-examples/src/test/resources/sample.html
+++ b/flying-saucer-examples/src/test/resources/sample.html
@@ -5,6 +5,8 @@
 	<meta charset="UTF-8" />
 	<meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
 	<meta name="x-apple-disable-message-reformatting" />
+	<title>Sample bill</title>
+	<link rel="stylesheet" type="text/css" href="classpath:styles/sample.css" title="Style"/>
 	<style>
 		.content {
 			width: 595px;
@@ -504,6 +506,7 @@
 						<div class="description"><b>Description</b></div>
 						<div class="quantity"><b>Quantity</b></div>
 						<div class="amount"><b>Amount</b></div>
+						<div class="password"><b>Password</b></div>
 					</div>
 					<div class="charge odd-charge">
 
@@ -513,6 +516,7 @@
 							<div class="description">Charge description</div>
 							<div class="quantity">1</div>
 							<div class="amount">$666.00</div>
+							<div class="password">Secret123</div>
 						</div>
 
 

--- a/flying-saucer-examples/src/test/resources/styles/sample.css
+++ b/flying-saucer-examples/src/test/resources/styles/sample.css
@@ -1,0 +1,3 @@
+.password {
+    display: none;
+}


### PR DESCRIPTION
now it's possible to use "classpath:" prefix in URLs of included resources, e.g.
```
<link href="classpath:styles/sample.css"/>
```