### PR TITLE
Make mockito a test scoped dependency

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -39,6 +39,7 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>5.17.0</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Make mockito-core a test scoped dependency, to avoid pulling a specific version of mockito-core in as a transitive dependency, that may cause dependency convergence issues. 