### PR TITLE
Set "Page only" as default initial view in PDF viewer

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -920,7 +920,6 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
             _bookmarks = HTMLOutline.generate(root.getElement(), root);
         }
         if (!_bookmarks.isEmpty()) {
-            _writer.setViewerPreferences(PdfWriter.PageModeUseOutlines);
             writeBookmarks(c, root, _writer.getRootOutline(), _bookmarks);
         }
     }


### PR DESCRIPTION
**Problem:**
There has been bugreports that the default initial view of the PDF when viewed in Acrobat Reader has been changed from "Page only" to "Bookmarks Panel and Page", when creating PDF files using Flyingsaucer. 
This begun when we upgraded to FS 9.8.0 and OpenPDF 2.0.2.

**Solution:**
Set "Page only" as default initial view in PDF viewer. In ITextOutputDevice.writeOutline() remove call to setViewerPreferences, in order to not modify viewer preferences. 

This solved this problem for our usage of FS/OpenPDF to create PDF invoices.