### PR TITLE
rename package "org.xhtmlrenderer.simple" in module "flaying-saucer-swt"

### DIFF
--- a/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/Browser.java
+++ b/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/Browser.java
@@ -64,7 +64,7 @@ import org.xhtmlrenderer.demo.browser.swt.actions.PrintPreviewAction;
 import org.xhtmlrenderer.demo.browser.swt.actions.QuitAction;
 import org.xhtmlrenderer.demo.browser.swt.actions.ReloadAction;
 import org.xhtmlrenderer.event.DocumentListener;
-import org.xhtmlrenderer.simple.SWTXHTMLRenderer;
+import org.xhtmlrenderer.swt.simple.SWTXHTMLRenderer;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;

--- a/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/actions/AboutAction.java
+++ b/flying-saucer-swt-examples/src/main/java/org/xhtmlrenderer/demo/browser/swt/actions/AboutAction.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
 import org.xhtmlrenderer.demo.browser.swt.Browser;
 import org.xhtmlrenderer.demo.browser.swt.BrowserUserAgent;
-import org.xhtmlrenderer.simple.SWTXHTMLRenderer;
+import org.xhtmlrenderer.swt.simple.SWTXHTMLRenderer;
 
 import javax.annotation.Nullable;
 

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/FormControlReplacementElement.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/FormControlReplacementElement.java
@@ -22,7 +22,7 @@ package org.xhtmlrenderer.swt;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.extend.ReplacedElement;
 import org.xhtmlrenderer.layout.LayoutContext;
-import org.xhtmlrenderer.simple.xhtml.swt.SWTFormControl;
+import org.xhtmlrenderer.swt.simple.SWTFormControl;
 
 import java.awt.*;
 

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTOutputDevice.java
@@ -36,7 +36,7 @@ import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.render.InlineText;
 import org.xhtmlrenderer.render.RenderingContext;
-import org.xhtmlrenderer.simple.xhtml.swt.SWTFormControl;
+import org.xhtmlrenderer.swt.simple.SWTFormControl;
 
 import javax.annotation.Nullable;
 import java.awt.*;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTButtonControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTButtonControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTCheckControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTCheckControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTFormControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTFormControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.widgets.Control;
 import org.xhtmlrenderer.simple.xhtml.FormControl;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTSelectControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTSelectControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTTextControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTTextControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXHTMLRenderer.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXHTMLRenderer.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.widgets.Composite;
 import org.w3c.dom.Document;
@@ -26,7 +26,6 @@ import org.xhtmlrenderer.extend.ReplacedElementFactory;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.simple.xhtml.XhtmlForm;
 import org.xhtmlrenderer.simple.xhtml.XhtmlNamespaceHandler;
-import org.xhtmlrenderer.simple.xhtml.swt.SWTXhtmlReplacedElementFactory;
 import org.xhtmlrenderer.swt.BasicRenderer;
 import org.xhtmlrenderer.swt.CursorListener;
 import org.xhtmlrenderer.swt.HoverListener;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlControl.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlControl.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * }}}
  */
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Device;

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlReplacedElementFactory.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlReplacedElementFactory.java
@@ -1,4 +1,4 @@
-package org.xhtmlrenderer.simple.xhtml.swt;
+package org.xhtmlrenderer.swt.simple;
 
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;


### PR DESCRIPTION


to avoid the collision when the same package is found in two modules ("flaying-saucer-core" and "flaying-saucer-swt"). Java 9 modules doesn't allow such a collision.