### PR TITLE
Add support for word-break:break-all CSS property.

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -1065,6 +1065,18 @@ public final class CSSName implements Comparable<CSSName> {
     /**
      * Unique CSSName instance for CSS3 property.
      */
+    public static final CSSName WORD_BREAK =
+            addProperty(
+                    "word-break",
+                    PRIMITIVE,
+                    "normal",
+                    INHERITS,
+                    new PrimitivePropertyBuilders.WordBreak()
+            );
+
+    /**
+     * Unique CSSName instance for CSS3 property.
+     */
     public static final CSSName WORD_WRAP =
             addProperty(
                     "word-wrap",

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/IdentValue.java
@@ -73,6 +73,7 @@ public class IdentValue implements FSDerivedValue {
     public static final IdentValue BORDER_BOX = addValue("border-box");
     public static final IdentValue BOTH = addValue("both");
     public static final IdentValue BOTTOM = addValue("bottom");
+    public static final IdentValue BREAK_ALL = addValue("break-all");
     public static final IdentValue CAPITALIZE = addValue("capitalize");
     public static final IdentValue CENTER = addValue("center");
     public static final IdentValue CIRCLE = addValue("circle");

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -1599,6 +1599,18 @@ public class PrimitivePropertyBuilders {
         }
     }
 
+    public static class WordBreak extends SingleIdent {
+        // normal | break-all
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] {
+                        IdentValue.NORMAL, IdentValue.BREAK_ALL});
+
+        @Override
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
     public static class WordWrap extends SingleIdent {
         // normal | break-word
         private static final BitSet ALLOWED = setFor(

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -676,6 +676,10 @@ public class CalculatedStyle {
         return getIdent(CSSName.WORD_WRAP);
     }
 
+    public IdentValue getWordBreak() {
+        return getIdent(CSSName.WORD_BREAK);
+    }
+
     public IdentValue getHyphens() {
         return getIdent(CSSName.HYPHENS);
     }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
@@ -112,7 +112,10 @@ public class Breaker {
         }
 
         context.setEndsOnNL(false);
-        doBreakText(c, context, avail, style, false);
+
+        boolean tryToBreakAnywhere = style.getWordBreak() == IdentValue.BREAK_ALL;
+
+        doBreakText(c, context, avail, style, tryToBreakAnywhere);
     }
 
     private static int getWidth(LayoutContext c, FSFont f, String text) {


### PR DESCRIPTION
This PR adds support for word-break:break-all CSS property: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#break-all