### PR TITLE
issue #530 page-break-inside: avoid not working fix

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
@@ -93,7 +93,7 @@ public class BlockBoxing {
             if (c.isPrint()) {
                 boolean needPageClear = child.isNeedPageClear();
                 if (needPageClear || mayCheckKeepTogether) {
-                    c.setMayCheckKeepTogether(mayCheckKeepTogether);
+                    if (mayCheckKeepTogether) c.setMayCheckKeepTogether(true);
                     boolean tryToAvoidPageBreak = child.getStyle().isAvoidPageBreakInside() && child.crossesPageBreak(c);
                     boolean keepWithInline = child.isNeedsKeepWithInline(c);
                     if (tryToAvoidPageBreak || needPageClear || keepWithInline) {


### PR DESCRIPTION
Correction of the #530 issue.
There was a problem in the `BlockBoxing::layoutContent` function.
I did it coherent with the `BlockBoxing::relayoutRun` function :
`mayCheckKeepTogether` is now  reverted to its initial value (was always  set to false before when only a page clear was needed )
