### PR TITLE
Overcoming Table Cell and Line Splitting Challenges

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
@@ -41,859 +41,859 @@ import java.util.List;
 import java.util.Set;
 
 public class TableCellBox extends BlockBox {
-	public static final TableCellBox SPANNING_CELL = new TableCellBox();
+    public static final TableCellBox SPANNING_CELL = new TableCellBox();
 
-	private int _row;
-	private int _col;
+    private int _row;
+    private int _col;
 
-	private TableBox _table;
-	private TableSectionBox _section;
+    private TableBox _table;
+    private TableSectionBox _section;
 
-	private BorderPropertySet _collapsedLayoutBorder;
-	private BorderPropertySet _collapsedPaintingBorder;
+    private BorderPropertySet _collapsedLayoutBorder;
+    private BorderPropertySet _collapsedPaintingBorder;
 
-	private CollapsedBorderValue _collapsedBorderTop;
-	private CollapsedBorderValue _collapsedBorderRight;
-	private CollapsedBorderValue _collapsedBorderBottom;
-	private CollapsedBorderValue _collapsedBorderLeft;
+    private CollapsedBorderValue _collapsedBorderTop;
+    private CollapsedBorderValue _collapsedBorderRight;
+    private CollapsedBorderValue _collapsedBorderBottom;
+    private CollapsedBorderValue _collapsedBorderLeft;
 
-	// 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset', 'groove', and the lowest: 'inset'.
+    // 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset', 'groove', and the lowest: 'inset'.
     private static final int[] BORDER_PRIORITIES = new int[IdentValue.getIdentCount()];
 
-	static {
-		BORDER_PRIORITIES[IdentValue.DOUBLE.FS_ID] = 1;
-		BORDER_PRIORITIES[IdentValue.SOLID.FS_ID] = 2;
-		BORDER_PRIORITIES[IdentValue.DASHED.FS_ID] = 3;
-		BORDER_PRIORITIES[IdentValue.DOTTED.FS_ID] = 4;
-		BORDER_PRIORITIES[IdentValue.RIDGE.FS_ID] = 5;
-		BORDER_PRIORITIES[IdentValue.OUTSET.FS_ID] = 6;
-		BORDER_PRIORITIES[IdentValue.GROOVE.FS_ID] = 7;
-		BORDER_PRIORITIES[IdentValue.INSET.FS_ID] = 8;
-	}
+    static {
+        BORDER_PRIORITIES[IdentValue.DOUBLE.FS_ID] = 1;
+        BORDER_PRIORITIES[IdentValue.SOLID.FS_ID] = 2;
+        BORDER_PRIORITIES[IdentValue.DASHED.FS_ID] = 3;
+        BORDER_PRIORITIES[IdentValue.DOTTED.FS_ID] = 4;
+        BORDER_PRIORITIES[IdentValue.RIDGE.FS_ID] = 5;
+        BORDER_PRIORITIES[IdentValue.OUTSET.FS_ID] = 6;
+        BORDER_PRIORITIES[IdentValue.GROOVE.FS_ID] = 7;
+        BORDER_PRIORITIES[IdentValue.INSET.FS_ID] = 8;
+    }
 
-	private static final int BCELL = 10;
-	private static final int BROW = 9;
-	private static final int BROWGROUP = 8;
-	private static final int BCOL = 7;
-	private static final int BTABLE = 6;
+    private static final int BCELL = 10;
+    private static final int BROW = 9;
+    private static final int BROWGROUP = 8;
+    private static final int BCOL = 7;
+    private static final int BTABLE = 6;
 
-	public TableCellBox() {
-	}
+    public TableCellBox() {
+    }
 
-	@Override
-	public BlockBox copyOf() {
-		TableCellBox result = new TableCellBox();
-		result.setStyle(getStyle());
-		result.setElement(getElement());
+    @Override
+    public BlockBox copyOf() {
+        TableCellBox result = new TableCellBox();
+        result.setStyle(getStyle());
+        result.setElement(getElement());
 
-		return result;
-	}
+        return result;
+    }
 
-	@Override
-	public BorderPropertySet getBorder(CssContext cssCtx) {
-		if (getTable().getStyle().isCollapseBorders()) {
-			// Should always be non-null, but might not be if layout code crashed
-			return _collapsedLayoutBorder == null ?
+    @Override
+    public BorderPropertySet getBorder(CssContext cssCtx) {
+        if (getTable().getStyle().isCollapseBorders()) {
+            // Should always be non-null, but might not be if layout code crashed
+            return _collapsedLayoutBorder == null ?
                     BorderPropertySet.EMPTY_BORDER : _collapsedLayoutBorder;
-		} else {
-			return super.getBorder(cssCtx);
-		}
-	}
+        } else {
+            return super.getBorder(cssCtx);
+        }
+    }
 
-	public void calcCollapsedBorder(CssContext c) {
-		CollapsedBorderValue top = collapsedTopBorder(c);
-		CollapsedBorderValue right = collapsedRightBorder(c);
-		CollapsedBorderValue bottom = collapsedBottomBorder(c);
-		CollapsedBorderValue left = collapsedLeftBorder(c);
+    public void calcCollapsedBorder(CssContext c) {
+        CollapsedBorderValue top = collapsedTopBorder(c);
+        CollapsedBorderValue right = collapsedRightBorder(c);
+        CollapsedBorderValue bottom = collapsedBottomBorder(c);
+        CollapsedBorderValue left = collapsedLeftBorder(c);
 
-		_collapsedPaintingBorder = new BorderPropertySet(top, right, bottom, left);
+        _collapsedPaintingBorder = new BorderPropertySet(top, right, bottom, left);
 
-		// Give the extra pixel to top and left.
-		top.setWidth((top.width() + 1) / 2);
-		right.setWidth(right.width() / 2);
-		bottom.setWidth(bottom.width() / 2);
-		left.setWidth((left.width() + 1) / 2);
+        // Give the extra pixel to top and left.
+        top.setWidth((top.width() + 1) / 2);
+        right.setWidth(right.width() / 2);
+        bottom.setWidth(bottom.width() / 2);
+        left.setWidth((left.width() + 1) / 2);
 
-		_collapsedLayoutBorder = new BorderPropertySet(top, right, bottom, left);
+        _collapsedLayoutBorder = new BorderPropertySet(top, right, bottom, left);
 
-		_collapsedBorderTop = top;
-		_collapsedBorderRight = right;
-		_collapsedBorderBottom = bottom;
-		_collapsedBorderLeft = left;
-	}
+        _collapsedBorderTop = top;
+        _collapsedBorderRight = right;
+        _collapsedBorderBottom = bottom;
+        _collapsedBorderLeft = left;
+    }
 
-	public int getCol() {
-		return _col;
-	}
+    public int getCol() {
+        return _col;
+    }
 
-	public void setCol(int col) {
-		_col = col;
-	}
+    public void setCol(int col) {
+        _col = col;
+    }
 
-	public int getRow() {
-		return _row;
-	}
+    public int getRow() {
+        return _row;
+    }
 
-	public void setRow(int row) {
-		_row = row;
-	}
+    public void setRow(int row) {
+        _row = row;
+    }
 
-	@Override
-	public void layout(LayoutContext c) {
-		super.layout(c);
-	}
+    @Override
+    public void layout(LayoutContext c) {
+        super.layout(c);
+    }
 
-	public TableBox getTable() {
-		// cell -> row -> section -> table
-		if (_table == null) {
-			_table = (TableBox) getParent().getParent().getParent();
-		}
-		return _table;
-	}
+    public TableBox getTable() {
+        // cell -> row -> section -> table
+        if (_table == null) {
+            _table = (TableBox) getParent().getParent().getParent();
+        }
+        return _table;
+    }
 
-	protected TableSectionBox getSection() {
-		if (_section == null) {
-			_section = (TableSectionBox) getParent().getParent();
-		}
-		return _section;
-	}
+    protected TableSectionBox getSection() {
+        if (_section == null) {
+            _section = (TableSectionBox) getParent().getParent();
+        }
+        return _section;
+    }
 
-	public Length getOuterStyleWidth(CssContext c) {
-		Length result = getStyle().asLength(c, CSSName.WIDTH);
-		if (result.isVariable() || result.isPercent()) {
-			return result;
-		}
+    public Length getOuterStyleWidth(CssContext c) {
+        Length result = getStyle().asLength(c, CSSName.WIDTH);
+        if (result.isVariable() || result.isPercent()) {
+            return result;
+        }
 
-		int bordersAndPadding = 0;
-		BorderPropertySet border = getBorder(c);
-		bordersAndPadding += (int) border.left() + (int) border.right();
+        int bordersAndPadding = 0;
+        BorderPropertySet border = getBorder(c);
+        bordersAndPadding += (int) border.left() + (int) border.right();
 
-		RectPropertySet padding = getPadding(c);
-		bordersAndPadding += (int) padding.left() + (int) padding.right();
+        RectPropertySet padding = getPadding(c);
+        bordersAndPadding += (int) padding.left() + (int) padding.right();
 
-		result.setValue(result.value() + bordersAndPadding);
+        result.setValue(result.value() + bordersAndPadding);
 
-		return result;
-	}
+        return result;
+    }
 
-	public Length getOuterStyleOrColWidth(CssContext c) {
-		Length result = getOuterStyleWidth(c);
-		if (getStyle().getColSpan() > 1 || !result.isVariable()) {
-			return result;
-		}
-		TableColumn col = getTable().colElement(getCol());
-		if (col != null) {
-			// XXX Need to add in collapsed borders from cell (if collapsing borders)
-			result = col.getStyle().asLength(c, CSSName.WIDTH);
-		}
-		return result;
-	}
+    public Length getOuterStyleOrColWidth(CssContext c) {
+        Length result = getOuterStyleWidth(c);
+        if (getStyle().getColSpan() > 1 || !result.isVariable()) {
+            return result;
+        }
+        TableColumn col = getTable().colElement(getCol());
+        if (col != null) {
+            // XXX Need to add in collapsed borders from cell (if collapsing borders)
+            result = col.getStyle().asLength(c, CSSName.WIDTH);
+        }
+        return result;
+    }
 
-	public void setLayoutWidth(LayoutContext c, int width) {
-		calcDimensions(c);
+    public void setLayoutWidth(LayoutContext c, int width) {
+        calcDimensions(c);
 
-		setContentWidth(width - getLeftMBP() - getRightMBP());
-	}
+        setContentWidth(width - getLeftMBP() - getRightMBP());
+    }
 
-	@Override
-	public boolean isAutoHeight() {
-		return getStyle().isAutoHeight() || !getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
-	}
+    @Override
+    public boolean isAutoHeight() {
+        return getStyle().isAutoHeight() || !getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
+    }
 
-	@Override
-	public int calcBaseline(LayoutContext c) {
-		int result = super.calcBaseline(c);
-		if (result != NO_BASELINE) {
-			return result;
-		} else {
-			Rectangle contentArea = getContentAreaEdge(getAbsX(), getAbsY(), c);
-			return (int) contentArea.getY();
-		}
-	}
+    @Override
+    public int calcBaseline(LayoutContext c) {
+        int result = super.calcBaseline(c);
+        if (result != NO_BASELINE) {
+            return result;
+        } else {
+            Rectangle contentArea = getContentAreaEdge(getAbsX(), getAbsY(), c);
+            return (int) contentArea.getY();
+        }
+    }
 
-	public int calcBlockBaseline(LayoutContext c) {
-		return super.calcBaseline(c);
-	}
+    public int calcBlockBaseline(LayoutContext c) {
+        return super.calcBaseline(c);
+    }
 
-	public void moveContent(final int deltaY) {
-		for (int i = 0; i < getChildCount(); i++) {
-			Box b = getChild(i);
-			b.setY(b.getY() + deltaY);
-		}
+    public void moveContent(final int deltaY) {
+        for (int i = 0; i < getChildCount(); i++) {
+            Box b = getChild(i);
+            b.setY(b.getY() + deltaY);
+        }
 
         getPersistentBFC().getFloatManager().performFloatOperation(
                 floater -> floater.setY(floater.getY() + deltaY));
 
-		calcChildLocations();
-	}
+        calcChildLocations();
+    }
 
-	public boolean isPageBreaksChange(LayoutContext c, int posDeltaY) {
-		if (!c.isPageBreaksAllowed()) {
-			return false;
-		}
+    public boolean isPageBreaksChange(LayoutContext c, int posDeltaY) {
+        if (!c.isPageBreaksAllowed()) {
+            return false;
+        }
 
-		PageBox page = c.getRootLayer().getFirstPage(c, this);
+        PageBox page = c.getRootLayer().getFirstPage(c, this);
 
-		int bottomEdge = getAbsY() + getChildrenHeight();
+        int bottomEdge = getAbsY() + getChildrenHeight();
 
         return page != null && (bottomEdge >= page.getBottom() - c.getExtraSpaceBottom() ||
                     bottomEdge + posDeltaY >= page.getBottom() - c.getExtraSpaceBottom());
-	}
+    }
 
-	public IdentValue getVerticalAlign() {
-		IdentValue val = getStyle().getIdent(CSSName.VERTICAL_ALIGN);
+    public IdentValue getVerticalAlign() {
+        IdentValue val = getStyle().getIdent(CSSName.VERTICAL_ALIGN);
 
-		if (val == IdentValue.TOP || val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
-			return val;
-		} else {
-			return IdentValue.BASELINE;
-		}
-	}
+        if (val == IdentValue.TOP || val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
+            return val;
+        } else {
+            return IdentValue.BASELINE;
+        }
+    }
 
-	private boolean isPaintBackgroundsAndBorders() {
-		boolean showEmpty = getStyle().isShowEmptyCells();
-		// XXX Not quite right, but good enough for now
-		// (e.g. absolute boxes will be counted as content here when the spec
-		// says the cell should be treated as empty).
-		return showEmpty || getChildrenContentType() != BlockBox.CONTENT_EMPTY;
+    private boolean isPaintBackgroundsAndBorders() {
+        boolean showEmpty = getStyle().isShowEmptyCells();
+        // XXX Not quite right, but good enough for now
+        // (e.g. absolute boxes will be counted as content here when the spec
+        // says the cell should be treated as empty).
+        return showEmpty || getChildrenContentType() != BlockBox.CONTENT_EMPTY;
 
-	}
+    }
 
-	@Override
-	public void paintBackground(RenderingContext c) {
-		if (isPaintBackgroundsAndBorders() && getStyle().isVisible()) {
-			Rectangle bounds;
-			if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
-				bounds = getContentLimitedBorderEdge(c);
-			} else {
-				bounds = getPaintingBorderEdge(c);
-			}
+    @Override
+    public void paintBackground(RenderingContext c) {
+        if (isPaintBackgroundsAndBorders() && getStyle().isVisible()) {
+            Rectangle bounds;
+            if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
+                bounds = getContentLimitedBorderEdge(c);
+            } else {
+                bounds = getPaintingBorderEdge(c);
+            }
 
-			if (bounds != null) {
-				paintBackgroundStack(c, bounds);
-			}
-		}
-	}
+            if (bounds != null) {
+                paintBackgroundStack(c, bounds);
+            }
+        }
+    }
 
-	private void paintBackgroundStack(RenderingContext c, Rectangle bounds) {
-		Rectangle imageContainer;
+    private void paintBackgroundStack(RenderingContext c, Rectangle bounds) {
+        Rectangle imageContainer;
 
-		BorderPropertySet border = getStyle().getBorder(c);
-		TableColumn column = getTable().colElement(getCol());
-		if (column != null) {
+        BorderPropertySet border = getStyle().getBorder(c);
+        TableColumn column = getTable().colElement(getCol());
+        if (column != null) {
             c.getOutputDevice().paintBackground(
                     c, column.getStyle(),
                     bounds, getTable().getColumnBounds(c, getCol()),
-					border);
-		}
+                    border);
+        }
 
-		Box row = getParent();
-		Box section = row.getParent();
+        Box row = getParent();
+        Box section = row.getParent();
 
-		CalculatedStyle tableStyle = getTable().getStyle();
+        CalculatedStyle tableStyle = getTable().getStyle();
 
-		CalculatedStyle sectionStyle = section.getStyle();
+        CalculatedStyle sectionStyle = section.getStyle();
 
-		imageContainer = section.getPaintingBorderEdge(c);
-		imageContainer.y += tableStyle.getBorderVSpacing(c);
-		imageContainer.height -= tableStyle.getBorderVSpacing(c);
-		imageContainer.x += tableStyle.getBorderHSpacing(c);
-		imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
+        imageContainer = section.getPaintingBorderEdge(c);
+        imageContainer.y += tableStyle.getBorderVSpacing(c);
+        imageContainer.height -= tableStyle.getBorderVSpacing(c);
+        imageContainer.x += tableStyle.getBorderHSpacing(c);
+        imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
 
-		c.getOutputDevice().paintBackground(c, sectionStyle, bounds, imageContainer, sectionStyle.getBorder(c));
+        c.getOutputDevice().paintBackground(c, sectionStyle, bounds, imageContainer, sectionStyle.getBorder(c));
 
-		CalculatedStyle rowStyle = row.getStyle();
+        CalculatedStyle rowStyle = row.getStyle();
 
-		imageContainer = row.getPaintingBorderEdge(c);
-		imageContainer.x += tableStyle.getBorderHSpacing(c);
-		imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
+        imageContainer = row.getPaintingBorderEdge(c);
+        imageContainer.x += tableStyle.getBorderHSpacing(c);
+        imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
 
-		c.getOutputDevice().paintBackground(c, rowStyle, bounds, imageContainer, rowStyle.getBorder(c));
-		c.getOutputDevice().paintBackground(c, getStyle(), bounds, getPaintingBorderEdge(c), border);
-	}
+        c.getOutputDevice().paintBackground(c, rowStyle, bounds, imageContainer, rowStyle.getBorder(c));
+        c.getOutputDevice().paintBackground(c, getStyle(), bounds, getPaintingBorderEdge(c), border);
+    }
 
