### PR TITLE
Adding F flag to make links pdf/a-1a conform

### DIFF
--- a/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf-itext5/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -31,6 +31,7 @@ import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfDestination;
 import com.itextpdf.text.pdf.PdfImportedPage;
 import com.itextpdf.text.pdf.PdfName;
+import com.itextpdf.text.pdf.PdfNumber;
 import com.itextpdf.text.pdf.PdfOutline;
 import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.PdfTextArray;
@@ -272,12 +273,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                         targetArea.setBorder(0);
                         targetArea.setBorderWidth(0);
 
-                        PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(),
-                                targetArea.getRight(), targetArea.getTop(), action);
-                        annot.put(PdfName.SUBTYPE, PdfName.LINK);
-                        annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
-                        annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
-                        _writer.addAnnotation(annot);
+                        addLinkAnnotation(action, targetArea);
                     }
                 } else {
                     int boxTop = box.getAbsY();
@@ -292,17 +288,22 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                         if (targetArea == null) {
                             return;
                         }
-                        PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(), targetArea.getRight(),
-                            targetArea.getTop(), action);
-                        annot.put(PdfName.SUBTYPE, PdfName.LINK);
-
-                        annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
-                        annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
-                        _writer.addAnnotation(annot);
+                        addLinkAnnotation(action, targetArea);
                     }
                 }
             }
         }
+    }
+
+    private void addLinkAnnotation(final PdfAction action, final com.itextpdf.text.Rectangle targetArea) {
+        PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(),
+                targetArea.getRight(), targetArea.getTop(), action);
+        annot.put(PdfName.SUBTYPE, PdfName.LINK);
+        annot.put(PdfName.F, new PdfNumber(PdfAnnotation.FLAGS_PRINT));
+
+        annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
+        annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
+        _writer.addAnnotation(annot);
     }
 
     public com.itextpdf.text.Rectangle createLocalTargetArea(RenderingContext c, Box box) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -33,6 +33,7 @@ import com.lowagie.text.pdf.PdfDictionary;
 import com.lowagie.text.pdf.PdfImportedPage;
 import com.lowagie.text.pdf.PdfIndirectReference;
 import com.lowagie.text.pdf.PdfName;
+import com.lowagie.text.pdf.PdfNumber;
 import com.lowagie.text.pdf.PdfOutline;
 import com.lowagie.text.pdf.PdfReader;
 import com.lowagie.text.pdf.PdfString;
@@ -277,12 +278,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                             targetArea.setBorder(0);
                             targetArea.setBorderWidth(0);
 
-                            PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(),
-                                    targetArea.getRight(), targetArea.getTop(), action);
-                            annot.put(PdfName.SUBTYPE, PdfName.LINK);
-                            annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
-                            annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
-                            _writer.addAnnotation(annot);
+                            addLinkAnnotation(action, targetArea);
                         }
                     }
                 } else {
@@ -292,16 +288,21 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
                     if (targetArea == null) {
                         return;
                     }
-                    PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(), targetArea.getRight(),
-                            targetArea.getTop(), action);
-                    annot.put(PdfName.SUBTYPE, PdfName.LINK);
-
-                    annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
-                    annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
-                    _writer.addAnnotation(annot);
+                    addLinkAnnotation(action, targetArea);
                 }
             }
         }
+    }
+
+    private void addLinkAnnotation(final PdfAction action, final com.lowagie.text.Rectangle targetArea) {
+        PdfAnnotation annot = new PdfAnnotation(_writer, targetArea.getLeft(), targetArea.getBottom(),
+                targetArea.getRight(), targetArea.getTop(), action);
+        annot.put(PdfName.SUBTYPE, PdfName.LINK);
+        annot.put(PdfName.F, new PdfNumber(PdfAnnotation.FLAGS_PRINT));
+
+        annot.setBorderStyle(new PdfBorderDictionary(0.0f, 0));
+        annot.setBorder(new PdfBorderArray(0.0f, 0.0f, 0));
+        _writer.addAnnotation(annot);
     }
 
     public com.lowagie.text.Rectangle createLocalTargetArea(RenderingContext c, Box box) {


### PR DESCRIPTION
Flying Saucer is not generating links from a tags that are PDF/A-1A conform:

`<a href="https://www.google.at/">My link</a>`

The veraPDF validation`of [Rule 6.5.3-2](https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFA-Part-1-rules#rule-653-2) fails with following error:

`An annotation dictionary shall contain the F key. The F key's Print flag bit shall be set to 1 and its Hidden, Invisible and NoView flag bits shall be set to 0.`

This fix adds the `F` key to the annotation of generated links, so the pdf passes the PDF/A-1A conformity check.

---

If the fix is acceptable, it would be nice to have a release soon. If version 9.6.0 cannot be released yet, it is also ok cherry-picking this commit to 9.5.2 and release from there.

Thanks for your time :)