### PR TITLE
Fix PDFAsImage scaling and uses of FSImage.scale for immutability changes

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BlockBox.java
@@ -366,7 +366,7 @@ public class BlockBox extends Box implements InlinePaintable {
             return null;
         }
         if (img.getHeight() > structMetrics.getAscent()) {
-            img.scale(-1, (int) structMetrics.getAscent());
+            img = img.scale(-1, (int) structMetrics.getAscent());
         }
         return new ImageMarker(img, img.getWidth() * 2);
     }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/ImageResourceLoader.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/ImageResourceLoader.java
@@ -116,8 +116,11 @@ public class ImageResourceLoader {
     public synchronized ImageResource get(final String uri, final int width, final int height) {
         if (isEmbeddedBase64Image(uri)) {
             ImageResource resource = loadEmbeddedBase64ImageResource(uri);
-            resource.getImage().scale(width, height);
-            return resource;
+            FSImage scaledImage = resource.getImage();
+            if (scaledImage != null) {
+                scaledImage = scaledImage.scale(width, height);
+            }
+            return new ImageResource(resource.getImageUri(), scaledImage);
         } else {
             CacheKey key = new CacheKey(uri, width, height);
             ImageResource ir = _imageCache.get(key);

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
@@ -63,7 +63,7 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
                     FSImage fsImage = uac.getImageResource(srcAttr).getImage();
                     if (fsImage != null) {
                         if (cssWidth != -1 || cssHeight != -1) {
-                            fsImage.scale(cssWidth, cssHeight);
+                            fsImage = fsImage.scale(cssWidth, cssHeight);
                         }
                         return new ITextImageElement(fsImage);
                     }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/PDFAsImage.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/PDFAsImage.java
@@ -39,6 +39,14 @@ public class PDFAsImage implements FSImage {
         _unscaledHeight = height;
     }
 
+    private PDFAsImage(URI source, float unscaledWidth, float unscaledHeight, float width, float height) {
+        _source = source;
+        _width = width;
+        _unscaledWidth = unscaledWidth;
+        _height = height;
+        _unscaledHeight = unscaledHeight;
+    }
+
     @Override
     public int getWidth() {
         return (int)_width;
@@ -62,7 +70,7 @@ public class PDFAsImage implements FSImage {
             targetHeight = getHeightAsFloat() * (targetWidth / getWidth());
         }
 
-        return new PDFAsImage(_source, targetWidth, targetHeight);
+        return new PDFAsImage(_source, _width, _height, targetWidth, targetHeight);
     }
 
     public URI getURI() {


### PR DESCRIPTION
https://github.com/flyingsaucerproject/flyingsaucer/commit/2ce6f9f05a058485185af39d7757b7ded8033280#diff-d210bc82c50b9ada2d6d90ecc8bb3688eaa4df211c1dd891615590558b732759R65 seems to have broken scaling of `<img>` tags which reference `.pdf` files - `ITextReplacedElementFactory` wasn't updated to use the new return value.

This PR updates the remaining usages of `FSImage.scale` to use the returned `FSImage` instead of the existing object, and passes through the unscaled width and height to the new `PDFAsImage` in `PDFAsImage.scale`.