### PR TITLE
#403 don't embed slf4j-api in flying-saucer-pdf-osgi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Any of SLF4J implementations includes slf4j-api anyway.