### PR TITLE
be sure to dispose Graphics object after using it

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/ReplacedElementFactory.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/ReplacedElementFactory.java
@@ -24,6 +24,9 @@ import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
 public interface ReplacedElementFactory {
 
     /**
@@ -36,6 +39,8 @@ public interface ReplacedElementFactory {
      * @return The {@code ReplacedElement} or {@code null} if no
      * {@code ReplacedElement} applies
      */
+    @Nullable
+    @CheckReturnValue
     ReplacedElement createReplacedElement(
             LayoutContext c, BlockBox box,
             UserAgentCallback uac, int cssWidth, int cssHeight);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/Graphics2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/Graphics2DRenderer.java
@@ -25,6 +25,8 @@ import org.xhtmlrenderer.layout.SharedContext;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
+import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
+
 
 /**
  * <p>
@@ -36,7 +38,7 @@ import java.awt.image.BufferedImage;
  * {@link XHTMLPanel}, as well as easy-to-use static utility methods.
  * For example, to render a document in an image that is 600 pixels wide use the
  * {@link #renderToImageAutoSize(String,int,int)} method like this:</p>
- * 
+ *
  * <pre>{@code
  * BufferedImage img = Graphics2DRenderer.renderToImage( "test.xhtml", width);
  * }</pre>
@@ -183,10 +185,10 @@ public class Graphics2DRenderer {
         g2r.setDocument(url);
         Dimension dim = new Dimension(width, height);
         BufferedImage buff = new BufferedImage((int) dim.getWidth(), (int) dim.getHeight(), bufferedImageType);
-        Graphics2D g = (Graphics2D) buff.getGraphics();
-        g2r.layout(g, dim);
-        g2r.render(g);
-        g.dispose();
+        withGraphics(buff, g -> {
+            g2r.layout(g, dim);
+            g2r.render(g);
+        });
         return buff;
     }
 
@@ -222,19 +224,15 @@ public class Graphics2DRenderer {
         Dimension dim = new Dimension(width, 1000);
 
         // do layout with temp buffer
-        BufferedImage buff = new BufferedImage((int) dim.getWidth(), (int) dim.getHeight(), bufferedImageType);
-        Graphics2D g = (Graphics2D) buff.getGraphics();
-        g2r.layout(g, new Dimension(width, 1000));
-        g.dispose();
+        BufferedImage tempBuffer = new BufferedImage((int) dim.getWidth(), (int) dim.getHeight(), bufferedImageType);
+        withGraphics(tempBuffer, g -> g2r.layout(g, new Dimension(width, 1000)));
 
         // get size
         Rectangle rect = g2r.getMinimumSize();
 
         // render into real buffer
-        buff = new BufferedImage((int) rect.getWidth(), (int) rect.getHeight(), bufferedImageType);
-        g = (Graphics2D) buff.getGraphics();
-        g2r.render(g);
-        g.dispose();
+        BufferedImage buff = new BufferedImage((int) rect.getWidth(), (int) rect.getHeight(), bufferedImageType);
+        withGraphics(buff, g -> g2r.render(g));
 
         // return real buffer
         return buff;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/NoReplacedElementFactory.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/NoReplacedElementFactory.java
@@ -7,10 +7,15 @@ import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class NoReplacedElementFactory implements ReplacedElementFactory {
 
+    @Nullable
     public ReplacedElement createReplacedElement(LayoutContext c, BlockBox box,
-            UserAgentCallback uac, int cssWidth, int cssHeight) {
+                                             UserAgentCallback uac, int cssWidth, int cssHeight) {
         return null;
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BasicPanel.java
@@ -49,6 +49,8 @@ import java.net.URL;
 import java.util.List;
 import java.util.logging.Level;
 
+import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
+
 /**
  * A Swing {@link javax.swing.JPanel} that encloses the Flying Saucer renderer
  * for easy integration into Swing applications.
@@ -99,28 +101,21 @@ public abstract class BasicPanel extends RootPanel implements FormSubmissionList
         // if this is the first time painting this document, then calc layout
         Layer root = getRootLayer();
         if (root == null || isNeedRelayout()) {
-            Graphics gg = g.create();
-            try {
-                doDocumentLayout(gg);
-            } finally {
-                gg.dispose();
-            }
+            withGraphics(g, gg -> doDocumentLayout(gg));
             root = getRootLayer();
         }
         setNeedRelayout(false);
         if (root == null) {
             XRLog.render(Level.FINE, "skipping the actual painting");
         } else {
-            Graphics gg = g.create();
-            try {
+            Layer rootLayer = root;
+            withGraphics(g, gg -> {
                 RenderingContext c = newRenderingContext((Graphics2D) gg);
                 long start = System.currentTimeMillis();
-                doRender(c, root);
+                doRender(c, rootLayer);
                 long end = System.currentTimeMillis();
                 XRLog.render(Level.FINE, "RENDERING TOOK " + (end - start) + " ms");
-            } finally {
-                gg.dispose();
-            }
+            });
         }
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BoxRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/BoxRenderer.java
@@ -41,6 +41,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
+
 /**
  * <p>Renders an XML files, formatted with CSS, as an Box. Input is a document in the form of file or URL,
  * and output is the root of the Box model. A BoxRenderer is not intended to be re-used for multiple document
@@ -213,8 +215,7 @@ public class BoxRenderer {
             height = this.height == -1 ? root.getHeight() : this.height;
             BufferedImage outputImage = createBufferedImage(this.width, height);
             outputDevice = new Java2DOutputDevice(outputImage);
-            Graphics2D newG = (Graphics2D) outputImage.getGraphics();
-            try {
+            withGraphics(outputImage, newG -> {
                 if ( renderingHints != null ) {
                     newG.getRenderingHints().putAll(renderingHints);
                 }
@@ -225,9 +226,7 @@ public class BoxRenderer {
                 sharedContext.getTextRenderer().setup(rc.getFontContext());
 
                 root.getLayer().paint(rc);
-            } finally {
-                if (newG != null) newG.dispose();
-            }
+            });
 
             rendered = true;
         }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
 
 /**
  * <p>Renders an XML files, formatted with CSS, as an image. Input is a document in the form of file or URL,
@@ -249,16 +250,14 @@ public class Java2DRenderer {
             height = this.height == -1 ? root.getHeight() : this.height;
             outputImage = createBufferedImage(this.width, height);
             outputDevice = new Java2DOutputDevice(outputImage);
-            Graphics2D newG = (Graphics2D) outputImage.getGraphics();
+            withGraphics(outputImage, newG -> {
+                RenderingContext rc = sharedContext.newRenderingContextInstance();
+                rc.setFontContext(new Java2DFontContext(newG));
+                rc.setOutputDevice(outputDevice);
+                sharedContext.getTextRenderer().setup(rc.getFontContext());
+                root.getLayer().paint(rc);
+            });
 
-            RenderingContext rc = sharedContext.newRenderingContextInstance();
-            rc.setFontContext(new Java2DFontContext(newG));
-            rc.setOutputDevice(outputDevice);
-            sharedContext.getTextRenderer().setup(rc.getFontContext());
-
-            root.getLayer().paint(rc);
-
-            newG.dispose();
             rendered = true;
         }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/DelegatingReplacedElementFactory.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/DelegatingReplacedElementFactory.java
@@ -27,6 +27,8 @@ import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,6 +44,8 @@ public class DelegatingReplacedElementFactory implements ReplacedElementFactory 
     private final Map<String, ElementReplacer> byNameReplacers = new HashMap<>();
     private final List<ERItem> elementReplacements = new ArrayList<>();
 
+    @Nullable
+    @CheckReturnValue
     @Override
     public ReplacedElement createReplacedElement(final LayoutContext context,
                                                  final BlockBox box,

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/DocumentDiffTest.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/DocumentDiffTest.java
@@ -37,6 +37,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.logging.Level;
 
+import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
+
 public class DocumentDiffTest {
     private static final int width = 500;
     private static final int height = 500;
@@ -88,11 +90,11 @@ public class DocumentDiffTest {
         renderer.setDocument(doc, new File(xhtml).toURI().toURL().toString());
 
         BufferedImage buff = new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
-        Graphics2D g = (Graphics2D) buff.getGraphics();
-
-        Dimension dim = new Dimension(width, height);
-        renderer.layout(g, dim);
-        renderer.render(g);
+        withGraphics(buff, g -> {
+            Dimension dim = new Dimension(width, height);
+            renderer.layout(g, dim);
+            renderer.render(g);
+        });
 
         getDiff(renderer.getPanel().getRootBox(), "");
         return "";

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/ElementReplacer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/test/ElementReplacer.java
@@ -1,14 +1,17 @@
 package org.xhtmlrenderer.test;
 
-import org.xhtmlrenderer.layout.LayoutContext;
+import org.w3c.dom.Element;
 import org.xhtmlrenderer.extend.ReplacedElement;
 import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
-import org.w3c.dom.Element;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * @author patrick
 */
+@ParametersAreNonnullByDefault
 public abstract class ElementReplacer {
     public abstract boolean isElementNameMatch();
 

--- a/flying-saucer-examples/src/main/java/ImageMapReplacedElementFactory.java
+++ b/flying-saucer-examples/src/main/java/ImageMapReplacedElementFactory.java
@@ -33,6 +33,10 @@ import org.xhtmlrenderer.swing.SwingReplacedElement;
 import org.xhtmlrenderer.swing.SwingReplacedElementFactory;
 import org.xhtmlrenderer.util.XRLog;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
@@ -46,12 +50,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import static java.util.Objects.requireNonNull;
+
 
 /**
  * Sample for handling image maps in XHTML, as replaced elements.
  *
  * Sample is incomplete in current state and meant as a starting point for future work.
  */
+@ParametersAreNonnullByDefault
 public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory {
    private final ImageMapListener listener;
    private static final String IMG_USEMAP_ATTR = "usemap";
@@ -69,13 +76,12 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
    private static final String POLYGON_SHAPE = "polygon";
 
    public ImageMapReplacedElementFactory(ImageMapListener listener) {
-       super(null);
-       if (null == listener) {
-         throw new IllegalArgumentException("listener required");
-      }
-      this.listener = listener;
+      super(null);
+      this.listener = requireNonNull(listener, "listener required");
    }
 
+   @Nullable
+   @CheckReturnValue
    @Override
    public ReplacedElement createReplacedElement(LayoutContext context, BlockBox box, UserAgentCallback uac, int cssWidth, int cssHeight) {
       Element e = box.getElement();
@@ -100,7 +106,8 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
       }
    }
 
-    private boolean isNotBlank(String _v) {
+    @CheckReturnValue
+    private boolean isNotBlank(@Nullable String _v) {
         if (_v == null || _v.isEmpty()) {
             return false;
         }
@@ -112,6 +119,8 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
     }
 
     // See SwingReplacedElementFactory#replaceImage
+   @Nonnull
+   @CheckReturnValue
    protected ReplacedElement replaceImageMap(UserAgentCallback uac, LayoutContext context, Element elem, String usemapAttr, int cssWidth, int cssHeight) {
       ReplacedElement re;
       // lookup in cache, or instantiate
@@ -154,13 +163,17 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
       return re;
    }
 
-    private static boolean areEqual(String str1, String str2) {
+    @CheckReturnValue
+    private static boolean areEqual(@Nullable String str1, @Nullable String str2) {
         return (str1 == null && str2 == null) || (str1 != null && str1.equals(str2));
     }
-    private static boolean areEqualIgnoreCase(String str1, String str2) {
+
+    @CheckReturnValue
+    private static boolean areEqualIgnoreCase(@Nullable String str1, @Nullable String str2) {
         return (str1 == null && str2 == null) || (str1 != null && str1.equalsIgnoreCase(str2));
     }
 
+    @ParametersAreNonnullByDefault
     private static final class ImageMapReplacedElement extends SwingReplacedElement {
       private final Map<Shape, String> areas;
 
@@ -207,7 +220,7 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
          }
       }
 
-      private static Map<Shape, String> parseMap(Node map) {
+      private static Map<Shape, String> parseMap(@Nullable Node map) {
          if (null == map) {
             return Collections.emptyMap();
          } else if (map.hasChildNodes()) {
@@ -250,11 +263,15 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
          }
       }
 
+      @Nullable
+      @CheckReturnValue
       private static String getAttribute(NamedNodeMap attrs, String attrName) {
          final Node node = attrs.getNamedItem(attrName);
          return null == node ? null : node.getNodeValue();
       }
 
+      @Nullable
+      @CheckReturnValue
       private static Shape getCoords(String[] coordValues, int length) {
          if ((-1 == length && 0 == coordValues.length % 2) || length == coordValues.length) {
             int[] coords = new int[coordValues.length];
@@ -290,6 +307,8 @@ public class ImageMapReplacedElementFactory extends SwingReplacedElementFactory 
          }
       }
 
+      @Nonnull
+      @CheckReturnValue
       private static JComponent create(Image image, int targetWidth, int targetHeight) {
          final JLabel component = new JLabel(new ImageIcon(image));
          component.setSize(component.getPreferredSize());

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/AbstractFormField.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/AbstractFormField.java
@@ -28,6 +28,7 @@ import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.util.Util;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.awt.*;
 
@@ -44,6 +45,7 @@ public abstract class AbstractFormField implements ITextReplacedElement {
     private int _width;
     private int _height;
 
+    @Nullable
     private String _fieldName;
 
     protected abstract String getFieldType();

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
@@ -20,7 +20,6 @@
 package org.xhtmlrenderer.pdf;
 
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.ReplacedElement;
 import org.xhtmlrenderer.extend.ReplacedElementFactory;
@@ -29,11 +28,15 @@ import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@ParametersAreNonnullByDefault
 public class ITextReplacedElementFactory implements ReplacedElementFactory {
     private final ITextOutputDevice _outputDevice;
 
@@ -44,6 +47,8 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
         _outputDevice = outputDevice;
     }
 
+    @Nullable
+    @CheckReturnValue
     @Override
     public ReplacedElement createReplacedElement(LayoutContext c, BlockBox box,
                                                  UserAgentCallback uac, int cssWidth, int cssHeight) {
@@ -102,22 +107,6 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
         return null;
     }
 
-    private boolean isTextarea(Element e) {
-        if (!e.getNodeName().equals("textarea")) {
-            return false;
-        }
-
-        Node n = e.getFirstChild();
-        while (n != null) {
-            short nodeType = n.getNodeType();
-            if (nodeType != Node.TEXT_NODE && nodeType != Node.CDATA_SECTION_NODE) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     private void saveResult(Element e, RadioButtonFormField result) {
         _radioButtonsByElem.put(e, result);
 
@@ -158,6 +147,8 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
         _radioButtonsByName.remove(fieldName);
     }
 
+    @Nullable
+    @CheckReturnValue
     public List<RadioButtonFormField> getRadioButtons(String name) {
         return _radioButtonsByName.get(name);
     }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TextFormField.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/TextFormField.java
@@ -34,6 +34,8 @@ import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.RenderingContext;
 import org.xhtmlrenderer.util.Util;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 
@@ -178,17 +180,10 @@ public class TextFormField extends AbstractFormField {
     }
   }
 
-  protected String getValue(Element e)
-  {
-    String result = e.getAttribute("value");
-    if (Util.isNullOrEmpty(result))
-    {
-      return "";
-    }
-    else
-    {
-      return result;
-    }
+  @Nonnull
+  @CheckReturnValue
+  protected String getValue(Element e) {
+    return e.getAttribute("value");
   }
 
   public int getBaseline()

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTReplacedElementFactory.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTReplacedElementFactory.java
@@ -30,6 +30,9 @@ import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
 import org.xhtmlrenderer.util.ImageUtil;
 import org.xhtmlrenderer.util.XRLog;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -37,6 +40,7 @@ import java.util.logging.Level;
 /**
  * @author Vianney le Clément
  */
+@ParametersAreNonnullByDefault
 public class SWTReplacedElementFactory implements ReplacedElementFactory {
     /**
      * Cache of image components (ReplacedElements) for quick lookup, keyed by
@@ -51,6 +55,9 @@ public class SWTReplacedElementFactory implements ReplacedElementFactory {
         reset();
     }
 
+    @Nullable
+    @CheckReturnValue
+    @Override
     public ReplacedElement createReplacedElement(LayoutContext c, BlockBox box,
             UserAgentCallback uac, int cssWidth, int cssHeight) {
         Element e = box.getElement();
@@ -79,6 +86,8 @@ public class SWTReplacedElementFactory implements ReplacedElementFactory {
      * @param cssHeight Target height of the image
      * @return A ReplacedElement for the image; will not be null.
      */
+    @Nullable
+    @CheckReturnValue
     protected ReplacedElement replaceImage(UserAgentCallback uac,
             LayoutContext context, Element elem, int cssWidth, int cssHeight) {
         ReplacedElement re = null;
@@ -131,6 +140,8 @@ public class SWTReplacedElementFactory implements ReplacedElementFactory {
      * @param e The element by which the image is keyed
      * @return The ReplacedElement for the image, or null if there is none.
      */
+    @Nullable
+    @CheckReturnValue
     protected ReplacedElement lookupImageReplacedElement(Element e) {
         return _imageComponents.get(e);
     }

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlReplacedElementFactory.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/simple/SWTXhtmlReplacedElementFactory.java
@@ -17,10 +17,13 @@ import org.xhtmlrenderer.swt.BasicRenderer;
 import org.xhtmlrenderer.swt.FormControlReplacementElement;
 import org.xhtmlrenderer.swt.SWTReplacedElementFactory;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashMap;
 import java.util.Map;
 
+@ParametersAreNonnullByDefault
 public class SWTXhtmlReplacedElementFactory extends SWTReplacedElementFactory {
     private final BasicRenderer _parent;
     private final Map<Element, XhtmlForm> _forms = new HashMap<>();
@@ -34,10 +37,14 @@ public class SWTXhtmlReplacedElementFactory extends SWTReplacedElementFactory {
      * @return the form corresponding to element {@code e} or {@code null} if none
      */
     @Nullable
+    @CheckReturnValue
     public XhtmlForm getForm(Element e) {
         return _forms.get(e);
     }
 
+    @Nullable
+    @CheckReturnValue
+    @Override
     public ReplacedElement createReplacedElement(LayoutContext c, BlockBox box,
             UserAgentCallback uac, int cssWidth, int cssHeight) {
         ReplacedElement re = super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
@@ -126,6 +133,8 @@ public class SWTXhtmlReplacedElementFactory extends SWTReplacedElementFactory {
         _controls.clear();
     }
 
+    @Nullable
+    @CheckReturnValue
     protected Element getParentForm(Element e, LayoutContext context) {
         Node node = e;
         XhtmlNamespaceHandler nsh = (XhtmlNamespaceHandler) context


### PR DESCRIPTION
This commit introduces utility method `ImageUtil.withGraphics()` that disposes the graphics object in try-with-resources block.