### PR TITLE
Add automatic module name to MANIFEST.MF in flying-saucer-core

### DIFF
--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -62,6 +62,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.core</Bundle-SymbolicName>
+            <Automatic-Module-Name>flying.saucer</Automatic-Module-Name>
             <Bundle-Version>${project.version}</Bundle-Version>
             <!-- Dependency resolution seems not to work properly with default
               behavior of importing the exported packages. -->

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -97,6 +97,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.fop</Bundle-SymbolicName>
+            <Automatic-Module-Name>flying.saucer.fop</Automatic-Module-Name>
             <Bundle-Version>${project.version}</Bundle-Version>
             <!-- Dependency resolution seems not to work properly with default
               behavior of importing the exported packages. -->

--- a/flying-saucer-pdf-osgi/pom.xml
+++ b/flying-saucer-pdf-osgi/pom.xml
@@ -33,6 +33,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.pdf.osgi</Bundle-SymbolicName>
+            <Automatic-Module-Name>flying.saucer.pdf.osgi</Automatic-Module-Name>
             <Bundle-Version>${project.version}</Bundle-Version>
             <!-- This bundle re-bundles the original flying-saucer-pdf artifact
               and only needs to import packages from flying-saucer-core. -->

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -47,5 +47,17 @@
         </includes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>flying.saucer.pdf</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/flying-saucer-swt/pom.xml
+++ b/flying-saucer-swt/pom.xml
@@ -129,6 +129,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>org.xhtmlrenderer.flying.saucer.swt</Bundle-SymbolicName>
+            <Automatic-Module-Name>flying.saucer.swt</Automatic-Module-Name>
             <Bundle-Version>${project.version}</Bundle-Version>
             <!-- Dependency resolution seems not to work properly with default
               behavior of importing the exported packages. -->


### PR DESCRIPTION
This change will make it easier to use flying-sourcer-core in a module based project.