-	@Override
-	public void paintBorder(RenderingContext c) {
-		if (isPaintBackgroundsAndBorders() && !hasCollapsedPaintingBorder()) {
-			// Collapsed table borders are painted separately
-			if (c.isPrint() && getTable().getStyle().isPaginateTable() && getStyle().isVisible()) {
-				Rectangle bounds = getContentLimitedBorderEdge(c);
-				if (bounds != null) {
-					c.getOutputDevice().paintBorder(c, getStyle(), bounds, getBorderSides());
-				}
-			} else {
-				super.paintBorder(c);
-			}
-		}
-	}
+    @Override
+    public void paintBorder(RenderingContext c) {
+        if (isPaintBackgroundsAndBorders() && !hasCollapsedPaintingBorder()) {
+            // Collapsed table borders are painted separately
+            if (c.isPrint() && getTable().getStyle().isPaginateTable() && getStyle().isVisible()) {
+                Rectangle bounds = getContentLimitedBorderEdge(c);
+                if (bounds != null) {
+                    c.getOutputDevice().paintBorder(c, getStyle(), bounds, getBorderSides());
+                }
+            } else {
+                super.paintBorder(c);
+            }
+        }
+    }
 
-	public void paintCollapsedBorder(RenderingContext c, int side) {
+    public void paintCollapsedBorder(RenderingContext c, int side) {
         c.getOutputDevice().paintCollapsedBorder(
                 c, getCollapsedPaintingBorder(), getCollapsedBorderBounds(c), side);
-	}
+    }
 
-	private Rectangle getContentLimitedBorderEdge(RenderingContext c) {
-		Rectangle result = getPaintingBorderEdge(c);
+    private Rectangle getContentLimitedBorderEdge(RenderingContext c) {
+        Rectangle result = getPaintingBorderEdge(c);
 
-		TableSectionBox section = getSection();
-		if (section.isHeader() || section.isFooter()) {
-			return result;
-		}
+        TableSectionBox section = getSection();
+        if (section.isHeader() || section.isFooter()) {
+            return result;
+        }
 
-		ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
+        ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
         ContentLimit limit = contentLimitContainer != null ? contentLimitContainer.getContentLimit(c.getPageNo()) : null;
 
-		if (limit == null) {
-			return null;
-		} else {
+        if (limit == null) {
+            return null;
+        } else {
             if (limit.getTop() == ContentLimit.UNDEFINED ||
                     limit.getBottom() == ContentLimit.UNDEFINED) {
-				return result;
-			}
+                return result;
+            }
 
-			int top;
-			if (c.getPageNo() == contentLimitContainer.getInitialPageNo()) {
-				top = result.y;
-			} else {
-				top = limit.getTop() - ((TableRowBox) getParent()).getExtraSpaceTop();
-			}
+            int top;
+            if (c.getPageNo() == contentLimitContainer.getInitialPageNo()) {
+                top = result.y;
+            } else {
+                top = limit.getTop() - ((TableRowBox) getParent()).getExtraSpaceTop();
+            }
 
-			int bottom;
-			if (c.getPageNo() == contentLimitContainer.getLastPageNo()) {
-				bottom = result.y + result.height;
-			} else {
-				bottom = limit.getBottom() + ((TableRowBox) getParent()).getExtraSpaceBottom();
-			}
+            int bottom;
+            if (c.getPageNo() == contentLimitContainer.getLastPageNo()) {
+                bottom = result.y + result.height;
+            } else {
+                bottom = limit.getBottom() + ((TableRowBox) getParent()).getExtraSpaceBottom();
+            }
 
-			result.y = top;
-			result.height = bottom - top;
+            result.y = top;
+            result.height = bottom - top;
 
-			return result;
-		}
-	}
+            return result;
+        }
+    }
 
-	@Override
-	public Rectangle getChildrenClipEdge(RenderingContext c) {
-		if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
-			Rectangle bounds = getContentLimitedBorderEdge(c);
-			if (bounds != null) {
-				BorderPropertySet border = getBorder(c);
-				RectPropertySet padding = getPadding(c);
-				bounds.y += (int) border.top() + (int) padding.top();
-				bounds.height -= (int) border.height() + (int) padding.height();
-				return bounds;
-			}
-		}
+    @Override
+    public Rectangle getChildrenClipEdge(RenderingContext c) {
+        if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
+            Rectangle bounds = getContentLimitedBorderEdge(c);
+            if (bounds != null) {
+                BorderPropertySet border = getBorder(c);
+                RectPropertySet padding = getPadding(c);
+                bounds.y += (int) border.top() + (int) padding.top();
+                bounds.height -= (int) border.height() + (int) padding.height();
+                return bounds;
+            }
+        }
 
-		return super.getChildrenClipEdge(c);
-	}
+        return super.getChildrenClipEdge(c);
+    }
 
-	@Override
-	protected boolean isFixedWidthAdvisoryOnly() {
-		return getTable().getStyle().isIdent(CSSName.TABLE_LAYOUT, IdentValue.AUTO);
-	}
+    @Override
+    protected boolean isFixedWidthAdvisoryOnly() {
+        return getTable().getStyle().isIdent(CSSName.TABLE_LAYOUT, IdentValue.AUTO);
+    }
 
-	@Override
-	protected boolean isSkipWhenCollapsingMargins() {
-		return true;
-	}
+    @Override
+    protected boolean isSkipWhenCollapsingMargins() {
+        return true;
+    }
 
-	// The following rules apply for resolving conflicts and figuring out which
-	// border
-	// to use.
-	// (1) Borders with the 'border-style' of 'hidden' take precedence over all
-	// other conflicting
-	// borders. Any border with this value suppresses all borders at this
-	// location.
-	// (2) Borders with a style of 'none' have the lowest priority. Only if the
-	// border properties of all
-	// the elements meeting at this edge are 'none' will the border be omitted
-	// (but note that 'none' is
-	// the default value for the border style.)
-	// (3) If none of the styles are 'hidden' and at least one of them is not
-	// 'none', then narrow borders
-	// are discarded in favor of wider ones. If several have the same
-	// 'border-width' then styles are preferred
-	// in this order: 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset',
-	// 'groove', and the lowest: 'inset'.
-	// (4) If border styles differ only in color, then a style set on a cell
-	// wins over one on a row,
-	// which wins over a row group, column, column group and, lastly, table. It
-	// is undefined which color
-	// is used when two elements of the same type disagree.
+    // The following rules apply for resolving conflicts and figuring out which
+    // border
+    // to use.
+    // (1) Borders with the 'border-style' of 'hidden' take precedence over all
+    // other conflicting
+    // borders. Any border with this value suppresses all borders at this
+    // location.
+    // (2) Borders with a style of 'none' have the lowest priority. Only if the
+    // border properties of all
+    // the elements meeting at this edge are 'none' will the border be omitted
+    // (but note that 'none' is
+    // the default value for the border style.)
+    // (3) If none of the styles are 'hidden' and at least one of them is not
+    // 'none', then narrow borders
+    // are discarded in favor of wider ones. If several have the same
+    // 'border-width' then styles are preferred
+    // in this order: 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset',
+    // 'groove', and the lowest: 'inset'.
+    // (4) If border styles differ only in color, then a style set on a cell
+    // wins over one on a row,
+    // which wins over a row group, column, column group and, lastly, table. It
+    // is undefined which color
+    // is used when two elements of the same type disagree.
     public static CollapsedBorderValue compareBorders(
             CollapsedBorderValue border1, CollapsedBorderValue border2, boolean returnNullOnEqual) {
-		// Sanity check the values passed in. If either is null, return the other.
-		if (!border2.defined()) {
-			return border1;
-		}
+        // Sanity check the values passed in. If either is null, return the other.
+        if (!border2.defined()) {
+            return border1;
+        }
 
-		if (!border1.defined()) {
-			return border2;
-		}
+        if (!border1.defined()) {
+            return border2;
+        }
 
-		// Rule #1 above.
+        // Rule #1 above.
         if (border1.style() == IdentValue.HIDDEN)
         {
-			return border1;
-		}
+            return border1;
+        }
         if (border2.style() == IdentValue.HIDDEN)
         {
-			return border2;
-		}
+            return border2;
+        }
 
-		// Rule #2 above. A style of 'none' has the lowest priority and always loses
-		// to any other border.
-		if (border2.style() == IdentValue.NONE) {
-			return border1;
-		}
+        // Rule #2 above. A style of 'none' has the lowest priority and always loses
+        // to any other border.
+        if (border2.style() == IdentValue.NONE) {
+            return border1;
+        }
 
-		if (border1.style() == IdentValue.NONE) {
-			return border2;
-		}
+        if (border1.style() == IdentValue.NONE) {
+            return border2;
+        }
 
-		// The first part of rule #3 above. Wider borders win.
-		if (border1.width() != border2.width()) {
-			return border1.width() > border2.width() ? border1 : border2;
-		}
+        // The first part of rule #3 above. Wider borders win.
+        if (border1.width() != border2.width()) {
+            return border1.width() > border2.width() ? border1 : border2;
+        }
 
-		// The borders have equal width. Sort by border style.
-		if (border1.style() != border2.style()) {
+        // The borders have equal width. Sort by border style.
+        if (border1.style() != border2.style()) {
             return BORDER_PRIORITIES[border1.style().FS_ID] >
                 BORDER_PRIORITIES[border2.style().FS_ID] ? border1 : border2;
-		}
+        }
 
-		// The border have the same width and style. Rely on precedence (cell
-		// over row group, etc.)
-		if (returnNullOnEqual && border1.precedence() == border2.precedence()) {
-			return null;
-		} else {
-			return border1.precedence() >= border2.precedence() ? border1 : border2;
-		}
-	}
+        // The border have the same width and style. Rely on precedence (cell
+        // over row group, etc.)
+        if (returnNullOnEqual && border1.precedence() == border2.precedence()) {
+            return null;
+        } else {
+            return border1.precedence() >= border2.precedence() ? border1 : border2;
+        }
+    }
 
     private static CollapsedBorderValue compareBorders(
             CollapsedBorderValue border1, CollapsedBorderValue border2) {
-		return compareBorders(border1, border2, false);
-	}
+        return compareBorders(border1, border2, false);
+    }
 
