### PR TITLE
Findbugs library should not be distributed to client apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
The findbugs library is only required at build time. It should never be packaged in a distributed client application. Right now flyingsaucer depends on findbugs with a `compile` scope, which means every application using flyingsaucer will automatically inherit the dependency, and fingbugs will end in the packaged application (fat jar, war, ...).

The solution is to set its scope to `provided`, as recommended by various sources including https://stackoverflow.com/a/26868773.

This will avoid the burden for every application to exclude the findbugs dependency from flyingsaucer.