### PR TITLE
Include OpenPDF version in PDF producer string

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -40,6 +40,7 @@ import org.xhtmlrenderer.layout.BoxBuilder;
 import org.xhtmlrenderer.layout.Layer;
 import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.layout.SharedContext;
+import org.xhtmlrenderer.pdf.util.VersionUtil;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.PageBox;
 import org.xhtmlrenderer.render.RenderingContext;
@@ -77,9 +78,9 @@ public class ITextRenderer {
     public static final float DEFAULT_DOTS_PER_POINT = 20f * 4f / 3f;
     public static final int DEFAULT_DOTS_PER_PIXEL = 20;
 
-    // TODO: Ideally the PDF producer version should be automatically updated.
-    private String pdfProducer = "Flying Saucer 10 with OpenPDF 3.";
-    private String pdfCreator = "Flying Saucer 10 with OpenPDF 3.";
+    // TODO: Ideally the Flying Saucer version should be automatically updated.
+    private String pdfProducer = "Flying Saucer 10 with OpenPDF " + VersionUtil.getOpenPDFVersionNumber();
+    private String pdfCreator = "Flying Saucer 10 with OpenPDF " + VersionUtil.getOpenPDFVersionNumber();
     private int compression = 9;
     private boolean compressionEnabled = true;
 

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/util/VersionUtil.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/util/VersionUtil.java
@@ -1,0 +1,31 @@
+package org.xhtmlrenderer.pdf.util;
+
+import org.openpdf.text.Document;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Utility class to get OpenPDF version information.
+ */
+public class VersionUtil {
+
+    private static final String VERSION_PROPERTIES = "org/openpdf/text/version.properties";
+
+    public static String getOpenPDFVersionNumber() {
+        String releaseVersion = "UNKNOWN";
+        try (InputStream input = Document.class.getClassLoader()
+            .getResourceAsStream(VERSION_PROPERTIES)) {
+            if (input != null) {
+                Properties prop = new Properties();
+                prop.load(input);
+                releaseVersion = prop.getProperty("bundleVersion", releaseVersion);
+            }
+        } catch (IOException ignored) {
+            // ignore this and leave the default
+        }
+        return releaseVersion;
+    }
+
+}


### PR DESCRIPTION
Include OpenPDF version in PDF file producer string.

In a follow up task, one could update Flying Saucer to write it's version as Implementation-Version to it's own MANIFEST file and show that version in ITextRenderer PDF producer string also. I think this would be best done by the maintainer of FS so they get it exactly the way they want.

See https://github.com/flyingsaucerproject/flyingsaucer/pull/586