### PR TITLE
Page size 3value fix

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
@@ -148,34 +148,34 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
                 throw new CSSParseException("Invalid value for size property", -1);
             }
         }  else if (values.size() == 3) {
-			PropertyValue value1 = (PropertyValue) values.get(0);
-			PropertyValue value2 = (PropertyValue) values.get(1);
-			PropertyValue value3 = (PropertyValue) values.get(2);
+            PropertyValue value1 = (PropertyValue) values.get(0);
+            PropertyValue value2 = (PropertyValue) values.get(1);
+            PropertyValue value3 = (PropertyValue) values.get(2);
 
-			checkInheritAllowed(value3, false);
+            checkInheritAllowed(value3, false);
 			
-			if (isLength(value1) && isLength(value2) && value2.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
-				if (value1.getFloatValue() < 0.0f) {
-					throw new CSSParseException("A page dimension may not be negative", -1);
-				}
+            if (isLength(value1) && isLength(value2) && value2.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+                if (value1.getFloatValue() < 0.0f) {
+                    throw new CSSParseException("A page dimension may not be negative", -1);
+                }
 
-				if (value2.getFloatValue() < 0.0f) {
-					throw new CSSParseException("A page dimension may not be negative", -1);
-				}
+                if (value2.getFloatValue() < 0.0f) {
+                    throw new CSSParseException("A page dimension may not be negative", -1);
+                }
 
-				if (!(value3.toString().equals("landscape") || value3.toString().equals("portrait"))) {
-					throw new CSSParseException("Value " + value1 + " is not a valid page orientation", -1);
-				}
+                if (!(value3.toString().equals("landscape") || value3.toString().equals("portrait"))) {
+                    throw new CSSParseException("Value " + value3 + " is not a valid page orientation", -1);
+                }
 
-				result.add(new PropertyDeclaration(CSSName.FS_PAGE_WIDTH, value1, important, origin));
-				result.add(new PropertyDeclaration(CSSName.FS_PAGE_HEIGHT, value2, important, origin));
-				result.add(new PropertyDeclaration(CSSName.FS_PAGE_ORIENTATION, value3, important, origin));
-				return result;
-			} else {
-				throw new CSSParseException("Size property parsing error", -1);
-			}
-		} else {
-			throw new CSSParseException("Invalid value count for size property", -1);
-		}
+                result.add(new PropertyDeclaration(CSSName.FS_PAGE_WIDTH, value1, important, origin));
+                result.add(new PropertyDeclaration(CSSName.FS_PAGE_HEIGHT, value2, important, origin));
+                result.add(new PropertyDeclaration(CSSName.FS_PAGE_ORIENTATION, value3, important, origin));
+                return result;
+            } else {
+                throw new CSSParseException("Size property parsing error", -1);
+            }
+        } else {
+            throw new CSSParseException("Invalid value count for size property", -1);
+        }
     }
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
@@ -94,7 +94,7 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
             } else {
                 throw new CSSParseException("Value for " + cssName + " must be a length or identifier", -1);
             }
-        } else if (values.size() == 2) { /* values.size == 2 */
+        } else if (values.size() == 2) {
             PropertyValue value1 = (PropertyValue)values.get(0);
             PropertyValue value2 = (PropertyValue)values.get(1);
 
@@ -154,7 +154,7 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
 
             checkInheritAllowed(value3, false);
 			
-            if (isLength(value1) && isLength(value2) && value2.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+            if (isLength(value1) && isLength(value2) && value3.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
                 if (value1.getFloatValue() < 0.0f) {
                     throw new CSSParseException("A page dimension may not be negative", -1);
                 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/SizePropertyBuilder.java
@@ -37,7 +37,7 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
     public List<PropertyDeclaration> buildDeclarations(
             CSSName cssName, List<? extends CSSPrimitiveValue> values, int origin, boolean important, boolean inheritAllowed) {
         List<PropertyDeclaration> result = new ArrayList<>(3);
-        assertFoundUpToValues(cssName, values, 2);
+        assertFoundUpToValues(cssName, values, 3);
 
         if (values.size() == 1) {
             PropertyValue value = (PropertyValue)values.get(0);
@@ -94,7 +94,7 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
             } else {
                 throw new CSSParseException("Value for " + cssName + " must be a length or identifier", -1);
             }
-        } else { /* values.size == 2 */
+        } else if (values.size() == 2) { /* values.size == 2 */
             PropertyValue value1 = (PropertyValue)values.get(0);
             PropertyValue value2 = (PropertyValue)values.get(1);
 
@@ -135,7 +135,7 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
 
                 PageSize pageSize = PageSize.getPageSize(value2.getStringValue());
                 if (pageSize == null) {
-                    throw new CSSParseException("Value " + value1 + " is not a valid page size", -1);
+                    throw new CSSParseException("Value " + value2 + " is not a valid page size", -1);
                 }
 
                 result.add(new PropertyDeclaration(
@@ -147,6 +147,35 @@ public class SizePropertyBuilder extends AbstractPropertyBuilder {
             } else {
                 throw new CSSParseException("Invalid value for size property", -1);
             }
-        }
+        }  else if (values.size() == 3) {
+			PropertyValue value1 = (PropertyValue) values.get(0);
+			PropertyValue value2 = (PropertyValue) values.get(1);
+			PropertyValue value3 = (PropertyValue) values.get(2);
+
+			checkInheritAllowed(value3, false);
+			
+			if (isLength(value1) && isLength(value2) && value2.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+				if (value1.getFloatValue() < 0.0f) {
+					throw new CSSParseException("A page dimension may not be negative", -1);
+				}
+
+				if (value2.getFloatValue() < 0.0f) {
+					throw new CSSParseException("A page dimension may not be negative", -1);
+				}
+
+				if (!(value3.toString().equals("landscape") || value3.toString().equals("portrait"))) {
+					throw new CSSParseException("Value " + value1 + " is not a valid page orientation", -1);
+				}
+
+				result.add(new PropertyDeclaration(CSSName.FS_PAGE_WIDTH, value1, important, origin));
+				result.add(new PropertyDeclaration(CSSName.FS_PAGE_HEIGHT, value2, important, origin));
+				result.add(new PropertyDeclaration(CSSName.FS_PAGE_ORIENTATION, value3, important, origin));
+				return result;
+			} else {
+				throw new CSSParseException("Size property parsing error", -1);
+			}
+		} else {
+			throw new CSSParseException("Invalid value count for size property", -1);
+		}
     }
 }


### PR DESCRIPTION
I wanted to create a PDF for a label printer with landscape orientation AND a custom size which evidently isn't supported.

```
@page {
   size: 40mm 20mm landscape;
}
```

This is an attempt to fix that (+ fixed one typo in original code reporting error on incorrect parameter value).

I'm unable to test this properly right now with current version as I'm unable to compile the library with Java 17 (still using FS 9.4.1 with Java 1.8), but it compiled OK and works (with slight modifications for the old version), this is to get it fixed when I'll be able to upgrade and to give something back, thanks.
Succesfully created portrait label on landscape paper 40x20mm...