### PR TITLE
#596 Fix "1. The cell borders are rendered outside the table border"

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
@@ -772,7 +772,20 @@ public class TableCellBox extends BlockBox {
     @CheckReturnValue
     private Rectangle getCollapsedBorderBounds(CssContext c) {
         BorderPropertySet border = getCollapsedPaintingBorder();
-        Rectangle bounds = getPaintingBorderEdge(c);
+        Rectangle bounds;
+
+        // Use content-limited border edge for paginated tables to prevent borders
+        // from extending beyond table boundaries when spanning multiple pages
+        if (
+            c instanceof RenderingContext && ((RenderingContext) c).isPrint() &&
+            getTable() != null && getTable().getStyle() != null &&
+            getTable().getStyle().isPaginateTable()
+        ) {
+            bounds = getContentLimitedBorderEdge((RenderingContext) c);
+        } else {
+            bounds = getPaintingBorderEdge(c);
+        }
+
         bounds.x -= (int) border.left() / 2;
         bounds.y -= (int) border.top() / 2;
         bounds.width += (int) border.left() / 2 + ((int) border.right() + 1) / 2;


### PR DESCRIPTION

This PR addresses the issue https://github.com/flyingsaucerproject/flyingsaucer/issues/596 (issue 1 -> "1. The cell borders are rendered outside the table border").
If -fs-table-paginate: paginate; (isPaginateTable()) is used, the getCollapsedBorderBounds() method has been modified to return getContentLimitedBorderEdge().
Please evaluate whether this change is valid.
Thank you.