### PR TITLE
#481 [bugfix] flip bottom left and right radius

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/derived/BorderPropertySet.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/derived/BorderPropertySet.java
@@ -33,13 +33,14 @@ import static org.xhtmlrenderer.css.constants.CSSName.BORDER_TOP_WIDTH;
 import static org.xhtmlrenderer.css.constants.IdentValue.HIDDEN;
 import static org.xhtmlrenderer.css.constants.IdentValue.NONE;
 import static org.xhtmlrenderer.css.parser.FSRGBColor.TRANSPARENT;
+import static org.xhtmlrenderer.css.style.BorderRadiusCorner.UNDEFINED;
 
 /**
  * User: patrick
  * Date: Oct 21, 2005
  */
 public class BorderPropertySet extends RectPropertySet {
-    private static final Corners NO_CORNERS = new Corners(BorderRadiusCorner.UNDEFINED, BorderRadiusCorner.UNDEFINED, BorderRadiusCorner.UNDEFINED, BorderRadiusCorner.UNDEFINED);
+    private static final Corners NO_CORNERS = new Corners(UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED);
     private static final Styles NO_STYLES = new Styles(null, null, null, null);
     private static final Colors NO_COLORS = new Colors(TRANSPARENT, TRANSPARENT, TRANSPARENT, TRANSPARENT);
     public static final BorderPropertySet EMPTY_BORDER = new BorderPropertySet(0.0f, 0.0f, 0.0f, 0.0f, NO_STYLES, NO_CORNERS, NO_COLORS);
@@ -70,7 +71,7 @@ public class BorderPropertySet extends RectPropertySet {
     }
 
     private record Corners(BorderRadiusCorner topLeft, BorderRadiusCorner topRight,
-                           BorderRadiusCorner bottomLeft, BorderRadiusCorner bottomRight) {
+                           BorderRadiusCorner bottomRight, BorderRadiusCorner bottomLeft) {
     }
 
     private final Styles styles;
@@ -130,8 +131,8 @@ public class BorderPropertySet extends RectPropertySet {
                 new Corners(
                         new BorderRadiusCorner(BORDER_TOP_LEFT_RADIUS, style, ctx),
                         new BorderRadiusCorner(BORDER_TOP_RIGHT_RADIUS, style, ctx),
-                        new BorderRadiusCorner(BORDER_BOTTOM_LEFT_RADIUS, style, ctx),
-                        new BorderRadiusCorner(BORDER_BOTTOM_RIGHT_RADIUS, style, ctx)
+                        new BorderRadiusCorner(BORDER_BOTTOM_RIGHT_RADIUS, style, ctx),
+                        new BorderRadiusCorner(BORDER_BOTTOM_LEFT_RADIUS, style, ctx)
                 ),
                 new Colors(
                         style.asColor(BORDER_TOP_COLOR),

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/BorderPainter.java
@@ -37,7 +37,7 @@ public class BorderPainter {
     public static final int LEFT = 2;
     public static final int BOTTOM = 4;
     public static final int RIGHT = 8;
-    public static final int ALL = TOP + LEFT + BOTTOM + RIGHT;
+    public static final int ALL = TOP | LEFT | BOTTOM | RIGHT;
 
     /**
      * Generates a full round rectangle that is made of bounds and border

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LeftRightBorderTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LeftRightBorderTest.java
@@ -1,0 +1,36 @@
+package org.xhtmlrenderer.pdf;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static org.xhtmlrenderer.pdf.TestUtils.printFile;
+
+public class LeftRightBorderTest {
+    private static final Logger log = LoggerFactory.getLogger(LeftRightBorderTest.class);
+
+    @Test
+    public void deepHierarchyInCss() throws IOException {
+        byte[] bytes = generatePdf("left-right-border.html");
+        PDF pdf = printFile(log, bytes, "left-right-border.pdf");
+        assertThat(pdf).containsText(
+            "Border top left radius",
+            "Border top right radius",
+            "Border bottom left radius",
+            "Border bottom right radius"
+        );
+    }
+
+    private byte[] generatePdf(String htmlPath) {
+        URL htmlUrl = requireNonNull(currentThread().getContextClassLoader().getResource(htmlPath),
+                () -> "Test resource not found: " + htmlPath);
+        return Html2Pdf.fromUrl(htmlUrl);
+    }
+}

--- a/flying-saucer-pdf/src/test/resources/left-right-border.html
+++ b/flying-saucer-pdf/src/test/resources/left-right-border.html
@@ -1,0 +1,47 @@
+<html lang="en">
+<head>
+    <title>TEST</title>
+
+    <style>
+        div {
+            background-color: cornflowerblue;
+            color: white;
+            padding: 10px;
+            margin: 10px;
+            width: 50%;
+            text-align: center;
+        }
+
+        .border-bottom-left {
+            border-bottom-left-radius: 30px;
+        }
+
+        .border-bottom-right {
+            border-bottom-right-radius: 30px;
+        }
+
+        .border-top-left {
+            border-top-left-radius: 30px;
+        }
+
+        .border-top-right {
+            border-top-right-radius: 30px;
+        }
+    </style>
+</head>
+<body>
+<div class="border-top-left">
+    <span>Border top left radius</span>
+</div>
+<div class="border-top-right">
+    <span>Border top right radius</span>
+</div>
+<div class="border-bottom-left">
+    <span>Border bottom left radius</span>
+</div>
+<div class="border-bottom-right">
+    <span>Border bottom right radius</span>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
the bug was in method `BorderPropertySet.normalizedInstance` which used left and right bottom corners in the opposite order.