### PR TITLE
Exclude legacy XML libraries imported by Batik to prevent JPMS conflicts

### DIFF
--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -39,6 +39,22 @@
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-codec</artifactId>
       <version>${batik.version}</version>
+      <exclusions>
+          <!-- Exclude legacy XML libraries (xml-apis, xerces, xalan) that duplicate java.xml.
+               Prevents JPMS module conflicts and ensures Java 11+ compatibility. -->
+        <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Removed xml-apis, xercesImpl, and xalan from Flying Saucer dependency batik (https://github.com/apache/xmlgraphics-batik) , since these are already provided by the JDK's java.xml module in modern Java versions. This fixes "org.w3c.dom accessible from more than one module" errors and improves Java 11+ compatibility.

This will resolve the following compilation error:
> ajc: The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml

These libraries were historically included to support older JDKs (pre-Java 6) that lacked built-in XML APIs. On modern Java versions, they are redundant and cause package duplication under the JPMS module system. Removing them ensures a clean dependency tree, eliminates duplicate classes, and allows Flying Saucer to build and run cleanly on all supported Java 11+ environments.

I discovered this error when updating to Flying Saucer 10 in the accounting software I am working on...

<img width="1298" height="418" alt="image" src="https://github.com/user-attachments/assets/5638ef1c-8a7f-4053-9956-1853629a06b8" />


This issue could also be reported to batik as a bug there, I might get around to doing that soon.
https://xmlgraphics.apache.org/batik/   
https://github.com/apache/xmlgraphics-batik   

