### PR TITLE
#425 restore method ITestRenderer.getWriter()

### DIFF
--- a/flying-saucer-examples/src/test/java/org/xhtmlrenderer/pdf/PDFRenderToMultiplePagesTest.java
+++ b/flying-saucer-examples/src/test/java/org/xhtmlrenderer/pdf/PDFRenderToMultiplePagesTest.java
@@ -25,7 +25,7 @@ public class PDFRenderToMultiplePagesTest {
         String[] inputs = createSimpleFakeDocuments();
         generatePDF(inputs, output);
         log.info("Sample file with {} documents rendered as PDF to {}", inputs.length, output.toURI());
-        
+
         PDF pdf = new PDF(output);
         assertThat(pdf).containsText("Page1", "Page2", "Page3");
     }
@@ -39,6 +39,8 @@ public class PDFRenderToMultiplePagesTest {
             renderer.setDocumentFromString(inputs[0]);
             renderer.layout();
             renderer.createPDF(os, false);
+
+            renderer.getWriter().setFullCompression();
 
             // each page after the first we add using layout() followed by writeNextDocument()
             for (int i = 1; i < inputs.length; i++) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -547,10 +547,12 @@ public class ITextRenderer {
                 "\n<?xpacket end='r'?>";
     }
 
+    @CheckReturnValue
     public ITextOutputDevice getOutputDevice() {
         return _outputDevice;
     }
 
+    @CheckReturnValue
     public SharedContext getSharedContext() {
         return _sharedContext;
     }
@@ -561,14 +563,18 @@ public class ITextRenderer {
         _root.exportText(c, writer);
     }
 
+    @Nullable
+    @CheckReturnValue
     public BlockBox getRootBox() {
         return _root;
     }
 
+    @CheckReturnValue
     public float getDotsPerPoint() {
         return _dotsPerPoint;
     }
 
+    @CheckReturnValue
     public List<PagePosition> findPagePositionsByID(Pattern pattern) {
         return _outputDevice.findPagePositionsByID(newLayoutContext(), pattern);
     }
@@ -590,11 +596,19 @@ public class ITextRenderer {
         }
     }
 
+    @Nullable
+    @CheckReturnValue
     public PDFCreationListener getListener() {
         return _listener;
     }
 
     public void setListener(PDFCreationListener listener) {
         _listener = listener;
+    }
+
+    @Nullable
+    @CheckReturnValue
+    public PdfWriter getWriter() {
+        return _writer;
     }
 }


### PR DESCRIPTION
it still can be useful, e.g.:
```java
public class XmpMetadataPdfCreationListener extends DefaultPDFCreationListener {
    @Override
    public void preOpen(ITextRenderer iTextRenderer) {
        // ...
        iTextRenderer.getWriter().setXmpMetadata(...)
        // ...
    }
}
```