### PR TITLE
#611 fix NPE when table doesn't have "content limited border"

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
@@ -852,6 +852,9 @@ public class TableCellBox extends BlockBox {
             getTable().getStyle().isPaginateTable()
         ) {
             bounds = getContentLimitedBorderEdge(renderingContext);
+            if (bounds == null) {
+                bounds = getPaintingBorderEdge(c);
+            }
             bounds = adjustBoundsToAvoidTheadOverlap(renderingContext, bounds);
         } else {
             bounds = getPaintingBorderEdge(c);


### PR DESCRIPTION
I have no idea what it means, but before commit e8f4c72048bde00, method `getCollapsedBorderBounds()` always returned `getPaintingBorderEdge(c)`.