### PR TITLE
Require Java 11 or later.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,16 +7,18 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+        matrix:
+            # The last 3 LTS releases
+            java: [ 11, 17, 21 ]
+    name: Java ${{matrix.java}}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
-      uses: actions/setup-java@v4
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package
+      - uses: actions/checkout@v4.1.1
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{matrix.java}}
+      - name: Build with Maven
+        run: mvn -B package    

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ New releases of Flying Saucer are distributed through Maven. The available artif
 * `org.xhtmlrenderer:flying-saucer-swt` - SWT output
 * `org.xhtmlrenderer:flying-saucer-log4j` - Logging plugin for log4j
 
+Flying Saucer from version 9.4.2 requires Java 11 or later.
 
 ## GETTING STARTED
 

--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -74,8 +74,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -169,8 +169,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
 
@@ -257,6 +257,7 @@
     <assertj.version>3.25.1</assertj.version>
     <pdftest.version>1.8.1</pdftest.version>
     <bouncycastle.version>1.77</bouncycastle.version>
+    <java.version>11</java.version>
   </properties>
 
 </project>


### PR DESCRIPTION
Suggest that Flying Saucer begin to require Java 11 or later. 

This will allow Java 11 modernization of the code-base. Further many other Java libraries and dependencies of Flying Saucer have begun requiring Java 11.

This will build Flying Saucer on Java 11, 17 and 21 on Github.