### PR TITLE
change scope of jsr305 dependency from "provided" to "compile"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
it cannot be "provided" because it's not "provided at runtime by JDK or a container". it's rather a "compile" dependency because it's needed for compilation of user project (at least maven projects).