### PR TITLE
Restore image size logic

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFSImage.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFSImage.java
@@ -19,38 +19,49 @@
  */
 package org.xhtmlrenderer.pdf;
 
+import com.lowagie.text.Image;
 import org.jspecify.annotations.NonNull;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.Size;
 
-public class ITextFSImage implements FSImage {
-    protected final byte[] image;
-    protected final Size size;
-    protected final String uri;
+public class ITextFSImage implements FSImage, Cloneable {
+    private final Image image;
 
-    public ITextFSImage(byte[] image, Size size, String uri) {
+    public ITextFSImage(Image image) {
         this.image = image;
-        this.size = size;
-        this.uri = uri;
     }
 
     @Override
     public int getWidth() {
-        return size.width();
+        return (int) image.getPlainWidth();
     }
 
     @Override
     public int getHeight() {
-        return size.height();
+        return (int) image.getPlainHeight();
     }
 
     @NonNull
     @Override
     public FSImage scale(int width, int height) {
-        return new ITextFSImage(image, size.scale(width, height), uri);
+        Size current = new Size(getWidth(), getHeight());
+        Size target = current.scale(width, height);
+
+        if (!target.equals(current)) {
+            Image scaledImage = Image.getInstance(image);
+            scaledImage.scaleAbsolute(target.width(), target.height());
+            return new ITextFSImage(scaledImage);
+        }
+        return this;
     }
 
-    public byte[] getImage() {
+    public Image getImage() {
         return image;
+    }
+
+    @Override
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    public Object clone() {
+        return new ITextFSImage(Image.getInstance(image));
     }
 }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -866,9 +866,7 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
         if (fsImage instanceof PDFAsImage pdfAsImage) {
             drawPDFAsImage(pdfAsImage, x, y);
         } else if (fsImage instanceof ITextFSImage iTextImage) {
-            byte[] imageBytes = iTextImage.getImage();
-
-            Image image = createItextImage(imageBytes);
+            Image image = iTextImage.getImage();
 
             if (fsImage.getHeight() <= 0 || fsImage.getWidth() <= 0) {
                 return;
@@ -894,14 +892,6 @@ public class ITextOutputDevice extends AbstractOutputDevice implements OutputDev
         }
         else {
             throw new UnsupportedOperationException("Unsupported image type: " + fsImage.getClass().getName());
-        }
-    }
-
-    private Image createItextImage(byte[] imageBytes) {
-        try {
-            return Image.getInstance(imageBytes);
-        } catch (IOException e) {
-            throw new XRRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/SvgImage.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/SvgImage.java
@@ -1,25 +1,7 @@
-/*
- * {{{ header & license
- * Copyright (c) 2006 Wisconsin Court System
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation; either version 2.1
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- * }}}
- */
 package org.xhtmlrenderer.pdf;
 
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.lowagie.text.Image;
 import org.apache.batik.transcoder.Transcoder;
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
@@ -28,14 +10,33 @@ import org.apache.batik.transcoder.image.PNGTranscoder;
 import org.jspecify.annotations.NonNull;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.Size;
+import org.xhtmlrenderer.util.XRRuntimeException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class SvgImage extends ITextFSImage {
+    protected final byte[] image;
+    protected final Size size;
+    protected final String uri;
+
+    @SuppressWarnings("DataFlowIssue")
     public SvgImage(byte[] image, Size size, String uri) {
-        super(image, size, uri);
+        super(null); // bad design - just to keep backward compatibility (the original ITextFSImage API)
+        this.image = image;
+        this.size = size;
+        this.uri = uri;
+    }
+
+    @Override
+    public int getWidth() {
+        return size.width();
+    }
+
+    @Override
+    public int getHeight() {
+        return size.height();
     }
 
     @NonNull
@@ -46,7 +47,7 @@ public class SvgImage extends ITextFSImage {
     }
 
     @Override
-    public byte[] getImage() {
+    public Image getImage() {
         Transcoder transcoder = new PNGTranscoder();
         transcoder.addTranscodingHint(PNGTranscoder.KEY_WIDTH, 1.0f * getWidth());
         transcoder.addTranscodingHint(PNGTranscoder.KEY_HEIGHT, 1.0f * getHeight());
@@ -55,11 +56,24 @@ public class SvgImage extends ITextFSImage {
             try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                 transcoder.transcode(new TranscoderInput(in), new TranscoderOutput(out));
                 out.flush();
-                return out.toByteArray();
+                return createItextImage(out.toByteArray());
             }
-        }
-        catch (IOException | TranscoderException e) {
+        } catch (IOException | TranscoderException e) {
             throw new RuntimeException("Failed to convert SVG to PNG (%s)".formatted(uri), e);
         }
+    }
+
+    private static Image createItextImage(byte[] imageBytes) {
+        try {
+            return Image.getInstance(imageBytes);
+        } catch (IOException e) {
+            throw new XRRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    public Object clone() {
+        return this;
     }
 }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextUserAgentTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextUserAgentTest.java
@@ -6,16 +6,10 @@ import org.xhtmlrenderer.extend.Size;
 import java.io.IOException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ITextUserAgentTest {
     private final ITextUserAgent agent = new ITextUserAgent(new ITextOutputDevice(1.0f), 1);
-
-    @Test
-    void pngSize() throws IOException {
-        assertThat(agent.getOriginalImageSize(resourceToByteArray("/flyingsaucer.png"))).isEqualTo(new Size(109, 92));
-    }
 
     @Test
     void svg_withWidthAndHeightAttributes() throws IOException {


### PR DESCRIPTION
* #539 restore original design of ITextFSImage (which might be used by FS users)
* #537 restore manipulation with "dots per pixel" in method `scaleToOutputResolution()` - I still don't get it, but seems it affected the image size
* #540 instead of creating a fake `new Size(-1, -1)`, read the actual image size.