-	private CollapsedBorderValue collapsedLeftBorder(CssContext c) {
-		BorderPropertySet border = getStyle().getBorder(c);
-		// For border left, we need to check, in order of precedence:
-		// (1) Our left border.
-		CollapsedBorderValue result = CollapsedBorderValue.borderLeft(border, BCELL);
+    private CollapsedBorderValue collapsedLeftBorder(CssContext c) {
+        BorderPropertySet border = getStyle().getBorder(c);
+        // For border left, we need to check, in order of precedence:
+        // (1) Our left border.
+        CollapsedBorderValue result = CollapsedBorderValue.borderLeft(border, BCELL);
 
-		// (2) The previous cell's right border.
-		TableCellBox prevCell = getTable().cellLeft(this);
-		if (prevCell != null) {
+        // (2) The previous cell's right border.
+        TableCellBox prevCell = getTable().cellLeft(this);
+        if (prevCell != null) {
             result = compareBorders(
                     result, CollapsedBorderValue.borderRight(prevCell.getStyle().getBorder(c), BCELL));
-			if (result.hidden()) {
-				return result;
-			}
-		} else if (getCol() == 0) {
-			// (3) Our row's left border.
+            if (result.hidden()) {
+                return result;
+            }
+        } else if (getCol() == 0) {
+            // (3) Our row's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getParent().getStyle().getBorder(c), BROW));
-			if (result.hidden()) {
-				return result;
-			}
+            if (result.hidden()) {
+                return result;
+            }
 
-			// (4) Our row group's left border.
+            // (4) Our row group's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getSection().getStyle().getBorder(c), BROWGROUP));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (5) Our column's left border.
-		TableColumn colElt = getTable().colElement(getCol());
-		if (colElt != null) {
+        // (5) Our column's left border.
+        TableColumn colElt = getTable().colElement(getCol());
+        if (colElt != null) {
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(colElt.getStyle().getBorder(c), BCOL));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (6) The previous column's right border.
-		if (getCol() > 0) {
-			if (getStyle().getRowSpan() > 1) {
-				return result;
-			}
-			colElt = getTable().colElement(getCol() - 1);
-			if (colElt != null) {
+        // (6) The previous column's right border.
+        if (getCol() > 0) {
+            if (getStyle().getRowSpan() > 1) {
+                return result;
+            }
+            colElt = getTable().colElement(getCol() - 1);
+            if (colElt != null) {
                 result = compareBorders(
                         result, CollapsedBorderValue.borderRight(colElt.getStyle().getBorder(c), BCOL));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		}
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        }
 
-		if (getCol() == 0) {
-			// (7) The table's left border.
+        if (getCol() == 0) {
+            // (7) The table's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getTable().getStyle().getBorder(c), BTABLE));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private CollapsedBorderValue collapsedRightBorder(CssContext c) {
-		TableBox tableElt = getTable();
-		boolean inLastColumn = false;
-		int effCol = tableElt.colToEffCol(getCol() + getStyle().getColSpan() - 1);
-		if (effCol == tableElt.numEffCols() - 1) {
-			inLastColumn = true;
-		}
+    private CollapsedBorderValue collapsedRightBorder(CssContext c) {
+        TableBox tableElt = getTable();
+        boolean inLastColumn = false;
+        int effCol = tableElt.colToEffCol(getCol() + getStyle().getColSpan() - 1);
+        if (effCol == tableElt.numEffCols() - 1) {
+            inLastColumn = true;
+        }
 
-		// For border right, we need to check, in order of precedence:
-		// (1) Our right border.
+        // For border right, we need to check, in order of precedence:
+        // (1) Our right border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderRight(getStyle().getBorder(c), BCELL);
 
-		// (2) The next cell's left border.
-		if (!inLastColumn) {
-			if (getStyle().getRowSpan() > 1) {
-				return result;
-			}
-			TableCellBox nextCell = tableElt.cellRight(this);
-			if (nextCell != null) {
-				result = compareBorders(result,
-						CollapsedBorderValue.borderLeft(nextCell.getStyle().getBorder(c), BCELL));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		} else {
-			// (3) Our row's right border.
-			result = compareBorders(result,
-					CollapsedBorderValue.borderRight(getParent().getStyle().getBorder(c), BROW));
-			if (result.hidden()) {
-				return result;
-			}
+        // (2) The next cell's left border.
+        if (!inLastColumn) {
+            if (getStyle().getRowSpan() > 1) {
+                return result;
+            }
+            TableCellBox nextCell = tableElt.cellRight(this);
+            if (nextCell != null) {
+                result = compareBorders(result,
+                        CollapsedBorderValue.borderLeft(nextCell.getStyle().getBorder(c), BCELL));
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        } else {
+            // (3) Our row's right border.
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderRight(getParent().getStyle().getBorder(c), BROW));
+            if (result.hidden()) {
+                return result;
+            }
 
-			// (4) Our row group's right border.
-			result = compareBorders(result,
-					CollapsedBorderValue.borderRight(getSection().getStyle().getBorder(c), BROWGROUP));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            // (4) Our row group's right border.
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderRight(getSection().getStyle().getBorder(c), BROWGROUP));
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (5) Our column's right border.
-		TableColumn colElt = getTable().colElement(getCol() + getStyle().getColSpan() - 1);
-		if (colElt != null) {
+        // (5) Our column's right border.
+        TableColumn colElt = getTable().colElement(getCol() + getStyle().getColSpan() - 1);
+        if (colElt != null) {
             result = compareBorders(result,
                     CollapsedBorderValue.borderRight(colElt.getStyle().getBorder(c), BCOL));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (6) The next column's left border.
-		if (!inLastColumn) {
-			colElt = tableElt.colElement(getCol() + getStyle().getColSpan());
-			if (colElt != null) {
+        // (6) The next column's left border.
+        if (!inLastColumn) {
+            colElt = tableElt.colElement(getCol() + getStyle().getColSpan());
+            if (colElt != null) {
                 result = compareBorders(result,
                         CollapsedBorderValue.borderLeft(colElt.getStyle().getBorder(c), BCOL));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		} else {
-			// (7) The table's right border.
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        } else {
+            // (7) The table's right border.
             result = compareBorders(result,
                     CollapsedBorderValue.borderRight(tableElt.getStyle().getBorder(c), BTABLE));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private CollapsedBorderValue collapsedTopBorder(CssContext c) {
-		// For border top, we need to check, in order of precedence:
-		// (1) Our top border.
+    private CollapsedBorderValue collapsedTopBorder(CssContext c) {
+        // For border top, we need to check, in order of precedence:
+        // (1) Our top border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderTop(getStyle().getBorder(c), BCELL);
 
-		TableCellBox prevCell = getTable().cellAbove(this);
-		if (prevCell != null) {
-			// (2) A previous cell's bottom border.
+        TableCellBox prevCell = getTable().cellAbove(this);
+        if (prevCell != null) {
+            // (2) A previous cell's bottom border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderBottom(prevCell.getStyle().getBorder(c), BCELL));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (3) Our row's top border.
+        // (3) Our row's top border.
         result = compareBorders(result,
                     CollapsedBorderValue.borderTop(getParent().getStyle().getBorder(c), BROW));
-		if (result.hidden()) {
-			return result;
-		}
+        if (result.hidden()) {
+            return result;
+        }
 
-		// (4) The previous row's bottom border.
-		if (prevCell != null) {
-			final TableRowBox prevRow;
-			if (prevCell.getSection() == getSection()) {
-				prevRow = (TableRowBox) getParent().getPreviousSibling();
-			} else {
-				prevRow = prevCell.getSection().getLastRow();
-			}
+        // (4) The previous row's bottom border.
+        if (prevCell != null) {
+            final TableRowBox prevRow;
+            if (prevCell.getSection() == getSection()) {
+                prevRow = (TableRowBox) getParent().getPreviousSibling();
+            } else {
+                prevRow = prevCell.getSection().getLastRow();
+            }
 
-			if (prevRow != null) {
-				result = compareBorders(result,
-						CollapsedBorderValue.borderBottom(prevRow.getStyle().getBorder(c), BROW));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		}
+            if (prevRow != null) {
+                result = compareBorders(result,
+                        CollapsedBorderValue.borderBottom(prevRow.getStyle().getBorder(c), BROW));
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        }
 
-		// Now check row groups.
-		TableSectionBox currSection = getSection();
-		if (getRow() == 0) {
-			// (5) Our row group's top border.
-			result = compareBorders(result,
-					CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
-			if (result.hidden()) {
-				return result;
-			}
+        // Now check row groups.
+        TableSectionBox currSection = getSection();
+        if (getRow() == 0) {
+            // (5) Our row group's top border.
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
+            if (result.hidden()) {
+                return result;
+            }
 
-			// (6) Previous row group's bottom border.
-			currSection = getTable().sectionAbove(currSection, false);
-			if (currSection != null) {
-				result = compareBorders(result,
-						CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		}
+            // (6) Previous row group's bottom border.
+            currSection = getTable().sectionAbove(currSection, false);
+            if (currSection != null) {
+                result = compareBorders(result,
+                        CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        }
 
-		if (currSection == null) {
-			// (8) Our column's top border.
-			TableColumn colElt = getTable().colElement(getCol());
-			if (colElt != null) {
+        if (currSection == null) {
+            // (8) Our column's top border.
+            TableColumn colElt = getTable().colElement(getCol());
+            if (colElt != null) {
                 result = compareBorders(result,
                             CollapsedBorderValue.borderTop(colElt.getStyle().getBorder(c), BCOL));
-				if (result.hidden()) {
-					return result;
-				}
-			}
+                if (result.hidden()) {
+                    return result;
+                }
+            }
 
-			// (9) The table's top border.
+            // (9) The table's top border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderTop(getTable().getStyle().getBorder(c), BTABLE));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private CollapsedBorderValue collapsedBottomBorder(CssContext c) {
-		// For border top, we need to check, in order of precedence:
-		// (1) Our bottom border.
+    private CollapsedBorderValue collapsedBottomBorder(CssContext c) {
+        // For border top, we need to check, in order of precedence:
+        // (1) Our bottom border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderBottom(getStyle().getBorder(c), BCELL);
 
-		TableCellBox nextCell = getTable().cellBelow(this);
-		if (nextCell != null) {
-			// (2) A following cell's top border.
+        TableCellBox nextCell = getTable().cellBelow(this);
+        if (nextCell != null) {
+            // (2) A following cell's top border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderTop(nextCell.getStyle().getBorder(c), BCELL));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// (3) Our row's bottom border. (FIXME: Deal with rowspan!)
+        // (3) Our row's bottom border. (FIXME: Deal with rowspan!)
         result = compareBorders(result,
                     CollapsedBorderValue.borderBottom(getParent().getStyle().getBorder(c), BROW));
-		if (result.hidden()) {
-			return result;
-		}
+        if (result.hidden()) {
+            return result;
+        }
 
-		// (4) The next row's top border.
-		if (nextCell != null) {
-			result = compareBorders(result,
-					CollapsedBorderValue.borderTop(nextCell.getParent().getStyle().getBorder(c), BROW));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+        // (4) The next row's top border.
+        if (nextCell != null) {
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderTop(nextCell.getParent().getStyle().getBorder(c), BROW));
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		// Now check row groups.
-		TableSectionBox currSection = getSection();
-		if (getRow() + getStyle().getRowSpan() >= currSection.numRows()) {
-			// (5) Our row group's bottom border.
-			result = compareBorders(result,
-					CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
-			if (result.hidden()) {
-				return result;
-			}
+        // Now check row groups.
+        TableSectionBox currSection = getSection();
+        if (getRow() + getStyle().getRowSpan() >= currSection.numRows()) {
+            // (5) Our row group's bottom border.
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
+            if (result.hidden()) {
+                return result;
+            }
 
-			// (6) Following row group's top border.
-			currSection = getTable().sectionBelow(currSection, false);
-			if (currSection != null) {
-				result = compareBorders(result,
-						CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
-				if (result.hidden()) {
-					return result;
-				}
-			}
-		}
+            // (6) Following row group's top border.
+            currSection = getTable().sectionBelow(currSection, false);
+            if (currSection != null) {
+                result = compareBorders(result,
+                        CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
+                if (result.hidden()) {
+                    return result;
+                }
+            }
+        }
 
-		if (currSection == null) {
-			// (8) Our column's bottom border.
-			TableColumn colElt = getTable().colElement(getCol());
-			if (colElt != null) {
-				result = compareBorders(result,
-						CollapsedBorderValue.borderBottom(colElt.getStyle().getBorder(c), BCOL));
-				if (result.hidden()) {
-					return result;
-				}
-			}
+        if (currSection == null) {
+            // (8) Our column's bottom border.
+            TableColumn colElt = getTable().colElement(getCol());
+            if (colElt != null) {
+                result = compareBorders(result,
+                        CollapsedBorderValue.borderBottom(colElt.getStyle().getBorder(c), BCOL));
+                if (result.hidden()) {
+                    return result;
+                }
+            }
 
-			// (9) The table's bottom border.
-			result = compareBorders(result,
-					CollapsedBorderValue.borderBottom(getTable().getStyle().getBorder(c), BTABLE));
-			if (result.hidden()) {
-				return result;
-			}
-		}
+            // (9) The table's bottom border.
+            result = compareBorders(result,
+                    CollapsedBorderValue.borderBottom(getTable().getStyle().getBorder(c), BTABLE));
+            if (result.hidden()) {
+                return result;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private Rectangle getCollapsedBorderBounds(CssContext c) {
-		BorderPropertySet border = getCollapsedPaintingBorder();
-		Rectangle bounds = getPaintingBorderEdge(c);
-		bounds.x -= (int) border.left() / 2;
-		bounds.y -= (int) border.top() / 2;
-		bounds.width += (int) border.left() / 2 + ((int) border.right() + 1) / 2;
-		bounds.height += (int) border.top() / 2 + ((int) border.bottom() + 1) / 2;
+    private Rectangle getCollapsedBorderBounds(CssContext c) {
+        BorderPropertySet border = getCollapsedPaintingBorder();
+        Rectangle bounds = getPaintingBorderEdge(c);
+        bounds.x -= (int) border.left() / 2;
+        bounds.y -= (int) border.top() / 2;
+        bounds.width += (int) border.left() / 2 + ((int) border.right() + 1) / 2;
+        bounds.height += (int) border.top() / 2 + ((int) border.bottom() + 1) / 2;
 
-		return bounds;
-	}
+        return bounds;
+    }
 
-	@Override
-	public Rectangle getPaintingClipEdge(CssContext c) {
-		if (hasCollapsedPaintingBorder()) {
-			return getCollapsedBorderBounds(c);
-		} else {
-			return super.getPaintingClipEdge(c);
-		}
-	}
+    @Override
+    public Rectangle getPaintingClipEdge(CssContext c) {
+        if (hasCollapsedPaintingBorder()) {
+            return getCollapsedBorderBounds(c);
+        } else {
+            return super.getPaintingClipEdge(c);
+        }
+    }
 
-	public boolean hasCollapsedPaintingBorder() {
-		return _collapsedPaintingBorder != null;
-	}
+    public boolean hasCollapsedPaintingBorder() {
+        return _collapsedPaintingBorder != null;
+    }
 
-	protected BorderPropertySet getCollapsedPaintingBorder() {
-		return _collapsedPaintingBorder;
-	}
+    protected BorderPropertySet getCollapsedPaintingBorder() {
+        return _collapsedPaintingBorder;
+    }
 
-	public CollapsedBorderValue getCollapsedBorderBottom() {
-		return _collapsedBorderBottom;
-	}
+    public CollapsedBorderValue getCollapsedBorderBottom() {
+        return _collapsedBorderBottom;
+    }
 
-	public CollapsedBorderValue getCollapsedBorderLeft() {
-		return _collapsedBorderLeft;
-	}
+    public CollapsedBorderValue getCollapsedBorderLeft() {
+        return _collapsedBorderLeft;
+    }
 
-	public CollapsedBorderValue getCollapsedBorderRight() {
-		return _collapsedBorderRight;
-	}
+    public CollapsedBorderValue getCollapsedBorderRight() {
+        return _collapsedBorderRight;
+    }
 
-	public CollapsedBorderValue getCollapsedBorderTop() {
-		return _collapsedBorderTop;
-	}
+    public CollapsedBorderValue getCollapsedBorderTop() {
+        return _collapsedBorderTop;
+    }
 
-	public void addCollapsedBorders(Set<CollapsedBorderValue> all, List<CollapsedBorderSide> borders) {
-		if (_collapsedBorderTop.exists() && !all.contains(_collapsedBorderTop)) {
-			all.add(_collapsedBorderTop);
-			borders.add(new CollapsedBorderSide(this, BorderPainter.TOP));
-		}
+    public void addCollapsedBorders(Set<CollapsedBorderValue> all, List<CollapsedBorderSide> borders) {
+        if (_collapsedBorderTop.exists() && !all.contains(_collapsedBorderTop)) {
+            all.add(_collapsedBorderTop);
+            borders.add(new CollapsedBorderSide(this, BorderPainter.TOP));
+        }
 
-		if (_collapsedBorderRight.exists() && !all.contains(_collapsedBorderRight)) {
-			all.add(_collapsedBorderRight);
-			borders.add(new CollapsedBorderSide(this, BorderPainter.RIGHT));
-		}
+        if (_collapsedBorderRight.exists() && !all.contains(_collapsedBorderRight)) {
+            all.add(_collapsedBorderRight);
+            borders.add(new CollapsedBorderSide(this, BorderPainter.RIGHT));
+        }
 
-		if (_collapsedBorderBottom.exists() && !all.contains(_collapsedBorderBottom)) {
-			all.add(_collapsedBorderBottom);
-			borders.add(new CollapsedBorderSide(this, BorderPainter.BOTTOM));
-		}
+        if (_collapsedBorderBottom.exists() && !all.contains(_collapsedBorderBottom)) {
+            all.add(_collapsedBorderBottom);
+            borders.add(new CollapsedBorderSide(this, BorderPainter.BOTTOM));
+        }
 
-		if (_collapsedBorderLeft.exists() && !all.contains(_collapsedBorderLeft)) {
-			all.add(_collapsedBorderLeft);
-			borders.add(new CollapsedBorderSide(this, BorderPainter.LEFT));
-		}
-	}
+        if (_collapsedBorderLeft.exists() && !all.contains(_collapsedBorderLeft)) {
+            all.add(_collapsedBorderLeft);
+            borders.add(new CollapsedBorderSide(this, BorderPainter.LEFT));
+        }
+    }
 
-	// Treat height as if it specifies border height (i.e.
-	// box-sizing: border-box in CSS3). There doesn't seem to be any
-	// justification in the spec for this, but everybody does it
-	// (in standards mode) so I guess we will too
-	@Override
-	protected int getCSSHeight(CssContext c) {
-		if (getStyle().isAutoHeight()) {
-			return -1;
-		} else {
+    // Treat height as if it specifies border height (i.e.
+    // box-sizing: border-box in CSS3). There doesn't seem to be any
+    // justification in the spec for this, but everybody does it
+    // (in standards mode) so I guess we will too
+    @Override
+    protected int getCSSHeight(CssContext c) {
+        if (getStyle().isAutoHeight()) {
+            return -1;
+        } else {
             int result = (int)getStyle().getFloatPropertyProportionalWidth(
                     CSSName.HEIGHT, getContainingBlock().getContentWidth(), c);
 
-			BorderPropertySet border = getBorder(c);
-			result -= (int) border.top() + (int) border.bottom();
+            BorderPropertySet border = getBorder(c);
+            result -= (int) border.top() + (int) border.bottom();
 
-			RectPropertySet padding = getPadding(c);
-			result -= (int) padding.top() + (int) padding.bottom();
+            RectPropertySet padding = getPadding(c);
+            result -= (int) padding.top() + (int) padding.bottom();
 
-			return result >= 0 ? result : -1;
-		}
-	}
+            return result >= 0 ? result : -1;
+        }
+    }
 
-	@Override
-	protected boolean isAllowHeightToShrink() {
-		return false;
-	}
+    @Override
+    protected boolean isAllowHeightToShrink() {
+        return false;
+    }
 
-	@Override
-	public boolean isNeedsClipOnPaint(RenderingContext c) {
-		boolean result = super.isNeedsClipOnPaint(c);
-		if (result) {
-			return result;
-		}
-		ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
-		if (contentLimitContainer == null) {
-			return false;
-		}
+    @Override
+    public boolean isNeedsClipOnPaint(RenderingContext c) {
+        boolean result = super.isNeedsClipOnPaint(c);
+        if (result) {
+            return result;
+        }
+        ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
+        if (contentLimitContainer == null) {
+            return false;
+        }
         return c.isPrint() && getTable().getStyle().isPaginateTable() &&
             contentLimitContainer.isContainsMultiplePages();
-	}
+    }
 
-	private int fixedHeight;
-	public void setFixedHeight(int fixedHeight) {
-		this.fixedHeight = fixedHeight;
-	}
-	
-	@Override
-	public void setHeight(int height) {
-		if (height != 0 && fixedHeight > 0) {
-			height = fixedHeight;
-		}
-		super.setHeight(height);
-	}
+    private int fixedHeight;
+    public void setFixedHeight(int fixedHeight) {
+        this.fixedHeight = fixedHeight;
+    }
+    
+    @Override
+    public void setHeight(int height) {
+        if (height != 0 && fixedHeight > 0) {
+            height = fixedHeight;
+        }
+        super.setHeight(height);
+    }
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
@@ -41,840 +41,859 @@ import java.util.List;
 import java.util.Set;
 
 public class TableCellBox extends BlockBox {
-    public static final TableCellBox SPANNING_CELL = new TableCellBox();
+	public static final TableCellBox SPANNING_CELL = new TableCellBox();
 
-    private int _row;
-    private int _col;
+	private int _row;
+	private int _col;
 
-    private TableBox _table;
-    private TableSectionBox _section;
+	private TableBox _table;
+	private TableSectionBox _section;
 
-    private BorderPropertySet _collapsedLayoutBorder;
-    private BorderPropertySet _collapsedPaintingBorder;
+	private BorderPropertySet _collapsedLayoutBorder;
+	private BorderPropertySet _collapsedPaintingBorder;
 
-    private CollapsedBorderValue _collapsedBorderTop;
-    private CollapsedBorderValue _collapsedBorderRight;
-    private CollapsedBorderValue _collapsedBorderBottom;
-    private CollapsedBorderValue _collapsedBorderLeft;
+	private CollapsedBorderValue _collapsedBorderTop;
+	private CollapsedBorderValue _collapsedBorderRight;
+	private CollapsedBorderValue _collapsedBorderBottom;
+	private CollapsedBorderValue _collapsedBorderLeft;
 
-    // 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset', 'groove', and the lowest: 'inset'.
+	// 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset', 'groove', and the lowest: 'inset'.
     private static final int[] BORDER_PRIORITIES = new int[IdentValue.getIdentCount()];
 
-    static {
-        BORDER_PRIORITIES[IdentValue.DOUBLE.FS_ID] = 1;
-        BORDER_PRIORITIES[IdentValue.SOLID.FS_ID] = 2;
-        BORDER_PRIORITIES[IdentValue.DASHED.FS_ID] = 3;
-        BORDER_PRIORITIES[IdentValue.DOTTED.FS_ID] = 4;
-        BORDER_PRIORITIES[IdentValue.RIDGE.FS_ID] = 5;
-        BORDER_PRIORITIES[IdentValue.OUTSET.FS_ID] = 6;
-        BORDER_PRIORITIES[IdentValue.GROOVE.FS_ID] = 7;
-        BORDER_PRIORITIES[IdentValue.INSET.FS_ID] = 8;
-    }
+	static {
+		BORDER_PRIORITIES[IdentValue.DOUBLE.FS_ID] = 1;
+		BORDER_PRIORITIES[IdentValue.SOLID.FS_ID] = 2;
+		BORDER_PRIORITIES[IdentValue.DASHED.FS_ID] = 3;
+		BORDER_PRIORITIES[IdentValue.DOTTED.FS_ID] = 4;
+		BORDER_PRIORITIES[IdentValue.RIDGE.FS_ID] = 5;
+		BORDER_PRIORITIES[IdentValue.OUTSET.FS_ID] = 6;
+		BORDER_PRIORITIES[IdentValue.GROOVE.FS_ID] = 7;
+		BORDER_PRIORITIES[IdentValue.INSET.FS_ID] = 8;
+	}
 
-    private static final int BCELL = 10;
-    private static final int BROW = 9;
-    private static final int BROWGROUP = 8;
-    private static final int BCOL = 7;
-    private static final int BTABLE = 6;
+	private static final int BCELL = 10;
+	private static final int BROW = 9;
+	private static final int BROWGROUP = 8;
+	private static final int BCOL = 7;
+	private static final int BTABLE = 6;
 
-    public TableCellBox() {
-    }
+	public TableCellBox() {
+	}
 
-    @Override
-    public BlockBox copyOf() {
-        TableCellBox result = new TableCellBox();
-        result.setStyle(getStyle());
-        result.setElement(getElement());
+	@Override
+	public BlockBox copyOf() {
+		TableCellBox result = new TableCellBox();
+		result.setStyle(getStyle());
+		result.setElement(getElement());
 
-        return result;
-    }
+		return result;
+	}
 
-    @Override
-    public BorderPropertySet getBorder(CssContext cssCtx) {
-        if (getTable().getStyle().isCollapseBorders()) {
-            // Should always be non-null, but might not be if layout code crashed
-            return _collapsedLayoutBorder == null ?
+	@Override
+	public BorderPropertySet getBorder(CssContext cssCtx) {
+		if (getTable().getStyle().isCollapseBorders()) {
+			// Should always be non-null, but might not be if layout code crashed
+			return _collapsedLayoutBorder == null ?
                     BorderPropertySet.EMPTY_BORDER : _collapsedLayoutBorder;
-        } else {
-            return super.getBorder(cssCtx);
-        }
-    }
+		} else {
+			return super.getBorder(cssCtx);
+		}
+	}
 
-    public void calcCollapsedBorder(CssContext c) {
-        CollapsedBorderValue top = collapsedTopBorder(c);
-        CollapsedBorderValue right = collapsedRightBorder(c);
-        CollapsedBorderValue bottom = collapsedBottomBorder(c);
-        CollapsedBorderValue left = collapsedLeftBorder(c);
+	public void calcCollapsedBorder(CssContext c) {
+		CollapsedBorderValue top = collapsedTopBorder(c);
+		CollapsedBorderValue right = collapsedRightBorder(c);
+		CollapsedBorderValue bottom = collapsedBottomBorder(c);
+		CollapsedBorderValue left = collapsedLeftBorder(c);
 
-        _collapsedPaintingBorder = new BorderPropertySet(top, right, bottom, left);
+		_collapsedPaintingBorder = new BorderPropertySet(top, right, bottom, left);
 
-        // Give the extra pixel to top and left.
-        top.setWidth((top.width()+1)/2);
-        right.setWidth(right.width()/2);
-        bottom.setWidth(bottom.width()/2);
-        left.setWidth((left.width()+1)/2);
+		// Give the extra pixel to top and left.
+		top.setWidth((top.width() + 1) / 2);
+		right.setWidth(right.width() / 2);
+		bottom.setWidth(bottom.width() / 2);
+		left.setWidth((left.width() + 1) / 2);
 
-        _collapsedLayoutBorder = new BorderPropertySet(top, right, bottom, left);
+		_collapsedLayoutBorder = new BorderPropertySet(top, right, bottom, left);
 
-        _collapsedBorderTop = top;
-        _collapsedBorderRight = right;
-        _collapsedBorderBottom = bottom;
-        _collapsedBorderLeft = left;
-    }
+		_collapsedBorderTop = top;
+		_collapsedBorderRight = right;
+		_collapsedBorderBottom = bottom;
+		_collapsedBorderLeft = left;
+	}
 
-    public int getCol() {
-        return _col;
-    }
+	public int getCol() {
+		return _col;
+	}
 
-    public void setCol(int col) {
-        _col = col;
-    }
+	public void setCol(int col) {
+		_col = col;
+	}
 
-    public int getRow() {
-        return _row;
-    }
+	public int getRow() {
+		return _row;
+	}
 
-    public void setRow(int row) {
-        _row = row;
-    }
+	public void setRow(int row) {
+		_row = row;
+	}
 
-    @Override
-    public void layout(LayoutContext c) {
-        super.layout(c);
-    }
+	@Override
+	public void layout(LayoutContext c) {
+		super.layout(c);
+	}
 
-    public TableBox getTable() {
-        // cell -> row -> section -> table
-        if (_table == null) {
-            _table = (TableBox)getParent().getParent().getParent();
-        }
-        return _table;
-    }
+	public TableBox getTable() {
+		// cell -> row -> section -> table
+		if (_table == null) {
+			_table = (TableBox) getParent().getParent().getParent();
+		}
+		return _table;
+	}
 
-    protected TableSectionBox getSection() {
-        if (_section == null) {
-            _section = (TableSectionBox)getParent().getParent();
-        }
-        return _section;
-    }
+	protected TableSectionBox getSection() {
+		if (_section == null) {
+			_section = (TableSectionBox) getParent().getParent();
+		}
+		return _section;
+	}
 
-    public Length getOuterStyleWidth(CssContext c) {
-        Length result = getStyle().asLength(c, CSSName.WIDTH);
-        if (result.isVariable() || result.isPercent()) {
-            return result;
-        }
+	public Length getOuterStyleWidth(CssContext c) {
+		Length result = getStyle().asLength(c, CSSName.WIDTH);
+		if (result.isVariable() || result.isPercent()) {
+			return result;
+		}
 
-        int bordersAndPadding = 0;
-        BorderPropertySet border = getBorder(c);
-        bordersAndPadding += (int)border.left() + (int)border.right();
+		int bordersAndPadding = 0;
+		BorderPropertySet border = getBorder(c);
+		bordersAndPadding += (int) border.left() + (int) border.right();
 
-        RectPropertySet padding = getPadding(c);
-        bordersAndPadding += (int)padding.left() + (int)padding.right();
+		RectPropertySet padding = getPadding(c);
+		bordersAndPadding += (int) padding.left() + (int) padding.right();
 
-        result.setValue(result.value() + bordersAndPadding);
+		result.setValue(result.value() + bordersAndPadding);
 
-        return result;
-    }
+		return result;
+	}
 
-    public Length getOuterStyleOrColWidth(CssContext c) {
-        Length result = getOuterStyleWidth(c);
-        if (getStyle().getColSpan() > 1 || ! result.isVariable()) {
-            return result;
-        }
-        TableColumn col = getTable().colElement(getCol());
-        if (col != null) {
-            // XXX Need to add in collapsed borders from cell (if collapsing borders)
-            result = col.getStyle().asLength(c, CSSName.WIDTH);
-        }
-        return result;
-    }
+	public Length getOuterStyleOrColWidth(CssContext c) {
+		Length result = getOuterStyleWidth(c);
+		if (getStyle().getColSpan() > 1 || !result.isVariable()) {
+			return result;
+		}
+		TableColumn col = getTable().colElement(getCol());
+		if (col != null) {
+			// XXX Need to add in collapsed borders from cell (if collapsing borders)
+			result = col.getStyle().asLength(c, CSSName.WIDTH);
+		}
+		return result;
+	}
 
-    public void setLayoutWidth(LayoutContext c, int width) {
-        calcDimensions(c);
+	public void setLayoutWidth(LayoutContext c, int width) {
+		calcDimensions(c);
 
-        setContentWidth(width - getLeftMBP() - getRightMBP());
-    }
+		setContentWidth(width - getLeftMBP() - getRightMBP());
+	}
 
-    @Override
-    public boolean isAutoHeight() {
-        return getStyle().isAutoHeight() || ! getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
-    }
+	@Override
+	public boolean isAutoHeight() {
+		return getStyle().isAutoHeight() || !getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
+	}
 
-    @Override
-    public int calcBaseline(LayoutContext c) {
-        int result = super.calcBaseline(c);
-        if (result != NO_BASELINE) {
-            return result;
-        } else {
-            Rectangle contentArea = getContentAreaEdge(getAbsX(), getAbsY(), c);
-            return (int)contentArea.getY();
-        }
-    }
+	@Override
+	public int calcBaseline(LayoutContext c) {
+		int result = super.calcBaseline(c);
+		if (result != NO_BASELINE) {
+			return result;
+		} else {
+			Rectangle contentArea = getContentAreaEdge(getAbsX(), getAbsY(), c);
+			return (int) contentArea.getY();
+		}
+	}
 
-    public int calcBlockBaseline(LayoutContext c) {
-        return super.calcBaseline(c);
-    }
+	public int calcBlockBaseline(LayoutContext c) {
+		return super.calcBaseline(c);
+	}
 
-    public void moveContent(final int deltaY) {
-        for (int i = 0; i < getChildCount(); i++) {
-            Box b = getChild(i);
-            b.setY(b.getY() + deltaY);
-        }
+	public void moveContent(final int deltaY) {
+		for (int i = 0; i < getChildCount(); i++) {
+			Box b = getChild(i);
+			b.setY(b.getY() + deltaY);
+		}
 
         getPersistentBFC().getFloatManager().performFloatOperation(
                 floater -> floater.setY(floater.getY() + deltaY));
 
-        calcChildLocations();
-    }
+		calcChildLocations();
+	}
 
-    public boolean isPageBreaksChange(LayoutContext c, int posDeltaY) {
-        if (! c.isPageBreaksAllowed()) {
-            return false;
-        }
+	public boolean isPageBreaksChange(LayoutContext c, int posDeltaY) {
+		if (!c.isPageBreaksAllowed()) {
+			return false;
+		}
 
-        PageBox page = c.getRootLayer().getFirstPage(c, this);
+		PageBox page = c.getRootLayer().getFirstPage(c, this);
 
-        int bottomEdge = getAbsY() + getChildrenHeight();
+		int bottomEdge = getAbsY() + getChildrenHeight();
 
         return page != null && (bottomEdge >= page.getBottom() - c.getExtraSpaceBottom() ||
                     bottomEdge + posDeltaY >= page.getBottom() - c.getExtraSpaceBottom());
-    }
+	}
 
-    public IdentValue getVerticalAlign() {
-        IdentValue val = getStyle().getIdent(CSSName.VERTICAL_ALIGN);
+	public IdentValue getVerticalAlign() {
+		IdentValue val = getStyle().getIdent(CSSName.VERTICAL_ALIGN);
 
-        if (val == IdentValue.TOP || val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
-            return val;
-        } else {
-            return IdentValue.BASELINE;
-        }
-    }
+		if (val == IdentValue.TOP || val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
+			return val;
+		} else {
+			return IdentValue.BASELINE;
+		}
+	}
 
-    private boolean isPaintBackgroundsAndBorders() {
-        boolean showEmpty = getStyle().isShowEmptyCells();
-        // XXX Not quite right, but good enough for now
-        // (e.g. absolute boxes will be counted as content here when the spec
-        // says the cell should be treated as empty).
-        return showEmpty || getChildrenContentType() != BlockBox.CONTENT_EMPTY;
+	private boolean isPaintBackgroundsAndBorders() {
+		boolean showEmpty = getStyle().isShowEmptyCells();
+		// XXX Not quite right, but good enough for now
+		// (e.g. absolute boxes will be counted as content here when the spec
+		// says the cell should be treated as empty).
+		return showEmpty || getChildrenContentType() != BlockBox.CONTENT_EMPTY;
 
-    }
+	}
 
-    @Override
-    public void paintBackground(RenderingContext c) {
-        if (isPaintBackgroundsAndBorders() && getStyle().isVisible()) {
-            Rectangle bounds;
-            if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
-                bounds = getContentLimitedBorderEdge(c);
-            } else {
-                bounds = getPaintingBorderEdge(c);
-            }
+	@Override
+	public void paintBackground(RenderingContext c) {
+		if (isPaintBackgroundsAndBorders() && getStyle().isVisible()) {
+			Rectangle bounds;
+			if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
+				bounds = getContentLimitedBorderEdge(c);
+			} else {
+				bounds = getPaintingBorderEdge(c);
+			}
 
-            if (bounds != null) {
-                paintBackgroundStack(c, bounds);
-            }
-        }
-    }
+			if (bounds != null) {
+				paintBackgroundStack(c, bounds);
+			}
+		}
+	}
 
-    private void paintBackgroundStack(RenderingContext c, Rectangle bounds) {
-        Rectangle imageContainer;
+	private void paintBackgroundStack(RenderingContext c, Rectangle bounds) {
+		Rectangle imageContainer;
 
-        BorderPropertySet border = getStyle().getBorder(c);
-        TableColumn column = getTable().colElement(getCol());
-        if (column != null) {
+		BorderPropertySet border = getStyle().getBorder(c);
+		TableColumn column = getTable().colElement(getCol());
+		if (column != null) {
             c.getOutputDevice().paintBackground(
                     c, column.getStyle(),
                     bounds, getTable().getColumnBounds(c, getCol()),
-                    border);
-        }
+					border);
+		}
 
-        Box row = getParent();
-        Box section = row.getParent();
+		Box row = getParent();
+		Box section = row.getParent();
 
-        CalculatedStyle tableStyle = getTable().getStyle();
+		CalculatedStyle tableStyle = getTable().getStyle();
 
-        CalculatedStyle sectionStyle = section.getStyle();
+		CalculatedStyle sectionStyle = section.getStyle();
 
-        imageContainer = section.getPaintingBorderEdge(c);
-        imageContainer.y += tableStyle.getBorderVSpacing(c);
-        imageContainer.height -= tableStyle.getBorderVSpacing(c);
-        imageContainer.x += tableStyle.getBorderHSpacing(c);
-        imageContainer.width -= 2*tableStyle.getBorderHSpacing(c);
+		imageContainer = section.getPaintingBorderEdge(c);
+		imageContainer.y += tableStyle.getBorderVSpacing(c);
+		imageContainer.height -= tableStyle.getBorderVSpacing(c);
+		imageContainer.x += tableStyle.getBorderHSpacing(c);
+		imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
 
-        c.getOutputDevice().paintBackground(c, sectionStyle, bounds, imageContainer, sectionStyle.getBorder(c));
+		c.getOutputDevice().paintBackground(c, sectionStyle, bounds, imageContainer, sectionStyle.getBorder(c));
 
-        CalculatedStyle rowStyle = row.getStyle();
+		CalculatedStyle rowStyle = row.getStyle();
 
-        imageContainer = row.getPaintingBorderEdge(c);
-        imageContainer.x += tableStyle.getBorderHSpacing(c);
-        imageContainer.width -= 2*tableStyle.getBorderHSpacing(c);
+		imageContainer = row.getPaintingBorderEdge(c);
+		imageContainer.x += tableStyle.getBorderHSpacing(c);
+		imageContainer.width -= 2 * tableStyle.getBorderHSpacing(c);
 
-        c.getOutputDevice().paintBackground(c, rowStyle, bounds, imageContainer, rowStyle.getBorder(c));
-        c.getOutputDevice().paintBackground(c, getStyle(), bounds, getPaintingBorderEdge(c), border);
-    }
+		c.getOutputDevice().paintBackground(c, rowStyle, bounds, imageContainer, rowStyle.getBorder(c));
+		c.getOutputDevice().paintBackground(c, getStyle(), bounds, getPaintingBorderEdge(c), border);
+	}
 
-    @Override
-    public void paintBorder(RenderingContext c) {
-        if (isPaintBackgroundsAndBorders() && ! hasCollapsedPaintingBorder()) {
-            // Collapsed table borders are painted separately
-            if (c.isPrint() && getTable().getStyle().isPaginateTable() && getStyle().isVisible()) {
-                Rectangle bounds = getContentLimitedBorderEdge(c);
-                if (bounds != null) {
-                    c.getOutputDevice().paintBorder(c, getStyle(), bounds, getBorderSides());
-                }
-            } else {
-                super.paintBorder(c);
-            }
-        }
-    }
+	@Override
+	public void paintBorder(RenderingContext c) {
+		if (isPaintBackgroundsAndBorders() && !hasCollapsedPaintingBorder()) {
+			// Collapsed table borders are painted separately
+			if (c.isPrint() && getTable().getStyle().isPaginateTable() && getStyle().isVisible()) {
+				Rectangle bounds = getContentLimitedBorderEdge(c);
+				if (bounds != null) {
+					c.getOutputDevice().paintBorder(c, getStyle(), bounds, getBorderSides());
+				}
+			} else {
+				super.paintBorder(c);
+			}
+		}
+	}
 
-    public void paintCollapsedBorder(RenderingContext c, int side) {
+	public void paintCollapsedBorder(RenderingContext c, int side) {
         c.getOutputDevice().paintCollapsedBorder(
                 c, getCollapsedPaintingBorder(), getCollapsedBorderBounds(c), side);
-    }
+	}
 
-    private Rectangle getContentLimitedBorderEdge(RenderingContext c) {
-        Rectangle result = getPaintingBorderEdge(c);
+	private Rectangle getContentLimitedBorderEdge(RenderingContext c) {
+		Rectangle result = getPaintingBorderEdge(c);
 
-        TableSectionBox section = getSection();
-        if (section.isHeader() || section.isFooter()) {
-            return result;
-        }
+		TableSectionBox section = getSection();
+		if (section.isHeader() || section.isFooter()) {
+			return result;
+		}
 
-        ContentLimitContainer contentLimitContainer = ((TableRowBox)getParent()).getContentLimitContainer();
+		ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
         ContentLimit limit = contentLimitContainer != null ? contentLimitContainer.getContentLimit(c.getPageNo()) : null;
 
-        if (limit == null) {
-            return null;
-        } else {
+		if (limit == null) {
+			return null;
+		} else {
             if (limit.getTop() == ContentLimit.UNDEFINED ||
                     limit.getBottom() == ContentLimit.UNDEFINED) {
-                return result;
-            }
+				return result;
+			}
 
-            int top;
-            if (c.getPageNo() == contentLimitContainer.getInitialPageNo()) {
-                top = result.y;
-            } else {
-                top = limit.getTop() - ((TableRowBox)getParent()).getExtraSpaceTop() ;
-            }
+			int top;
+			if (c.getPageNo() == contentLimitContainer.getInitialPageNo()) {
+				top = result.y;
+			} else {
+				top = limit.getTop() - ((TableRowBox) getParent()).getExtraSpaceTop();
+			}
 
-            int bottom;
-            if (c.getPageNo() == contentLimitContainer.getLastPageNo()) {
-                bottom = result.y + result.height;
-            } else {
-                bottom = limit.getBottom() + ((TableRowBox)getParent()).getExtraSpaceBottom();
-            }
+			int bottom;
+			if (c.getPageNo() == contentLimitContainer.getLastPageNo()) {
+				bottom = result.y + result.height;
+			} else {
+				bottom = limit.getBottom() + ((TableRowBox) getParent()).getExtraSpaceBottom();
+			}
 
-            result.y = top;
-            result.height = bottom - top;
+			result.y = top;
+			result.height = bottom - top;
 
-            return result;
-        }
-    }
+			return result;
+		}
+	}
 
-    @Override
-    public Rectangle getChildrenClipEdge(RenderingContext c) {
-        if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
-            Rectangle bounds = getContentLimitedBorderEdge(c);
-            if (bounds != null) {
-                BorderPropertySet border = getBorder(c);
-                RectPropertySet padding = getPadding(c);
-                bounds.y += (int)border.top() + (int)padding.top();
-                bounds.height -= (int)border.height() + (int)padding.height();
-                return bounds;
-            }
-        }
+	@Override
+	public Rectangle getChildrenClipEdge(RenderingContext c) {
+		if (c.isPrint() && getTable().getStyle().isPaginateTable()) {
+			Rectangle bounds = getContentLimitedBorderEdge(c);
+			if (bounds != null) {
+				BorderPropertySet border = getBorder(c);
+				RectPropertySet padding = getPadding(c);
+				bounds.y += (int) border.top() + (int) padding.top();
+				bounds.height -= (int) border.height() + (int) padding.height();
+				return bounds;
+			}
+		}
 
-        return super.getChildrenClipEdge(c);
-    }
+		return super.getChildrenClipEdge(c);
+	}
 
-    @Override
-    protected boolean isFixedWidthAdvisoryOnly() {
-        return getTable().getStyle().isIdent(CSSName.TABLE_LAYOUT, IdentValue.AUTO);
-    }
+	@Override
+	protected boolean isFixedWidthAdvisoryOnly() {
+		return getTable().getStyle().isIdent(CSSName.TABLE_LAYOUT, IdentValue.AUTO);
+	}
 
-    @Override
-    protected boolean isSkipWhenCollapsingMargins() {
-        return true;
-    }
+	@Override
+	protected boolean isSkipWhenCollapsingMargins() {
+		return true;
+	}
 
-    // The following rules apply for resolving conflicts and figuring out which
-    // border
-    // to use.
-    // (1) Borders with the 'border-style' of 'hidden' take precedence over all
-    // other conflicting
-    // borders. Any border with this value suppresses all borders at this
-    // location.
-    // (2) Borders with a style of 'none' have the lowest priority. Only if the
-    // border properties of all
-    // the elements meeting at this edge are 'none' will the border be omitted
-    // (but note that 'none' is
-    // the default value for the border style.)
-    // (3) If none of the styles are 'hidden' and at least one of them is not
-    // 'none', then narrow borders
-    // are discarded in favor of wider ones. If several have the same
-    // 'border-width' then styles are preferred
-    // in this order: 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset',
-    // 'groove', and the lowest: 'inset'.
-    // (4) If border styles differ only in color, then a style set on a cell
-    // wins over one on a row,
-    // which wins over a row group, column, column group and, lastly, table. It
-    // is undefined which color
-    // is used when two elements of the same type disagree.
+	// The following rules apply for resolving conflicts and figuring out which
+	// border
+	// to use.
+	// (1) Borders with the 'border-style' of 'hidden' take precedence over all
+	// other conflicting
+	// borders. Any border with this value suppresses all borders at this
+	// location.
+	// (2) Borders with a style of 'none' have the lowest priority. Only if the
+	// border properties of all
+	// the elements meeting at this edge are 'none' will the border be omitted
+	// (but note that 'none' is
+	// the default value for the border style.)
+	// (3) If none of the styles are 'hidden' and at least one of them is not
+	// 'none', then narrow borders
+	// are discarded in favor of wider ones. If several have the same
+	// 'border-width' then styles are preferred
+	// in this order: 'double', 'solid', 'dashed', 'dotted', 'ridge', 'outset',
+	// 'groove', and the lowest: 'inset'.
+	// (4) If border styles differ only in color, then a style set on a cell
+	// wins over one on a row,
+	// which wins over a row group, column, column group and, lastly, table. It
+	// is undefined which color
+	// is used when two elements of the same type disagree.
     public static CollapsedBorderValue compareBorders(
             CollapsedBorderValue border1, CollapsedBorderValue border2, boolean returnNullOnEqual) {
-        // Sanity check the values passed in.  If either is null, return the other.
-        if (!border2.defined()) {
-            return border1;
-        }
+		// Sanity check the values passed in. If either is null, return the other.
+		if (!border2.defined()) {
+			return border1;
+		}
 
-        if (!border1.defined()) {
-            return border2;
-        }
+		if (!border1.defined()) {
+			return border2;
+		}
 
-        // Rule #1 above.
+		// Rule #1 above.
         if (border1.style() == IdentValue.HIDDEN)
         {
-            return border1;
-        }
+			return border1;
+		}
         if (border2.style() == IdentValue.HIDDEN)
         {
-            return border2;
-        }
+			return border2;
+		}
 
-        // Rule #2 above. A style of 'none' has the lowest priority and always loses
-        // to any other border.
-        if (border2.style() == IdentValue.NONE) {
-            return border1;
-        }
+		// Rule #2 above. A style of 'none' has the lowest priority and always loses
+		// to any other border.
+		if (border2.style() == IdentValue.NONE) {
+			return border1;
+		}
 
-        if (border1.style() == IdentValue.NONE) {
-            return border2;
-        }
+		if (border1.style() == IdentValue.NONE) {
+			return border2;
+		}
 
-        // The first part of rule #3 above. Wider borders win.
-        if (border1.width() != border2.width()) {
-            return border1.width() > border2.width() ? border1 : border2;
-        }
+		// The first part of rule #3 above. Wider borders win.
+		if (border1.width() != border2.width()) {
+			return border1.width() > border2.width() ? border1 : border2;
+		}
 
-        // The borders have equal width. Sort by border style.
-        if (border1.style() != border2.style()) {
+		// The borders have equal width. Sort by border style.
+		if (border1.style() != border2.style()) {
             return BORDER_PRIORITIES[border1.style().FS_ID] >
                 BORDER_PRIORITIES[border2.style().FS_ID] ? border1 : border2;
-        }
+		}
 
-        // The border have the same width and style. Rely on precedence (cell
-        // over row group, etc.)
-        if (returnNullOnEqual && border1.precedence() == border2.precedence()) {
-            return null;
-        } else {
-            return border1.precedence() >= border2.precedence() ? border1 : border2;
-        }
-    }
+		// The border have the same width and style. Rely on precedence (cell
+		// over row group, etc.)
+		if (returnNullOnEqual && border1.precedence() == border2.precedence()) {
+			return null;
+		} else {
+			return border1.precedence() >= border2.precedence() ? border1 : border2;
+		}
+	}
 
     private static CollapsedBorderValue compareBorders(
             CollapsedBorderValue border1, CollapsedBorderValue border2) {
-        return compareBorders(border1, border2, false);
-    }
+		return compareBorders(border1, border2, false);
+	}
 
-    private CollapsedBorderValue collapsedLeftBorder(CssContext c) {
-        BorderPropertySet border = getStyle().getBorder(c);
-        // For border left, we need to check, in order of precedence:
-        // (1) Our left border.
-        CollapsedBorderValue result = CollapsedBorderValue.borderLeft(border, BCELL);
+	private CollapsedBorderValue collapsedLeftBorder(CssContext c) {
+		BorderPropertySet border = getStyle().getBorder(c);
+		// For border left, we need to check, in order of precedence:
+		// (1) Our left border.
+		CollapsedBorderValue result = CollapsedBorderValue.borderLeft(border, BCELL);
 
-        // (2) The previous cell's right border.
-        TableCellBox prevCell = getTable().cellLeft(this);
-        if (prevCell != null) {
+		// (2) The previous cell's right border.
+		TableCellBox prevCell = getTable().cellLeft(this);
+		if (prevCell != null) {
             result = compareBorders(
                     result, CollapsedBorderValue.borderRight(prevCell.getStyle().getBorder(c), BCELL));
-            if (result.hidden()) {
-                return result;
-            }
-        } else if (getCol() == 0) {
-            // (3) Our row's left border.
+			if (result.hidden()) {
+				return result;
+			}
+		} else if (getCol() == 0) {
+			// (3) Our row's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getParent().getStyle().getBorder(c), BROW));
-            if (result.hidden()) {
-                return result;
-            }
+			if (result.hidden()) {
+				return result;
+			}
 
-            // (4) Our row group's left border.
+			// (4) Our row group's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getSection().getStyle().getBorder(c), BROWGROUP));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (5) Our column's left border.
-        TableColumn colElt = getTable().colElement(getCol());
-        if (colElt != null) {
+		// (5) Our column's left border.
+		TableColumn colElt = getTable().colElement(getCol());
+		if (colElt != null) {
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(colElt.getStyle().getBorder(c), BCOL));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (6) The previous column's right border.
-        if (getCol() > 0) {
-            colElt = getTable().colElement(getCol() - 1);
-            if (colElt != null) {
+		// (6) The previous column's right border.
+		if (getCol() > 0) {
+			if (getStyle().getRowSpan() > 1) {
+				return result;
+			}
+			colElt = getTable().colElement(getCol() - 1);
+			if (colElt != null) {
                 result = compareBorders(
                         result, CollapsedBorderValue.borderRight(colElt.getStyle().getBorder(c), BCOL));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        }
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		}
 
-        if (getCol() == 0) {
-            // (7) The table's left border.
+		if (getCol() == 0) {
+			// (7) The table's left border.
             result = compareBorders(
                     result, CollapsedBorderValue.borderLeft(getTable().getStyle().getBorder(c), BTABLE));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    private CollapsedBorderValue collapsedRightBorder(CssContext c) {
-        TableBox tableElt = getTable();
-        boolean inLastColumn = false;
-        int effCol = tableElt.colToEffCol(getCol() + getStyle().getColSpan() - 1);
-        if (effCol == tableElt.numEffCols() - 1) {
-            inLastColumn = true;
-        }
+	private CollapsedBorderValue collapsedRightBorder(CssContext c) {
+		TableBox tableElt = getTable();
+		boolean inLastColumn = false;
+		int effCol = tableElt.colToEffCol(getCol() + getStyle().getColSpan() - 1);
+		if (effCol == tableElt.numEffCols() - 1) {
+			inLastColumn = true;
+		}
 
-        // For border right, we need to check, in order of precedence:
-        // (1) Our right border.
+		// For border right, we need to check, in order of precedence:
+		// (1) Our right border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderRight(getStyle().getBorder(c), BCELL);
 
-        // (2) The next cell's left border.
-        if (!inLastColumn) {
-            TableCellBox nextCell = tableElt.cellRight(this);
-            if (nextCell != null) {
-                result = compareBorders(result,
-                        CollapsedBorderValue.borderLeft(nextCell.getStyle().getBorder(c), BCELL));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        } else {
-            // (3) Our row's right border.
-            result = compareBorders(result,
-                    CollapsedBorderValue.borderRight(getParent().getStyle().getBorder(c), BROW));
-            if (result.hidden()) {
-                return result;
-            }
+		// (2) The next cell's left border.
+		if (!inLastColumn) {
+			if (getStyle().getRowSpan() > 1) {
+				return result;
+			}
+			TableCellBox nextCell = tableElt.cellRight(this);
+			if (nextCell != null) {
+				result = compareBorders(result,
+						CollapsedBorderValue.borderLeft(nextCell.getStyle().getBorder(c), BCELL));
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		} else {
+			// (3) Our row's right border.
+			result = compareBorders(result,
+					CollapsedBorderValue.borderRight(getParent().getStyle().getBorder(c), BROW));
+			if (result.hidden()) {
+				return result;
+			}
 
-            // (4) Our row group's right border.
-            result = compareBorders(result,
-                    CollapsedBorderValue.borderRight(getSection().getStyle().getBorder(c), BROWGROUP));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			// (4) Our row group's right border.
+			result = compareBorders(result,
+					CollapsedBorderValue.borderRight(getSection().getStyle().getBorder(c), BROWGROUP));
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (5) Our column's right border.
-        TableColumn colElt = getTable().colElement(getCol() + getStyle().getColSpan() - 1);
-        if (colElt != null) {
+		// (5) Our column's right border.
+		TableColumn colElt = getTable().colElement(getCol() + getStyle().getColSpan() - 1);
+		if (colElt != null) {
             result = compareBorders(result,
                     CollapsedBorderValue.borderRight(colElt.getStyle().getBorder(c), BCOL));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (6) The next column's left border.
-        if (!inLastColumn) {
-            colElt = tableElt.colElement(getCol() + getStyle().getColSpan());
-            if (colElt != null) {
+		// (6) The next column's left border.
+		if (!inLastColumn) {
+			colElt = tableElt.colElement(getCol() + getStyle().getColSpan());
+			if (colElt != null) {
                 result = compareBorders(result,
                         CollapsedBorderValue.borderLeft(colElt.getStyle().getBorder(c), BCOL));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        } else {
-            // (7) The table's right border.
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		} else {
+			// (7) The table's right border.
             result = compareBorders(result,
                     CollapsedBorderValue.borderRight(tableElt.getStyle().getBorder(c), BTABLE));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    private CollapsedBorderValue collapsedTopBorder(CssContext c) {
-        // For border top, we need to check, in order of precedence:
-        // (1) Our top border.
+	private CollapsedBorderValue collapsedTopBorder(CssContext c) {
+		// For border top, we need to check, in order of precedence:
+		// (1) Our top border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderTop(getStyle().getBorder(c), BCELL);
 
-        TableCellBox prevCell = getTable().cellAbove(this);
-        if (prevCell != null) {
-            // (2) A previous cell's bottom border.
+		TableCellBox prevCell = getTable().cellAbove(this);
+		if (prevCell != null) {
+			// (2) A previous cell's bottom border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderBottom(prevCell.getStyle().getBorder(c), BCELL));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (3) Our row's top border.
+		// (3) Our row's top border.
         result = compareBorders(result,
                     CollapsedBorderValue.borderTop(getParent().getStyle().getBorder(c), BROW));
-        if (result.hidden()) {
-            return result;
-        }
+		if (result.hidden()) {
+			return result;
+		}
 
-        // (4) The previous row's bottom border.
-        if (prevCell != null) {
-            final TableRowBox prevRow;
-            if (prevCell.getSection() == getSection()) {
-                prevRow = (TableRowBox) getParent().getPreviousSibling();
-            } else {
-                prevRow = prevCell.getSection().getLastRow();
-            }
+		// (4) The previous row's bottom border.
+		if (prevCell != null) {
+			final TableRowBox prevRow;
+			if (prevCell.getSection() == getSection()) {
+				prevRow = (TableRowBox) getParent().getPreviousSibling();
+			} else {
+				prevRow = prevCell.getSection().getLastRow();
+			}
 
-            if (prevRow != null) {
-                result = compareBorders(result,
-                            CollapsedBorderValue.borderBottom(prevRow.getStyle().getBorder(c), BROW));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        }
+			if (prevRow != null) {
+				result = compareBorders(result,
+						CollapsedBorderValue.borderBottom(prevRow.getStyle().getBorder(c), BROW));
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		}
 
-        // Now check row groups.
-        TableSectionBox currSection = getSection();
-        if (getRow() == 0) {
-            // (5) Our row group's top border.
-            result = compareBorders(result,
-                        CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
-            if (result.hidden()) {
-                return result;
-            }
+		// Now check row groups.
+		TableSectionBox currSection = getSection();
+		if (getRow() == 0) {
+			// (5) Our row group's top border.
+			result = compareBorders(result,
+					CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
+			if (result.hidden()) {
+				return result;
+			}
 
-            // (6) Previous row group's bottom border.
-            currSection = getTable().sectionAbove(currSection, false);
-            if (currSection != null) {
-                result = compareBorders(result,
-                            CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        }
+			// (6) Previous row group's bottom border.
+			currSection = getTable().sectionAbove(currSection, false);
+			if (currSection != null) {
+				result = compareBorders(result,
+						CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		}
 
-        if (currSection == null) {
-            // (8) Our column's top border.
-            TableColumn colElt = getTable().colElement(getCol());
-            if (colElt != null) {
+		if (currSection == null) {
+			// (8) Our column's top border.
+			TableColumn colElt = getTable().colElement(getCol());
+			if (colElt != null) {
                 result = compareBorders(result,
                             CollapsedBorderValue.borderTop(colElt.getStyle().getBorder(c), BCOL));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
+				if (result.hidden()) {
+					return result;
+				}
+			}
 
-            // (9) The table's top border.
+			// (9) The table's top border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderTop(getTable().getStyle().getBorder(c), BTABLE));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    private CollapsedBorderValue collapsedBottomBorder(CssContext c) {
-        // For border top, we need to check, in order of precedence:
-        // (1) Our bottom border.
+	private CollapsedBorderValue collapsedBottomBorder(CssContext c) {
+		// For border top, we need to check, in order of precedence:
+		// (1) Our bottom border.
         CollapsedBorderValue result =
             CollapsedBorderValue.borderBottom(getStyle().getBorder(c), BCELL);
 
-        TableCellBox nextCell = getTable().cellBelow(this);
-        if (nextCell != null) {
-            // (2) A following cell's top border.
+		TableCellBox nextCell = getTable().cellBelow(this);
+		if (nextCell != null) {
+			// (2) A following cell's top border.
             result = compareBorders(result,
                         CollapsedBorderValue.borderTop(nextCell.getStyle().getBorder(c), BCELL));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // (3) Our row's bottom border. (FIXME: Deal with rowspan!)
+		// (3) Our row's bottom border. (FIXME: Deal with rowspan!)
         result = compareBorders(result,
                     CollapsedBorderValue.borderBottom(getParent().getStyle().getBorder(c), BROW));
-        if (result.hidden()) {
-            return result;
-        }
+		if (result.hidden()) {
+			return result;
+		}
 
-        // (4) The next row's top border.
-        if (nextCell != null) {
-            result = compareBorders(result,
-                        CollapsedBorderValue.borderTop(nextCell.getParent().getStyle().getBorder(c), BROW));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+		// (4) The next row's top border.
+		if (nextCell != null) {
+			result = compareBorders(result,
+					CollapsedBorderValue.borderTop(nextCell.getParent().getStyle().getBorder(c), BROW));
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        // Now check row groups.
-        TableSectionBox currSection = getSection();
-        if (getRow() + getStyle().getRowSpan() >= currSection.numRows()) {
-            // (5) Our row group's bottom border.
-            result = compareBorders(result,
-                        CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
-            if (result.hidden()) {
-                return result;
-            }
+		// Now check row groups.
+		TableSectionBox currSection = getSection();
+		if (getRow() + getStyle().getRowSpan() >= currSection.numRows()) {
+			// (5) Our row group's bottom border.
+			result = compareBorders(result,
+					CollapsedBorderValue.borderBottom(currSection.getStyle().getBorder(c), BROWGROUP));
+			if (result.hidden()) {
+				return result;
+			}
 
-            // (6) Following row group's top border.
-            currSection = getTable().sectionBelow(currSection, false);
-            if (currSection != null) {
-                result = compareBorders(result,
-                            CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
-        }
+			// (6) Following row group's top border.
+			currSection = getTable().sectionBelow(currSection, false);
+			if (currSection != null) {
+				result = compareBorders(result,
+						CollapsedBorderValue.borderTop(currSection.getStyle().getBorder(c), BROWGROUP));
+				if (result.hidden()) {
+					return result;
+				}
+			}
+		}
 
-        if (currSection == null) {
-            // (8) Our column's bottom border.
-            TableColumn colElt = getTable().colElement(getCol());
-            if (colElt != null) {
-                result = compareBorders(result,
-                            CollapsedBorderValue.borderBottom(colElt.getStyle().getBorder(c), BCOL));
-                if (result.hidden()) {
-                    return result;
-                }
-            }
+		if (currSection == null) {
+			// (8) Our column's bottom border.
+			TableColumn colElt = getTable().colElement(getCol());
+			if (colElt != null) {
+				result = compareBorders(result,
+						CollapsedBorderValue.borderBottom(colElt.getStyle().getBorder(c), BCOL));
+				if (result.hidden()) {
+					return result;
+				}
+			}
 
-            // (9) The table's bottom border.
-            result = compareBorders(result,
-                        CollapsedBorderValue.borderBottom(getTable().getStyle().getBorder(c), BTABLE));
-            if (result.hidden()) {
-                return result;
-            }
-        }
+			// (9) The table's bottom border.
+			result = compareBorders(result,
+					CollapsedBorderValue.borderBottom(getTable().getStyle().getBorder(c), BTABLE));
+			if (result.hidden()) {
+				return result;
+			}
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    private Rectangle getCollapsedBorderBounds(CssContext c) {
-        BorderPropertySet border = getCollapsedPaintingBorder();
-        Rectangle bounds = getPaintingBorderEdge(c);
-        bounds.x -= (int) border.left() / 2;
-        bounds.y -= (int) border.top() / 2;
-        bounds.width += (int) border.left() / 2 + ((int) border.right() + 1) / 2;
-        bounds.height += (int) border.top() / 2 + ((int) border.bottom() + 1) / 2;
+	private Rectangle getCollapsedBorderBounds(CssContext c) {
+		BorderPropertySet border = getCollapsedPaintingBorder();
+		Rectangle bounds = getPaintingBorderEdge(c);
+		bounds.x -= (int) border.left() / 2;
+		bounds.y -= (int) border.top() / 2;
+		bounds.width += (int) border.left() / 2 + ((int) border.right() + 1) / 2;
+		bounds.height += (int) border.top() / 2 + ((int) border.bottom() + 1) / 2;
 
-        return bounds;
-    }
+		return bounds;
+	}
 
-    @Override
-    public Rectangle getPaintingClipEdge(CssContext c) {
-        if (hasCollapsedPaintingBorder()) {
-            return getCollapsedBorderBounds(c);
-        } else {
-            return super.getPaintingClipEdge(c);
-        }
-    }
+	@Override
+	public Rectangle getPaintingClipEdge(CssContext c) {
+		if (hasCollapsedPaintingBorder()) {
+			return getCollapsedBorderBounds(c);
+		} else {
+			return super.getPaintingClipEdge(c);
+		}
+	}
 
-    public boolean hasCollapsedPaintingBorder() {
-        return _collapsedPaintingBorder != null;
-    }
+	public boolean hasCollapsedPaintingBorder() {
+		return _collapsedPaintingBorder != null;
+	}
 
-    protected BorderPropertySet getCollapsedPaintingBorder() {
-        return _collapsedPaintingBorder;
-    }
+	protected BorderPropertySet getCollapsedPaintingBorder() {
+		return _collapsedPaintingBorder;
+	}
 
-    public CollapsedBorderValue getCollapsedBorderBottom() {
-        return _collapsedBorderBottom;
-    }
+	public CollapsedBorderValue getCollapsedBorderBottom() {
+		return _collapsedBorderBottom;
+	}
 
-    public CollapsedBorderValue getCollapsedBorderLeft() {
-        return _collapsedBorderLeft;
-    }
+	public CollapsedBorderValue getCollapsedBorderLeft() {
+		return _collapsedBorderLeft;
+	}
 
-    public CollapsedBorderValue getCollapsedBorderRight() {
-        return _collapsedBorderRight;
-    }
+	public CollapsedBorderValue getCollapsedBorderRight() {
+		return _collapsedBorderRight;
+	}
 
-    public CollapsedBorderValue getCollapsedBorderTop() {
-        return _collapsedBorderTop;
-    }
+	public CollapsedBorderValue getCollapsedBorderTop() {
+		return _collapsedBorderTop;
+	}
 
-    public void addCollapsedBorders(Set<CollapsedBorderValue> all, List<CollapsedBorderSide> borders) {
-        if (_collapsedBorderTop.exists() && !all.contains(_collapsedBorderTop)) {
-            all.add(_collapsedBorderTop);
-            borders.add(new CollapsedBorderSide(this, BorderPainter.TOP));
-        }
+	public void addCollapsedBorders(Set<CollapsedBorderValue> all, List<CollapsedBorderSide> borders) {
+		if (_collapsedBorderTop.exists() && !all.contains(_collapsedBorderTop)) {
+			all.add(_collapsedBorderTop);
+			borders.add(new CollapsedBorderSide(this, BorderPainter.TOP));
+		}
 
-        if (_collapsedBorderRight.exists() && !all.contains(_collapsedBorderRight)) {
-            all.add(_collapsedBorderRight);
-            borders.add(new CollapsedBorderSide(this, BorderPainter.RIGHT));
-        }
+		if (_collapsedBorderRight.exists() && !all.contains(_collapsedBorderRight)) {
+			all.add(_collapsedBorderRight);
+			borders.add(new CollapsedBorderSide(this, BorderPainter.RIGHT));
+		}
 
-        if (_collapsedBorderBottom.exists() && !all.contains(_collapsedBorderBottom)) {
-            all.add(_collapsedBorderBottom);
-            borders.add(new CollapsedBorderSide(this, BorderPainter.BOTTOM));
-        }
+		if (_collapsedBorderBottom.exists() && !all.contains(_collapsedBorderBottom)) {
+			all.add(_collapsedBorderBottom);
+			borders.add(new CollapsedBorderSide(this, BorderPainter.BOTTOM));
+		}
 
-        if (_collapsedBorderLeft.exists() && !all.contains(_collapsedBorderLeft)) {
-            all.add(_collapsedBorderLeft);
-            borders.add(new CollapsedBorderSide(this, BorderPainter.LEFT));
-        }
-    }
+		if (_collapsedBorderLeft.exists() && !all.contains(_collapsedBorderLeft)) {
+			all.add(_collapsedBorderLeft);
+			borders.add(new CollapsedBorderSide(this, BorderPainter.LEFT));
+		}
+	}
 
-    // Treat height as if it specifies border height (i.e.
-    // box-sizing: border-box in CSS3).  There doesn't seem to be any
-    // justification in the spec for this, but everybody does it
-    // (in standards mode) so I guess we will too
-    @Override
-    protected int getCSSHeight(CssContext c) {
-        if (getStyle().isAutoHeight()) {
-            return -1;
-        } else {
+	// Treat height as if it specifies border height (i.e.
+	// box-sizing: border-box in CSS3). There doesn't seem to be any
+	// justification in the spec for this, but everybody does it
+	// (in standards mode) so I guess we will too
+	@Override
+	protected int getCSSHeight(CssContext c) {
+		if (getStyle().isAutoHeight()) {
+			return -1;
+		} else {
             int result = (int)getStyle().getFloatPropertyProportionalWidth(
                     CSSName.HEIGHT, getContainingBlock().getContentWidth(), c);
 
-            BorderPropertySet border = getBorder(c);
-            result -= (int)border.top() + (int)border.bottom();
+			BorderPropertySet border = getBorder(c);
+			result -= (int) border.top() + (int) border.bottom();
 
-            RectPropertySet padding = getPadding(c);
-            result -= (int)padding.top() + (int)padding.bottom();
+			RectPropertySet padding = getPadding(c);
+			result -= (int) padding.top() + (int) padding.bottom();
 
-            return result >= 0 ? result : -1;
-        }
-    }
+			return result >= 0 ? result : -1;
+		}
+	}
 
-    @Override
-    protected boolean isAllowHeightToShrink() {
-        return false;
-    }
+	@Override
+	protected boolean isAllowHeightToShrink() {
+		return false;
+	}
 
-    @Override
-    public boolean isNeedsClipOnPaint(RenderingContext c) {
-        boolean result = super.isNeedsClipOnPaint(c);
-        if (result) {
-            return result;
-        }
-        ContentLimitContainer contentLimitContainer = ((TableRowBox)getParent()).getContentLimitContainer();
-        if (contentLimitContainer == null) {
-          return false;
-        }
+	@Override
+	public boolean isNeedsClipOnPaint(RenderingContext c) {
+		boolean result = super.isNeedsClipOnPaint(c);
+		if (result) {
+			return result;
+		}
+		ContentLimitContainer contentLimitContainer = ((TableRowBox) getParent()).getContentLimitContainer();
+		if (contentLimitContainer == null) {
+			return false;
+		}
         return c.isPrint() && getTable().getStyle().isPaginateTable() &&
             contentLimitContainer.isContainsMultiplePages();
-    }
+	}
+
+	private int fixedHeight;
+	public void setFixedHeight(int fixedHeight) {
+		this.fixedHeight = fixedHeight;
+	}
+	
+	@Override
+	public void setHeight(int height) {
+		if (height != 0 && fixedHeight > 0) {
+			height = fixedHeight;
+		}
+		super.setHeight(height);
+	}
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableRowBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableRowBox.java
@@ -40,629 +40,629 @@ import java.util.List;
 import static java.lang.System.lineSeparator;
 
 public class TableRowBox extends BlockBox {
-	private int _baseline;
-	private boolean _haveBaseline;
-	private int _heightOverride;
-	private ContentLimitContainer _contentLimitContainer;
+    private int _baseline;
+    private boolean _haveBaseline;
+    private int _heightOverride;
+    private ContentLimitContainer _contentLimitContainer;
 
-	private int _extraSpaceTop;
-	private int _extraSpaceBottom;
+    private int _extraSpaceTop;
+    private int _extraSpaceBottom;
 
-	public TableRowBox() {
-	}
+    public TableRowBox() {
+    }
 
-	@Override
-	public BlockBox copyOf() {
-		TableRowBox result = new TableRowBox();
-		result.setStyle(getStyle());
-		result.setElement(getElement());
+    @Override
+    public BlockBox copyOf() {
+        TableRowBox result = new TableRowBox();
+        result.setStyle(getStyle());
+        result.setElement(getElement());
 
-		return result;
-	}
+        return result;
+    }
 
-	@Override
-	public boolean isAutoHeight() {
-		return getStyle().isAutoHeight() || !getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
-	}
+    @Override
+    public boolean isAutoHeight() {
+        return getStyle().isAutoHeight() || !getStyle().hasAbsoluteUnit(CSSName.HEIGHT);
+    }
 
-	private TableBox getTable() {
-		// row -> section -> table
-		return (TableBox) getParent().getParent();
-	}
+    private TableBox getTable() {
+        // row -> section -> table
+        return (TableBox) getParent().getParent();
+    }
 
-	private TableSectionBox getSection() {
-		return (TableSectionBox) getParent();
-	}
+    private TableSectionBox getSection() {
+        return (TableSectionBox) getParent();
+    }
 
-	@Override
-	public void layout(LayoutContext c, int contentStart) {
-		boolean running = c.isPrint() && getTable().getStyle().isPaginateTable();
-		int prevExtraTop = 0;
-		int prevExtraBottom = 0;
+    @Override
+    public void layout(LayoutContext c, int contentStart) {
+        boolean running = c.isPrint() && getTable().getStyle().isPaginateTable();
+        int prevExtraTop = 0;
+        int prevExtraBottom = 0;
 
-		if (running) {
-			prevExtraTop = c.getExtraSpaceTop();
-			prevExtraBottom = c.getExtraSpaceBottom();
+        if (running) {
+            prevExtraTop = c.getExtraSpaceTop();
+            prevExtraBottom = c.getExtraSpaceBottom();
 
-			calcExtraSpaceTop(c);
-			calcExtraSpaceBottom(c);
+            calcExtraSpaceTop(c);
+            calcExtraSpaceBottom(c);
 
-			c.setExtraSpaceTop(c.getExtraSpaceTop() + getExtraSpaceTop());
-			c.setExtraSpaceBottom(c.getExtraSpaceBottom() + getExtraSpaceBottom());
-		}
+            c.setExtraSpaceTop(c.getExtraSpaceTop() + getExtraSpaceTop());
+            c.setExtraSpaceBottom(c.getExtraSpaceBottom() + getExtraSpaceBottom());
+        }
 
-		super.layout(c, contentStart);
+        super.layout(c, contentStart);
 
-		if (running) {
-			if (isShouldMoveToNextPage(c)) {
-				if (getTable().getFirstBodyRow() == this) {
-					// XXX Performance problem here. This forces the table
-					// to move to the next page (which we want), but the initial
-					// table layout run still completes (which we don't)
-					getTable().setNeedPageClear(true);
-				} else {
-					if (getIndex() > 0) {
-						List<TableCellBox> crow = ((TableSectionBox) getParent()).getGrid().get(getIndex()).getRow();
-						List<TableCellBox> prow = ((TableSectionBox) getParent()).getGrid().get(getIndex() - 1)
-								.getRow();
-						for (int i = 0; i < crow.size() && i < prow.size(); i++) {
-							TableCellBox ccell = crow.get(i);
-							TableCellBox pcell = prow.get(i);
-							if (ccell != null && ccell != TableCellBox.SPANNING_CELL && ccell == pcell) {
-								TableCellBox ncell = (TableCellBox) pcell.copyOf();
-								ncell.setParent(this);
-								ncell.setRow(getIndex());
-								ncell.setCol(i);
-								addChild(ncell);
-								for (int j = getIndex(); j < ((TableSectionBox) getParent()).getGrid().size(); j++) {
-									List<TableCellBox> nrow = ((TableSectionBox) getParent()).getGrid().get(j).getRow();
-									if (nrow.get(i) != pcell) {
-										break;
-									}
-									nrow.set(i, ncell);
-									pcell.setHeight(pcell.getHeight() - getParent().getChild(j).getHeight());
-								}
-								pcell.setFixedHeight(pcell.getHeight());
-								((TableRowBox) pcell.getParent()).relayoutCell(c, pcell, contentStart);
-								IdentValue val = pcell.getVerticalAlign();
-								if (val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
-									pcell.moveContent(
-											((TableRowBox) pcell.getParent()).recalcMiddleBottomDeltaY(pcell, val));
-								}
+        if (running) {
+            if (isShouldMoveToNextPage(c)) {
+                if (getTable().getFirstBodyRow() == this) {
+                    // XXX Performance problem here. This forces the table
+                    // to move to the next page (which we want), but the initial
+                    // table layout run still completes (which we don't)
+                    getTable().setNeedPageClear(true);
+                } else {
+                    if (getIndex() > 0) {
+                        List<TableCellBox> crow = ((TableSectionBox) getParent()).getGrid().get(getIndex()).getRow();
+                        List<TableCellBox> prow = ((TableSectionBox) getParent()).getGrid().get(getIndex() - 1)
+                                .getRow();
+                        for (int i = 0; i < crow.size() && i < prow.size(); i++) {
+                            TableCellBox ccell = crow.get(i);
+                            TableCellBox pcell = prow.get(i);
+                            if (ccell != null && ccell != TableCellBox.SPANNING_CELL && ccell == pcell) {
+                                TableCellBox ncell = (TableCellBox) pcell.copyOf();
+                                ncell.setParent(this);
+                                ncell.setRow(getIndex());
+                                ncell.setCol(i);
+                                addChild(ncell);
+                                for (int j = getIndex(); j < ((TableSectionBox) getParent()).getGrid().size(); j++) {
+                                    List<TableCellBox> nrow = ((TableSectionBox) getParent()).getGrid().get(j).getRow();
+                                    if (nrow.get(i) != pcell) {
+                                        break;
+                                    }
+                                    nrow.set(i, ncell);
+                                    pcell.setHeight(pcell.getHeight() - getParent().getChild(j).getHeight());
+                                }
+                                pcell.setFixedHeight(pcell.getHeight());
+                                ((TableRowBox) pcell.getParent()).relayoutCell(c, pcell, contentStart);
+                                IdentValue val = pcell.getVerticalAlign();
+                                if (val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
+                                    pcell.moveContent(
+                                            ((TableRowBox) pcell.getParent()).recalcMiddleBottomDeltaY(pcell, val));
+                                }
 
-								ncell.calcCollapsedBorder(c);
-								relayoutCell(c, ncell, contentStart);
-							}
-						}
-					}
+                                ncell.calcCollapsedBorder(c);
+                                relayoutCell(c, ncell, contentStart);
+                            }
+                        }
+                    }
 
-					setNeedPageClear(true);
-				}
-			}
-			c.setExtraSpaceTop(prevExtraTop);
-			c.setExtraSpaceBottom(prevExtraBottom);
-		}
-	}
+                    setNeedPageClear(true);
+                }
+            }
+            c.setExtraSpaceTop(prevExtraTop);
+            c.setExtraSpaceBottom(prevExtraBottom);
+        }
+    }
 
-	private int recalcMiddleBottomDeltaY(TableCellBox cell, IdentValue verticalAlign) {
-		if (cell.getChildCount() == 0) {
-			return 0;
-		}
-		int result = cell.getHeight() - cell.getChildrenHeight();
-		for (Box child : cell.getChildren()) {
-			result -= child.getHeight();
-		}
-		if (cell.getStyle().getRowSpan() == 1) {
-			result += cell.getHeight();
-		} else {
-			result += getAbsY() + cell.getHeight() - cell.getAbsY();
-		}
+    private int recalcMiddleBottomDeltaY(TableCellBox cell, IdentValue verticalAlign) {
+        if (cell.getChildCount() == 0) {
+            return 0;
+        }
+        int result = cell.getHeight() - cell.getChildrenHeight();
+        for (Box child : cell.getChildren()) {
+            result -= child.getHeight();
+        }
+        if (cell.getStyle().getRowSpan() == 1) {
+            result += cell.getHeight();
+        } else {
+            result += getAbsY() + cell.getHeight() - cell.getAbsY();
+        }
 
-		if (verticalAlign == IdentValue.MIDDLE) {
-			return result / 2;
-		} else { /* verticalAlign == IdentValue.BOTTOM */
-			return result;
-		}
-	}
+        if (verticalAlign == IdentValue.MIDDLE) {
+            return result / 2;
+        } else { /* verticalAlign == IdentValue.BOTTOM */
+            return result;
+        }
+    }
 
-	private boolean isShouldMoveToNextPage(LayoutContext c) {
-		PageBox page = c.getRootLayer().getFirstPage(c, this);
+    private boolean isShouldMoveToNextPage(LayoutContext c) {
+        PageBox page = c.getRootLayer().getFirstPage(c, this);
 
-		if (getAbsY() + getHeight() < page.getBottom()) {
-			return false;
-		}
+        if (getAbsY() + getHeight() < page.getBottom()) {
+            return false;
+        }
 
-		for (Box box : getChildren()) {
-			TableCellBox cell = (TableCellBox) box;
-			int baseline = cell.calcBlockBaseline(c);
-			if (baseline != BlockBox.NO_BASELINE && baseline < page.getBottom()) {
-				return false;
-			}
-		}
+        for (Box box : getChildren()) {
+            TableCellBox cell = (TableCellBox) box;
+            int baseline = cell.calcBlockBaseline(c);
+            if (baseline != BlockBox.NO_BASELINE && baseline < page.getBottom()) {
+                return false;
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override
-	public void analyzePageBreaks(LayoutContext c, ContentLimitContainer container) {
-		if (getTable().getStyle().isPaginateTable()) {
-			_contentLimitContainer = new ContentLimitContainer(c, getAbsY());
-			_contentLimitContainer.setParent(container);
+    @Override
+    public void analyzePageBreaks(LayoutContext c, ContentLimitContainer container) {
+        if (getTable().getStyle().isPaginateTable()) {
+            _contentLimitContainer = new ContentLimitContainer(c, getAbsY());
+            _contentLimitContainer.setParent(container);
 
-			if (container != null) {
-				container.updateTop(c, getAbsY());
-				container.updateBottom(c, getAbsY() + getHeight());
-			}
+            if (container != null) {
+                container.updateTop(c, getAbsY());
+                container.updateBottom(c, getAbsY() + getHeight());
+            }
 
-			for (Box b : getChildren()) {
-				b.analyzePageBreaks(c, _contentLimitContainer);
-			}
+            for (Box b : getChildren()) {
+                b.analyzePageBreaks(c, _contentLimitContainer);
+            }
 
-			if (container != null && _contentLimitContainer.isContainsMultiplePages()) {
-				propagateExtraSpace(c, container, _contentLimitContainer, getExtraSpaceTop(), getExtraSpaceBottom());
-			}
-		} else {
-			super.analyzePageBreaks(c, container);
-		}
-	}
+            if (container != null && _contentLimitContainer.isContainsMultiplePages()) {
+                propagateExtraSpace(c, container, _contentLimitContainer, getExtraSpaceTop(), getExtraSpaceBottom());
+            }
+        } else {
+            super.analyzePageBreaks(c, container);
+        }
+    }
 
-	private void calcExtraSpaceTop(LayoutContext c) {
-		int maxBorderAndPadding = 0;
+    private void calcExtraSpaceTop(LayoutContext c) {
+        int maxBorderAndPadding = 0;
 
-		for (Box box : getChildren()) {
-			TableCellBox cell = (TableCellBox) box;
+        for (Box box : getChildren()) {
+            TableCellBox cell = (TableCellBox) box;
 
-			int borderAndPadding = (int) cell.getPadding(c).top() + (int) cell.getBorder(c).top();
-			if (borderAndPadding > maxBorderAndPadding) {
-				maxBorderAndPadding = borderAndPadding;
-			}
-		}
+            int borderAndPadding = (int) cell.getPadding(c).top() + (int) cell.getBorder(c).top();
+            if (borderAndPadding > maxBorderAndPadding) {
+                maxBorderAndPadding = borderAndPadding;
+            }
+        }
 
-		_extraSpaceTop = maxBorderAndPadding;
-	}
+        _extraSpaceTop = maxBorderAndPadding;
+    }
 
-	private void calcExtraSpaceBottom(LayoutContext c) {
-		int maxBorderAndPadding = 0;
+    private void calcExtraSpaceBottom(LayoutContext c) {
+        int maxBorderAndPadding = 0;
 
-		int cRow = getIndex();
-		int totalRows = getSection().numRows();
-		List<RowData> grid = getSection().getGrid();
-		if (!grid.isEmpty() && cRow < grid.size()) {
-			List<TableCellBox> row = grid.get(cRow).getRow();
-			for (int cCol = 0; cCol < row.size(); cCol++) {
-				TableCellBox cell = row.get(cCol);
+        int cRow = getIndex();
+        int totalRows = getSection().numRows();
+        List<RowData> grid = getSection().getGrid();
+        if (!grid.isEmpty() && cRow < grid.size()) {
+            List<TableCellBox> row = grid.get(cRow).getRow();
+            for (int cCol = 0; cCol < row.size(); cCol++) {
+                TableCellBox cell = row.get(cCol);
 
-				if (cell == null || cell == TableCellBox.SPANNING_CELL) {
-					continue;
-				}
-				if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
-					continue;
-				}
+                if (cell == null || cell == TableCellBox.SPANNING_CELL) {
+                    continue;
+                }
+                if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
+                    continue;
+                }
 
-				int borderAndPadding = (int) cell.getPadding(c).bottom() + (int) cell.getBorder(c).bottom();
-				if (borderAndPadding > maxBorderAndPadding) {
-					maxBorderAndPadding = borderAndPadding;
-				}
-			}
-		}
+                int borderAndPadding = (int) cell.getPadding(c).bottom() + (int) cell.getBorder(c).bottom();
+                if (borderAndPadding > maxBorderAndPadding) {
+                    maxBorderAndPadding = borderAndPadding;
+                }
+            }
+        }
 
-		_extraSpaceBottom = maxBorderAndPadding;
-	}
+        _extraSpaceBottom = maxBorderAndPadding;
+    }
 
-	@Override
-	protected void layoutChildren(LayoutContext c, int contentStart) {
-		setState(Box.CHILDREN_FLUX);
-		ensureChildren(c);
+    @Override
+    protected void layoutChildren(LayoutContext c, int contentStart) {
+        setState(Box.CHILDREN_FLUX);
+        ensureChildren(c);
 
-		TableSectionBox section = getSection();
-		if (section.isNeedCellWidthCalc()) {
-			section.setCellWidths(c);
-			section.setNeedCellWidthCalc(false);
-		}
+        TableSectionBox section = getSection();
+        if (section.isNeedCellWidthCalc()) {
+            section.setCellWidths(c);
+            section.setNeedCellWidthCalc(false);
+        }
 
-		if (getChildrenContentType() != CONTENT_EMPTY) {
-			for (Box box : getChildren()) {
-				TableCellBox cell = (TableCellBox) box;
+        if (getChildrenContentType() != CONTENT_EMPTY) {
+            for (Box box : getChildren()) {
+                TableCellBox cell = (TableCellBox) box;
 
-				layoutCell(c, cell, 0);
+                layoutCell(c, cell, 0);
 
-			}
-		}
+            }
+        }
 
-		setState(Box.DONE);
-	}
+        setState(Box.DONE);
+    }
 
-	private void alignBaselineAlignedCells(LayoutContext c) {
-		int[] baselines = new int[getChildCount()];
-		int lowest = Integer.MIN_VALUE;
-		boolean found = false;
-		for (int i = 0; i < getChildCount(); i++) {
-			TableCellBox cell = (TableCellBox) getChild(i);
+    private void alignBaselineAlignedCells(LayoutContext c) {
+        int[] baselines = new int[getChildCount()];
+        int lowest = Integer.MIN_VALUE;
+        boolean found = false;
+        for (int i = 0; i < getChildCount(); i++) {
+            TableCellBox cell = (TableCellBox) getChild(i);
 
-			if (cell.getVerticalAlign() == IdentValue.BASELINE) {
-				int baseline = cell.calcBaseline(c);
-				baselines[i] = baseline;
-				if (baseline > lowest) {
-					lowest = baseline;
-				}
-				found = true;
-			}
-		}
+            if (cell.getVerticalAlign() == IdentValue.BASELINE) {
+                int baseline = cell.calcBaseline(c);
+                baselines[i] = baseline;
+                if (baseline > lowest) {
+                    lowest = baseline;
+                }
+                found = true;
+            }
+        }
 
-		if (found) {
-			for (int i = 0; i < getChildCount(); i++) {
-				TableCellBox cell = (TableCellBox) getChild(i);
+        if (found) {
+            for (int i = 0; i < getChildCount(); i++) {
+                TableCellBox cell = (TableCellBox) getChild(i);
 
-				if (cell.getVerticalAlign() == IdentValue.BASELINE) {
-					int deltaY = lowest - baselines[i];
-					if (deltaY != 0) {
-						if (c.isPrint() && cell.isPageBreaksChange(c, deltaY)) {
-							relayoutCell(c, cell, deltaY);
-						} else {
-							cell.moveContent(deltaY);
-							cell.setHeight(cell.getHeight() + deltaY);
-						}
-					}
-				}
-			}
+                if (cell.getVerticalAlign() == IdentValue.BASELINE) {
+                    int deltaY = lowest - baselines[i];
+                    if (deltaY != 0) {
+                        if (c.isPrint() && cell.isPageBreaksChange(c, deltaY)) {
+                            relayoutCell(c, cell, deltaY);
+                        } else {
+                            cell.moveContent(deltaY);
+                            cell.setHeight(cell.getHeight() + deltaY);
+                        }
+                    }
+                }
+            }
 
-			setBaseline(lowest - getAbsY());
-			setHaveBaseline(true);
-		}
-	}
+            setBaseline(lowest - getAbsY());
+            setHaveBaseline(true);
+        }
+    }
 
-	private boolean alignMiddleAndBottomAlignedCells(LayoutContext c) {
-		boolean needRowHeightRecalc = false;
+    private boolean alignMiddleAndBottomAlignedCells(LayoutContext c) {
+        boolean needRowHeightRecalc = false;
 
-		int cRow = getIndex();
-		int totalRows = getSection().numRows();
-		List<RowData> grid = getSection().getGrid();
-		if (!grid.isEmpty() && cRow < grid.size()) {
-			List<TableCellBox> row = grid.get(cRow).getRow();
-			for (int cCol = 0; cCol < row.size(); cCol++) {
-				TableCellBox cell = row.get(cCol);
+        int cRow = getIndex();
+        int totalRows = getSection().numRows();
+        List<RowData> grid = getSection().getGrid();
+        if (!grid.isEmpty() && cRow < grid.size()) {
+            List<TableCellBox> row = grid.get(cRow).getRow();
+            for (int cCol = 0; cCol < row.size(); cCol++) {
+                TableCellBox cell = row.get(cCol);
 
-				if (cell == null || cell == TableCellBox.SPANNING_CELL) {
-					continue;
-				}
-				if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
-					continue;
-				}
+                if (cell == null || cell == TableCellBox.SPANNING_CELL) {
+                    continue;
+                }
+                if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
+                    continue;
+                }
 
-				IdentValue val = cell.getVerticalAlign();
-				if (val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
-					int deltaY = calcMiddleBottomDeltaY(cell, val);
-					if (deltaY > 0) {
-						if (c.isPrint() && cell.isPageBreaksChange(c, deltaY)) {
-							int oldCellHeight = cell.getHeight();
-							relayoutCell(c, cell, deltaY);
-							if (oldCellHeight + deltaY != cell.getHeight()) {
-								needRowHeightRecalc = true;
-							}
-						} else {
-							cell.moveContent(deltaY);
-							// Set a provisional height in case we need to calculate
-							// a default baseline
-							cell.setHeight(cell.getHeight() + deltaY);
-						}
-					}
-				}
-			}
-		}
+                IdentValue val = cell.getVerticalAlign();
+                if (val == IdentValue.MIDDLE || val == IdentValue.BOTTOM) {
+                    int deltaY = calcMiddleBottomDeltaY(cell, val);
+                    if (deltaY > 0) {
+                        if (c.isPrint() && cell.isPageBreaksChange(c, deltaY)) {
+                            int oldCellHeight = cell.getHeight();
+                            relayoutCell(c, cell, deltaY);
+                            if (oldCellHeight + deltaY != cell.getHeight()) {
+                                needRowHeightRecalc = true;
+                            }
+                        } else {
+                            cell.moveContent(deltaY);
+                            // Set a provisional height in case we need to calculate
+                            // a default baseline
+                            cell.setHeight(cell.getHeight() + deltaY);
+                        }
+                    }
+                }
+            }
+        }
 
-		return needRowHeightRecalc;
-	}
+        return needRowHeightRecalc;
+    }
 
-	private int calcMiddleBottomDeltaY(TableCellBox cell, IdentValue verticalAlign) {
-		int result;
-		if (cell.getStyle().getRowSpan() == 1) {
-			result = getHeight() - cell.getChildrenHeight();
-		} else {
-			result = getAbsY() + getHeight() - (cell.getAbsY() + cell.getChildrenHeight());
-		}
+    private int calcMiddleBottomDeltaY(TableCellBox cell, IdentValue verticalAlign) {
+        int result;
+        if (cell.getStyle().getRowSpan() == 1) {
+            result = getHeight() - cell.getChildrenHeight();
+        } else {
+            result = getAbsY() + getHeight() - (cell.getAbsY() + cell.getChildrenHeight());
+        }
 
-		if (verticalAlign == IdentValue.MIDDLE) {
-			return result / 2;
-		} else { /* verticalAlign == IdentValue.BOTTOM */
-			return result;
-		}
-	}
+        if (verticalAlign == IdentValue.MIDDLE) {
+            return result / 2;
+        } else { /* verticalAlign == IdentValue.BOTTOM */
+            return result;
+        }
+    }
 
-	@Override
+    @Override
     protected void calcLayoutHeight(
             LayoutContext c, BorderPropertySet border,
             RectPropertySet margin, RectPropertySet padding) {
-		if (getHeightOverride() > 0) {
-			setHeight(getHeightOverride());
-		}
+        if (getHeightOverride() > 0) {
+            setHeight(getHeightOverride());
+        }
 
-		alignBaselineAlignedCells(c);
+        alignBaselineAlignedCells(c);
 
-		calcRowHeight(c);
+        calcRowHeight(c);
 
-		boolean recalcRowHeight = alignMiddleAndBottomAlignedCells(c);
+        boolean recalcRowHeight = alignMiddleAndBottomAlignedCells(c);
 
-		if (recalcRowHeight) {
-			calcRowHeight(c);
-		}
+        if (recalcRowHeight) {
+            calcRowHeight(c);
+        }
 
-		if (!isHaveBaseline()) {
-			calcDefaultBaseline(c);
-		}
+        if (!isHaveBaseline()) {
+            calcDefaultBaseline(c);
+        }
 
-		setCellHeights();
-	}
+        setCellHeights();
+    }
 
-	private void calcRowHeight(CssContext c) {
-		int y1 = getAbsY();
-		int y2;
+    private void calcRowHeight(CssContext c) {
+        int y1 = getAbsY();
+        int y2;
 
-		if (getHeight() != 0) {
-			y2 = y1 + getHeight();
-		} else {
-			y2 = y1;
-		}
+        if (getHeight() != 0) {
+            y2 = y1 + getHeight();
+        } else {
+            y2 = y1;
+        }
 
-		if (isLastRow()) {
-			int bottom = getTable().calcFixedHeightRowBottom(c);
-			if (bottom > 0 && bottom > y2) {
-				y2 = bottom;
-			}
-		}
+        if (isLastRow()) {
+            int bottom = getTable().calcFixedHeightRowBottom(c);
+            if (bottom > 0 && bottom > y2) {
+                y2 = bottom;
+            }
+        }
 
-		int cRow = getIndex();
-		int totalRows = getSection().numRows();
-		List<RowData> grid = getSection().getGrid();
-		if (!grid.isEmpty() && cRow < grid.size()) {
-			List<TableCellBox> row = grid.get(cRow).getRow();
-			for (int cCol = 0; cCol < row.size(); cCol++) {
-				TableCellBox cell = row.get(cCol);
+        int cRow = getIndex();
+        int totalRows = getSection().numRows();
+        List<RowData> grid = getSection().getGrid();
+        if (!grid.isEmpty() && cRow < grid.size()) {
+            List<TableCellBox> row = grid.get(cRow).getRow();
+            for (int cCol = 0; cCol < row.size(); cCol++) {
+                TableCellBox cell = row.get(cCol);
 
-				if (cell == null || cell == TableCellBox.SPANNING_CELL) {
-					continue;
-				}
-				if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
-					continue;
-				}
+                if (cell == null || cell == TableCellBox.SPANNING_CELL) {
+                    continue;
+                }
+                if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
+                    continue;
+                }
 
-				int bottomCellEdge = cell.getAbsY() + cell.getHeight();
-				if (bottomCellEdge > y2) {
-					y2 = bottomCellEdge;
-				}
-			}
-		}
+                int bottomCellEdge = cell.getAbsY() + cell.getHeight();
+                if (bottomCellEdge > y2) {
+                    y2 = bottomCellEdge;
+                }
+            }
+        }
 
-		setHeight(y2 - y1);
-	}
+        setHeight(y2 - y1);
+    }
 
-	private boolean isLastRow() {
-		TableBox table = getTable();
-		TableSectionBox section = getSection();
-		if (table.sectionBelow(section, true) == null) {
-			return section.getChild(section.getChildCount() - 1) == this;
-		} else {
-			return false;
-		}
-	}
+    private boolean isLastRow() {
+        TableBox table = getTable();
+        TableSectionBox section = getSection();
+        if (table.sectionBelow(section, true) == null) {
+            return section.getChild(section.getChildCount() - 1) == this;
+        } else {
+            return false;
+        }
+    }
 
-	private void calcDefaultBaseline(LayoutContext c) {
-		int lowestCellEdge = 0;
-		int cRow = getIndex();
-		int totalRows = getSection().numRows();
-		List<RowData> grid = getSection().getGrid();
-		if (!grid.isEmpty() && cRow < grid.size()) {
-			List<TableCellBox> row = grid.get(cRow).getRow();
-			for (int cCol = 0; cCol < row.size(); cCol++) {
-				TableCellBox cell = row.get(cCol);
+    private void calcDefaultBaseline(LayoutContext c) {
+        int lowestCellEdge = 0;
+        int cRow = getIndex();
+        int totalRows = getSection().numRows();
+        List<RowData> grid = getSection().getGrid();
+        if (!grid.isEmpty() && cRow < grid.size()) {
+            List<TableCellBox> row = grid.get(cRow).getRow();
+            for (int cCol = 0; cCol < row.size(); cCol++) {
+                TableCellBox cell = row.get(cCol);
 
-				if (cell == null || cell == TableCellBox.SPANNING_CELL) {
-					continue;
-				}
-				if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
-					continue;
-				}
+                if (cell == null || cell == TableCellBox.SPANNING_CELL) {
+                    continue;
+                }
+                if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
+                    continue;
+                }
 
-				Rectangle contentArea = cell.getContentAreaEdge(cell.getAbsX(), cell.getAbsY(), c);
-				int bottomCellEdge = contentArea.y + contentArea.height;
-				if (bottomCellEdge > lowestCellEdge) {
-					lowestCellEdge = bottomCellEdge;
-				}
-			}
-		}
-		if (lowestCellEdge > 0) {
-			setBaseline(lowestCellEdge - getAbsY());
-		}
-		setHaveBaseline(true);
-	}
+                Rectangle contentArea = cell.getContentAreaEdge(cell.getAbsX(), cell.getAbsY(), c);
+                int bottomCellEdge = contentArea.y + contentArea.height;
+                if (bottomCellEdge > lowestCellEdge) {
+                    lowestCellEdge = bottomCellEdge;
+                }
+            }
+        }
+        if (lowestCellEdge > 0) {
+            setBaseline(lowestCellEdge - getAbsY());
+        }
+        setHaveBaseline(true);
+    }
 
-	private void setCellHeights() {
-		int cRow = getIndex();
-		int totalRows = getSection().numRows();
-		List<RowData> grid = getSection().getGrid();
-		if (!grid.isEmpty() && cRow < grid.size()) {
-			List<TableCellBox> row = grid.get(cRow).getRow();
-			for (int cCol = 0; cCol < row.size(); cCol++) {
-				TableCellBox cell = row.get(cCol);
+    private void setCellHeights() {
+        int cRow = getIndex();
+        int totalRows = getSection().numRows();
+        List<RowData> grid = getSection().getGrid();
+        if (!grid.isEmpty() && cRow < grid.size()) {
+            List<TableCellBox> row = grid.get(cRow).getRow();
+            for (int cCol = 0; cCol < row.size(); cCol++) {
+                TableCellBox cell = row.get(cCol);
 
-				if (cell == null || cell == TableCellBox.SPANNING_CELL) {
-					continue;
-				}
+                if (cell == null || cell == TableCellBox.SPANNING_CELL) {
+                    continue;
+                }
 
-				if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
-					if (getTable().getStyle().isPaginateTable()) {
-						cell.setHeight(getAbsY() + getHeight() - cell.getAbsY());
-					}
-					continue;
-				}
+                if (cRow < totalRows - 1 && getSection().cellAt(cRow + 1, cCol) == cell) {
+                    if (getTable().getStyle().isPaginateTable()) {
+                        cell.setHeight(getAbsY() + getHeight() - cell.getAbsY());
+                    }
+                    continue;
+                }
 
-				if (cell.getStyle().getRowSpan() == 1) {
-					cell.setHeight(getHeight());
-				} else {
-					cell.setHeight(getAbsY() + getHeight() - cell.getAbsY());
-				}
-			}
+                if (cell.getStyle().getRowSpan() == 1) {
+                    cell.setHeight(getHeight());
+                } else {
+                    cell.setHeight(getAbsY() + getHeight() - cell.getAbsY());
+                }
+            }
 
-		}
-	}
+        }
+    }
 
-	private void relayoutCell(LayoutContext c, TableCellBox cell, int contentStart) {
-		int width = cell.getWidth();
-		cell.reset(c);
-		cell.setLayoutWidth(c, width);
-		layoutCell(c, cell, contentStart);
-	}
+    private void relayoutCell(LayoutContext c, TableCellBox cell, int contentStart) {
+        int width = cell.getWidth();
+        cell.reset(c);
+        cell.setLayoutWidth(c, width);
+        layoutCell(c, cell, contentStart);
+    }
 
-	private void layoutCell(LayoutContext c, TableCellBox cell, int contentStart) {
-		cell.initContainingLayer(c);
-		cell.calcCanvasLocation();
+    private void layoutCell(LayoutContext c, TableCellBox cell, int contentStart) {
+        cell.initContainingLayer(c);
+        cell.calcCanvasLocation();
 
-		cell.layout(c, contentStart);
-	}
+        cell.layout(c, contentStart);
+    }
 
-	@Override
-	public void initStaticPos(LayoutContext c, BlockBox parent, int childOffset) {
-		setX(0);
+    @Override
+    public void initStaticPos(LayoutContext c, BlockBox parent, int childOffset) {
+        setX(0);
 
-		TableBox table = getTable();
-		setY(parent.getHeight() + table.getStyle().getBorderVSpacing(c));
-		c.translate(0, getY() - childOffset);
-	}
+        TableBox table = getTable();
+        setY(parent.getHeight() + table.getStyle().getBorderVSpacing(c));
+        c.translate(0, getY() - childOffset);
+    }
 
-	public int getBaseline() {
-		return _baseline;
-	}
+    public int getBaseline() {
+        return _baseline;
+    }
 
-	public void setBaseline(int baseline) {
-		_baseline = baseline;
-	}
+    public void setBaseline(int baseline) {
+        _baseline = baseline;
+    }
 
-	@Override
-	protected boolean isSkipWhenCollapsingMargins() {
-		return true;
-	}
+    @Override
+    protected boolean isSkipWhenCollapsingMargins() {
+        return true;
+    }
 
-	@Override
-	public void paintBorder(RenderingContext c) {
-		// rows never have borders
-	}
+    @Override
+    public void paintBorder(RenderingContext c) {
+        // rows never have borders
+    }
 
-	@Override
-	public void paintBackground(RenderingContext c) {
-		// painted at the cell level
-	}
+    @Override
+    public void paintBackground(RenderingContext c) {
+        // painted at the cell level
+    }
 
-	@Override
-	public void reset(LayoutContext c) {
-		super.reset(c);
-		setHaveBaseline(false);
-		getSection().setNeedCellWidthCalc(true);
-		setContentLimitContainer(null);
-	}
+    @Override
+    public void reset(LayoutContext c) {
+        super.reset(c);
+        setHaveBaseline(false);
+        getSection().setNeedCellWidthCalc(true);
+        setContentLimitContainer(null);
+    }
 
-	public boolean isHaveBaseline() {
-		return _haveBaseline;
-	}
+    public boolean isHaveBaseline() {
+        return _haveBaseline;
+    }
 
-	public void setHaveBaseline(boolean haveBaseline) {
-		_haveBaseline = haveBaseline;
-	}
+    public void setHaveBaseline(boolean haveBaseline) {
+        _haveBaseline = haveBaseline;
+    }
 
-	@Override
-	protected String getExtraBoxDescription() {
-		if (isHaveBaseline()) {
-			return "(baseline=" + getBaseline() + ") ";
-		} else {
-			return "";
-		}
-	}
+    @Override
+    protected String getExtraBoxDescription() {
+        if (isHaveBaseline()) {
+            return "(baseline=" + getBaseline() + ") ";
+        } else {
+            return "";
+        }
+    }
 
-	public int getHeightOverride() {
-		return _heightOverride;
-	}
+    public int getHeightOverride() {
+        return _heightOverride;
+    }
 
-	public void setHeightOverride(int heightOverride) {
-		_heightOverride = heightOverride;
-	}
+    public void setHeightOverride(int heightOverride) {
+        _heightOverride = heightOverride;
+    }
 
-	@Override
-	public void exportText(RenderingContext c, Writer writer) throws IOException {
-		if (getTable().isMarginAreaRoot()) {
-			super.exportText(c, writer);
-		} else {
-			int yPos = getAbsY();
-			if (yPos >= c.getPage().getBottom() && isInDocumentFlow()) {
-				exportPageBoxText(c, writer, yPos);
-			}
+    @Override
+    public void exportText(RenderingContext c, Writer writer) throws IOException {
+        if (getTable().isMarginAreaRoot()) {
+            super.exportText(c, writer);
+        } else {
+            int yPos = getAbsY();
+            if (yPos >= c.getPage().getBottom() && isInDocumentFlow()) {
+                exportPageBoxText(c, writer, yPos);
+            }
 
-			for (Box box : getChildren()) {
-				TableCellBox cell = (TableCellBox) box;
-				StringBuilder buffer = new StringBuilder();
-				cell.collectText(c, buffer);
-				writer.write(buffer.toString().trim());
-				int cSpan = cell.getStyle().getColSpan();
-				for (int j = 0; j < cSpan; j++) {
-					writer.write('\t');
-				}
-			}
+            for (Box box : getChildren()) {
+                TableCellBox cell = (TableCellBox) box;
+                StringBuilder buffer = new StringBuilder();
+                cell.collectText(c, buffer);
+                writer.write(buffer.toString().trim());
+                int cSpan = cell.getStyle().getColSpan();
+                for (int j = 0; j < cSpan; j++) {
+                    writer.write('\t');
+                }
+            }
 
-			writer.write(lineSeparator());
-		}
-	}
+            writer.write(lineSeparator());
+        }
+    }
 
-	public ContentLimitContainer getContentLimitContainer() {
-		return _contentLimitContainer;
-	}
+    public ContentLimitContainer getContentLimitContainer() {
+        return _contentLimitContainer;
+    }
 
-	public void setContentLimitContainer(ContentLimitContainer contentLimitContainer) {
-		_contentLimitContainer = contentLimitContainer;
-	}
+    public void setContentLimitContainer(ContentLimitContainer contentLimitContainer) {
+        _contentLimitContainer = contentLimitContainer;
+    }
 
-	public int getExtraSpaceTop() {
-		return _extraSpaceTop;
-	}
+    public int getExtraSpaceTop() {
+        return _extraSpaceTop;
+    }
 
-	public void setExtraSpaceTop(int extraSpaceTop) {
-		_extraSpaceTop = extraSpaceTop;
-	}
+    public void setExtraSpaceTop(int extraSpaceTop) {
+        _extraSpaceTop = extraSpaceTop;
+    }
 
-	public int getExtraSpaceBottom() {
-		return _extraSpaceBottom;
-	}
+    public int getExtraSpaceBottom() {
+        return _extraSpaceBottom;
+    }
 
-	public void setExtraSpaceBottom(int extraSpaceBottom) {
-		_extraSpaceBottom = extraSpaceBottom;
-	}
+    public void setExtraSpaceBottom(int extraSpaceBottom) {
+        _extraSpaceBottom = extraSpaceBottom;
+    }
 
-	@Override
+    @Override
     public int forcePageBreakBefore(LayoutContext c, IdentValue pageBreakValue,
             boolean pendingPageName) {
-		int currentDelta = super.forcePageBreakBefore(c, pageBreakValue, pendingPageName);
+        int currentDelta = super.forcePageBreakBefore(c, pageBreakValue, pendingPageName);
 
-		// additional calculations for collapsed borders.
-		if (c.isPrint() && getStyle().isCollapseBorders()) {
-			// get destination page for this row
-			PageBox page = c.getRootLayer().getPage(c, getAbsY() + currentDelta);
-			if (page != null) {
+        // additional calculations for collapsed borders.
+        if (c.isPrint() && getStyle().isCollapseBorders()) {
+            // get destination page for this row
+            PageBox page = c.getRootLayer().getPage(c, getAbsY() + currentDelta);
+            if (page != null) {
 
-				// calculate max spill from the collapsed top borders of each child
-				int spill = 0;
-				for (Box box : getChildren()) {
-					TableCellBox cell = (TableCellBox) box;
-					BorderPropertySet collapsed = cell.getCollapsedPaintingBorder();
-					if (collapsed != null) {
-						spill = Math.max(spill, (int) collapsed.top() / 2);
-					}
-				}
+                // calculate max spill from the collapsed top borders of each child
+                int spill = 0;
+                for (Box box : getChildren()) {
+                    TableCellBox cell = (TableCellBox) box;
+                    BorderPropertySet collapsed = cell.getCollapsedPaintingBorder();
+                    if (collapsed != null) {
+                        spill = Math.max(spill, (int) collapsed.top() / 2);
+                    }
+                }
 
-				// be sure that the current start of the row is >= the start of the page
-				int borderTop = getAbsY() + currentDelta + (int) getMargin(c).top() - spill;
-				int rowDelta = page.getTop() - borderTop;
-				if (rowDelta > 0) {
-					setY(getY() + rowDelta);
-					currentDelta += rowDelta;
-				}
-			}
-		}
-		return currentDelta;
-	}
+                // be sure that the current start of the row is >= the start of the page
+                int borderTop = getAbsY() + currentDelta + (int) getMargin(c).top() - spill;
+                int rowDelta = page.getTop() - borderTop;
+                if (rowDelta > 0) {
+                    setY(getY() + rowDelta);
+                    currentDelta += rowDelta;
+                }
+            }
+        }
+        return currentDelta;
+    }
 }


### PR DESCRIPTION
While using Flying Saucer, we encountered two issues: the first one concerns the rendering of cells with overlapping rowspan and colspan which draws a border in the middle. The second issue is that during PDF generation, the table headers are correctly repeated, but the table rows are incorrectly split.

Attached, you will find an illustration of the XHTML and the two issues fixed by this code are highlighted in red.
Before fix issues :
![Sans titre](https://github.com/user-attachments/assets/8d21e274-cb59-4be5-9739-d7e5b6684a78)

After fix issues :
![xhtmlrender](https://github.com/user-attachments/assets/bbc7fd4c-4f98-4af3-925e-54d59f272fca)
![cut row and border](https://github.com/user-attachments/assets/06d7570b-8212-4902-ac36-b7d7c777fafa)