### PR TITLE
bump to latest compatible openpdf (2.4.0) - requires Java 21 as baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <openpdf.version>2.0.5</openpdf.version>
+    <openpdf.version>2.4.0</openpdf.version>
     <batik.version>1.19</batik.version>
     <commons-io.version>2.20.0</commons-io.version>
     <junit.version>5.13.4</junit.version>


### PR DESCRIPTION
commit/PR by renovate was closed (https://github.com/flyingsaucerproject/flyingsaucer/pull/548) as it was superseded by https://github.com/flyingsaucerproject/flyingsaucer/pull/553

relates to #554