### PR TITLE
Use Jsoup to parse HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 Flying Saucer is a pure-Java library for rendering arbitrary well-formed XML 
 (or XHTML) using CSS 2.1 for layout and formatting, output to Swing panels, 
-PDF, and images.
+PDF, and images. 
+
+The new [Jsoup](https://jsoup.org/) based HTML parser will allow supporting HTML 5 syntax
+and features in Flying Saucer, with a goal of implementing full HTML5 support over time. 
 
 Comprehensive documentation available in [The Flying Saucer User's Guide](https://flyingsaucerproject.github.io/flyingsaucer/r8/guide/users-guide-R8.html).
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/FSCatalog.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/FSCatalog.java
@@ -63,6 +63,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Patrick Wright
  */
+@Deprecated
 public class FSCatalog {
     /**
      * Default constructor

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/FSEntityResolver.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/FSEntityResolver.java
@@ -54,6 +54,7 @@ import java.util.logging.Level;
  *
  * @author Patrick Wright
  */
+@Deprecated
 public class FSEntityResolver implements EntityResolver2 {
     private static final Logger log = LoggerFactory.getLogger(FSEntityResolver.class);
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
@@ -1,0 +1,104 @@
+/*
+ * {{{ header & license
+ * Flying Saucer - Copyright (c) 2024
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package org.xhtmlrenderer.resource;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.xhtmlrenderer.util.XRLog;
+import org.xhtmlrenderer.util.XRRuntimeException;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.xml.transform.TransformerException;
+
+/**
+ * HTMLResource uses JSoup to parse XML resources.
+ */
+@ParametersAreNonnullByDefault
+public class HTMLResource extends AbstractResource {
+    private org.w3c.dom.Document document;
+
+    private HTMLResource(InputStream stream) {
+        super(stream);
+        try {
+            Document jsoupDoc = Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
+            this.document = convertJsoupToW3CDocument(jsoupDoc);
+        } catch (IOException | ParserConfigurationException | TransformerException | SAXException e) {
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to parse and convert XML document.", e);
+            throw new XRRuntimeException("Failed to parse and convert XML document.", e);
+        }
+    }
+
+    public static HTMLResource load(URL source) {
+        try (InputStream stream = source.openStream()) {
+            return new HTMLResource(stream);
+        } catch (IOException e) {
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load XML from URL.", e);
+            throw new XRRuntimeException("Failed to load XML from URL.", e);
+        }
+    }
+
+    public static HTMLResource load(InputStream stream) {
+        return new HTMLResource(stream);
+    }
+
+    public static HTMLResource load(Reader reader) {
+        try {
+            InputStream stream = convertReaderToInputStream(reader);
+            return new HTMLResource(stream);
+        } catch (IOException e) {
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load XML from Reader.", e);
+            throw new XRRuntimeException("Failed to load XML from Reader.", e);
+        }
+    }
+
+    public static HTMLResource load(String xml) {
+        return load(new StringReader(xml));
+    }
+
+    public org.w3c.dom.Document getDocument() {
+        return document;
+    }
+
+    private static org.w3c.dom.Document convertJsoupToW3CDocument(Document jsoupDoc) throws ParserConfigurationException, IOException, TransformerException, SAXException {
+        String html = jsoupDoc.outerHtml();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static InputStream convertReaderToInputStream(Reader reader) throws IOException {
+        char[] charBuffer = new char[8 * 1024];
+        StringBuilder builder = new StringBuilder();
+        int numCharsRead;
+        while ((numCharsRead = reader.read(charBuffer, 0, charBuffer.length)) != -1) {
+            builder.append(charBuffer, 0, numCharsRead);
+        }
+        return new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
@@ -20,21 +20,16 @@
 package org.xhtmlrenderer.resource;
 
 import org.jsoup.Jsoup;
+import org.jsoup.helper.W3CDom;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.xhtmlrenderer.util.XRLog;
 import org.xhtmlrenderer.util.XRRuntimeException;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.net.URL;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import javax.xml.transform.TransformerException;
 
 /**
  * HTMLResource uses JSoup to parse XML resources.
@@ -47,8 +42,9 @@ public class HTMLResource extends AbstractResource {
         super(stream);
         try {
             Document jsoupDoc = Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
-            this.document = convertJsoupToW3CDocument(jsoupDoc);
-        } catch (IOException | ParserConfigurationException | TransformerException | SAXException e) {
+            W3CDom w3cDom = new W3CDom();
+            this.document = w3cDom.fromJsoup(jsoupDoc);
+        } catch (IOException  e) {
             XRLog.load(java.util.logging.Level.SEVERE, "Failed to parse and convert HTML document.", e);
             throw new XRRuntimeException("Failed to parse and convert HTML document.", e);
         }
@@ -83,13 +79,6 @@ public class HTMLResource extends AbstractResource {
 
     public org.w3c.dom.Document getDocument() {
         return document;
-    }
-
-    private static org.w3c.dom.Document convertJsoupToW3CDocument(Document jsoupDoc) throws ParserConfigurationException, IOException, TransformerException, SAXException {
-        String html = jsoupDoc.outerHtml();
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        return builder.parse(new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8)));
     }
 
     private static InputStream convertReaderToInputStream(Reader reader) throws IOException {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
@@ -32,7 +32,7 @@ import java.net.URL;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * HTMLResource uses JSoup to parse XML resources.
+ * HTMLResource uses JSoup to parse HTML.
  */
 @ParametersAreNonnullByDefault
 public class HTMLResource extends AbstractResource {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
@@ -41,7 +41,7 @@ public class HTMLResource extends AbstractResource {
     private HTMLResource(InputStream stream) {
         super(stream);
         try {
-            Document jsoupDoc = Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
+            Document jsoupDoc = Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.htmlParser());
             W3CDom w3cDom = new W3CDom();
             this.document = w3cDom.fromJsoup(jsoupDoc);
         } catch (IOException  e) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/HTMLResource.java
@@ -49,8 +49,8 @@ public class HTMLResource extends AbstractResource {
             Document jsoupDoc = Jsoup.parse(stream, StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
             this.document = convertJsoupToW3CDocument(jsoupDoc);
         } catch (IOException | ParserConfigurationException | TransformerException | SAXException e) {
-            XRLog.load(java.util.logging.Level.SEVERE, "Failed to parse and convert XML document.", e);
-            throw new XRRuntimeException("Failed to parse and convert XML document.", e);
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to parse and convert HTML document.", e);
+            throw new XRRuntimeException("Failed to parse and convert HTML document.", e);
         }
     }
 
@@ -58,8 +58,8 @@ public class HTMLResource extends AbstractResource {
         try (InputStream stream = source.openStream()) {
             return new HTMLResource(stream);
         } catch (IOException e) {
-            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load XML from URL.", e);
-            throw new XRRuntimeException("Failed to load XML from URL.", e);
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load HTML from URL.", e);
+            throw new XRRuntimeException("Failed to load HTML from URL.", e);
         }
     }
 
@@ -72,8 +72,8 @@ public class HTMLResource extends AbstractResource {
             InputStream stream = convertReaderToInputStream(reader);
             return new HTMLResource(stream);
         } catch (IOException e) {
-            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load XML from Reader.", e);
-            throw new XRRuntimeException("Failed to load XML from Reader.", e);
+            XRLog.load(java.util.logging.Level.SEVERE, "Failed to load HTML from Reader.", e);
+            throw new XRRuntimeException("Failed to load HTML from Reader.", e);
         }
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/resource/XMLResource.java
@@ -59,8 +59,11 @@ import java.util.logging.Level;
 
 
 /**
+ * Deprecated, see HTMLResource instead.
+ *
  * @author Patrick Wright
  */
+@Deprecated
 @ParametersAreNonnullByDefault
 public class XMLResource extends AbstractResource {
     private Document document;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -29,6 +29,7 @@ import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.PageBox;
 import org.xhtmlrenderer.render.RenderingContext;
+import org.xhtmlrenderer.resource.HTMLResource;
 import org.xhtmlrenderer.resource.XMLResource;
 import org.xhtmlrenderer.simple.NoNamespaceHandler;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
@@ -340,8 +341,7 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
     }
 
     public void setDocumentFromString(String content, @Nullable String url, NamespaceHandler nsh) {
-        InputSource is = new InputSource(new StringReader(content));
-        Document dom = XMLResource.load(is).getDocument();
+        Document dom = HTMLResource.load(content).getDocument();
 
         setDocument(dom, url, nsh);
     }

--- a/flying-saucer-examples/src/main/java/org/xhtmlrenderer/demo/browser/BrowserPanel.java
+++ b/flying-saucer-examples/src/main/java/org/xhtmlrenderer/demo/browser/BrowserPanel.java
@@ -26,6 +26,7 @@ import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 import org.xhtmlrenderer.pdf.PDFCreationListener;
 import org.xhtmlrenderer.pdf.util.XHtmlMetaToPdfInfoAdapter;
+import org.xhtmlrenderer.resource.HTMLResource;
 import org.xhtmlrenderer.resource.XMLResource;
 import org.xhtmlrenderer.simple.FSScrollPane;
 import org.xhtmlrenderer.swing.ImageResourceLoader;
@@ -316,7 +317,7 @@ public class BrowserPanel extends JPanel implements DocumentListener {
     }
 
     private void handlePageLoadFailed(String url_text, XRRuntimeException ex) {
-        final XMLResource xr;
+        final HTMLResource xr;
         final String rootCause = getRootCause(ex);
         final String msg = GeneralUtil.escapeHTML(addLineBreaks(rootCause));
         String notFound =
@@ -333,7 +334,7 @@ public class BrowserPanel extends JPanel implements DocumentListener {
                         "</body>\n" +
                         "</html>";
 
-        xr = XMLResource.load(new StringReader(notFound));
+        xr = HTMLResource.load(notFound);
         SwingUtilities.invokeLater(() -> root.panel.view.setDocument(xr.getDocument(), null));
    }
 

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -39,10 +39,9 @@ import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.PageBox;
 import org.xhtmlrenderer.render.RenderingContext;
 import org.xhtmlrenderer.render.ViewportBox;
-import org.xhtmlrenderer.resource.XMLResource;
+import org.xhtmlrenderer.resource.HTMLResource;
 import org.xhtmlrenderer.simple.extend.XhtmlNamespaceHandler;
 import org.xhtmlrenderer.util.Configuration;
-import org.xml.sax.InputSource;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -215,7 +214,7 @@ public class ITextRenderer {
 
     private Document parse(String content) {
         try (var is = new StringReader(content)) {
-            return XMLResource.load(new InputSource(is)).getDocument();
+            return HTMLResource.load(is).getDocument();
         }
     }
 

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/FloatedTableCellTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/FloatedTableCellTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xhtmlrenderer.resource.HTMLResource;
 import org.xhtmlrenderer.resource.XMLResource;
 
 import java.io.File;
@@ -36,7 +37,7 @@ class FloatedTableCellTest {
 			</html>""";
 
         ITextRenderer renderer = new ITextRenderer();
-		byte[] result = renderer.createPDF(XMLResource.load(page).getDocument());
+		byte[] result = renderer.createPDF(HTMLResource.load(page).getDocument());
 		printFile(result, "table-with-floated-cell.pdf");
 		PDF pdf = new PDF(result);
 		assertThat(pdf).containsText("first cell", "second cell");
@@ -48,7 +49,7 @@ class FloatedTableCellTest {
 			<table><tr><td style="float:left;">first cell {float:left;}</td></tr></table>""";
 
         ITextRenderer renderer = new ITextRenderer();
-		byte[] result = renderer.createPDF(XMLResource.load(page).getDocument());
+		byte[] result = renderer.createPDF(HTMLResource.load(page).getDocument());
 		printFile(result, "table-cell.pdf");
 		
 		PDF pdf = new PDF(result);		

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.17.2</version>
+    </dependency>
   </dependencies>
 
   <modules>


### PR DESCRIPTION
Use JSOUP to parse HTML. 
https://jsoup.org/

Deprecate XMLResource. 
Add HTMLResource.

Jsoup is a HTML parser, so it could work better to parse HTML than the SAX parser currently in use.
I consider this a proposal, which I think is a step in the right direction. However, I am not fully sure that I understand all the consequences of this yet. So I would like to propose this change, maybe it will be accepted. Related: #279 and #282. 

Further, Jsoup is a HTML parser, and most users of Flying saucer will be expecting HTML syntax to be valid, not just XHTML. The current parser in Flysing Saucer is a SAX based XML parser which will throw exceptions if there input is not valid XHTML.

And importantly, we need to make sure that this doesn't introduce any XSS or HTML based vulnerabilities.