### PR TITLE
Add support for has pseudo class and columns

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -28,6 +28,7 @@ import org.xhtmlrenderer.css.parser.property.BackgroundPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.BorderPropertyBuilders;
 import org.xhtmlrenderer.css.parser.property.BorderSpacingPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.ContentPropertyBuilder;
+import org.xhtmlrenderer.css.parser.property.ColumnsPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.CounterPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.FontPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.ListStylePropertyBuilder;
@@ -436,6 +437,33 @@ public final class CSSName implements Comparable<CSSName> {
                     "none",
                     NOT_INHERITED,
                     new PrimitivePropertyBuilders.Clear()
+            );
+
+    public static final CSSName COLUMN_COUNT =
+            addProperty(
+                    "column-count",
+                    PRIMITIVE,
+                    "auto",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.ColumnCount()
+            );
+
+    public static final CSSName COLUMN_GAP =
+            addProperty(
+                    "column-gap",
+                    PRIMITIVE,
+                    "normal",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.ColumnGap()
+            );
+
+    public static final CSSName COLUMN_WIDTH =
+            addProperty(
+                    "column-width",
+                    PRIMITIVE,
+                    "auto",
+                    NOT_INHERITED,
+                    new PrimitivePropertyBuilders.ColumnWidth()
             );
 
     /**
@@ -1590,6 +1618,15 @@ public final class CSSName implements Comparable<CSSName> {
                     "0",
                     INHERITS,
                     new BorderSpacingPropertyBuilder()
+            );
+
+    public static final CSSName COLUMNS_SHORTHAND =
+            addProperty(
+                    "columns",
+                    SHORTHAND,
+                    "auto auto",
+                    NOT_INHERITED,
+                    new ColumnsPropertyBuilder()
             );
 
     /**

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Condition.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Condition.java
@@ -22,6 +22,7 @@ package org.xhtmlrenderer.css.newmatch;
 import org.w3c.dom.Node;
 import org.xhtmlrenderer.css.extend.AttributeResolver;
 import org.xhtmlrenderer.css.extend.TreeResolver;
+import org.xhtmlrenderer.css.newmatch.Selector.Axis;
 import org.xhtmlrenderer.css.parser.CSSParseException;
 
 import java.util.ArrayList;
@@ -158,6 +159,10 @@ abstract class Condition {
      */
     static Condition createUnsupportedCondition() {
         return new UnsupportedCondition();
+    }
+
+    static Condition createHasCondition(List<Selector.HasRelativeSelector> relativeSelectors) {
+        return new HasCondition(relativeSelectors);
     }
 
     private abstract static class AttributeCompareCondition extends Condition {
@@ -468,6 +473,142 @@ abstract class Condition {
             return false;
         }
 
+    }
+
+    private static class HasCondition extends Condition {
+        private final List<Selector.HasRelativeSelector> relativeSelectors;
+
+        private HasCondition(List<Selector.HasRelativeSelector> relativeSelectors) {
+            this.relativeSelectors = relativeSelectors;
+        }
+
+        @Override
+        boolean matches(Node e, AttributeResolver attRes, TreeResolver treeRes) {
+            for (Selector.HasRelativeSelector relativeSelector : relativeSelectors) {
+                if (matchesRelativeSelector(e, attRes, treeRes, relativeSelector)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean matchesRelativeSelector(Node scope, AttributeResolver attRes, TreeResolver treeRes, Selector.HasRelativeSelector relativeSelector) {
+            List<Axis> axes = relativeSelector.axes();
+            List<Selector> selectors = relativeSelector.selectors();
+            Axis firstAxis = axes.getFirst();
+            for (Node candidate : findCandidates(scope, firstAxis)) {
+                if (matchesRelativeSelectorAt(scope, candidate, selectors.size() - 1, selectors, axes, attRes, treeRes)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean matchesRelativeSelectorAt(
+                Node scope,
+                Node candidate,
+                int selectorIndex,
+                List<Selector> selectors,
+                List<Axis> axes,
+                AttributeResolver attRes,
+                TreeResolver treeRes) {
+            Selector selector = selectors.get(selectorIndex);
+            if (!selector.matches(candidate, attRes, treeRes) || !selector.matchesDynamic(candidate, attRes, treeRes)) {
+                return false;
+            }
+
+            Axis relation = axes.get(selectorIndex);
+            if (selectorIndex == 0) {
+                return matchesScopeRelation(scope, candidate, relation, treeRes);
+            }
+
+            return switch (relation) {
+                case CHILD_AXIS -> {
+                    Node parent = treeRes.getParentElement(candidate);
+                    yield parent != null && matchesRelativeSelectorAt(scope, parent, selectorIndex - 1, selectors, axes, attRes, treeRes);
+                }
+                case IMMEDIATE_SIBLING_AXIS -> {
+                    Node previous = treeRes.getPreviousSiblingElement(candidate);
+                    yield previous != null && matchesRelativeSelectorAt(scope, previous, selectorIndex - 1, selectors, axes, attRes, treeRes);
+                }
+                case DESCENDANT_AXIS -> {
+                    Node ancestor = treeRes.getParentElement(candidate);
+                    boolean matched = false;
+                    while (ancestor != null) {
+                        if (matchesRelativeSelectorAt(scope, ancestor, selectorIndex - 1, selectors, axes, attRes, treeRes)) {
+                            matched = true;
+                            break;
+                        }
+                        ancestor = treeRes.getParentElement(ancestor);
+                    }
+                    yield matched;
+                }
+            };
+        }
+
+        private boolean matchesScopeRelation(Node scope, Node candidate, Axis relation, TreeResolver treeRes) {
+            return switch (relation) {
+                case CHILD_AXIS -> scope == treeRes.getParentElement(candidate);
+                case IMMEDIATE_SIBLING_AXIS -> scope == treeRes.getPreviousSiblingElement(candidate);
+                case DESCENDANT_AXIS -> isDescendantOf(candidate, scope, treeRes);
+            };
+        }
+
+        private boolean isDescendantOf(Node candidate, Node scope, TreeResolver treeRes) {
+            Node parent = treeRes.getParentElement(candidate);
+            while (parent != null) {
+                if (parent == scope) {
+                    return true;
+                }
+                parent = treeRes.getParentElement(parent);
+            }
+            return false;
+        }
+
+        private List<Node> findCandidates(Node scope, Axis firstAxis) {
+            return switch (firstAxis) {
+                case CHILD_AXIS -> findChildElements(scope);
+                case DESCENDANT_AXIS -> findDescendantElements(scope);
+                case IMMEDIATE_SIBLING_AXIS -> findNextSiblingElement(scope);
+            };
+        }
+
+        private List<Node> findChildElements(Node scope) {
+            List<Node> result = new ArrayList<>();
+            Node child = scope.getFirstChild();
+            while (child != null) {
+                if (child.getNodeType() == Node.ELEMENT_NODE) {
+                    result.add(child);
+                }
+                child = child.getNextSibling();
+            }
+            return result;
+        }
+
+        private List<Node> findDescendantElements(Node scope) {
+            List<Node> result = new ArrayList<>();
+            collectDescendantElements(scope, result);
+            return result;
+        }
+
+        private void collectDescendantElements(Node node, List<Node> acc) {
+            Node child = node.getFirstChild();
+            while (child != null) {
+                if (child.getNodeType() == Node.ELEMENT_NODE) {
+                    acc.add(child);
+                    collectDescendantElements(child, acc);
+                }
+                child = child.getNextSibling();
+            }
+        }
+
+        private List<Node> findNextSiblingElement(Node scope) {
+            Node sibling = scope.getNextSibling();
+            while (sibling != null && sibling.getNodeType() != Node.ELEMENT_NODE) {
+                sibling = sibling.getNextSibling();
+            }
+            return sibling == null ? List.of() : List.of(sibling);
+        }
     }
 
     private static String[] split(String s, char ch) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Selector.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/newmatch/Selector.java
@@ -42,6 +42,14 @@ import static org.xhtmlrenderer.css.newmatch.Selector.Axis.DESCENDANT_AXIS;
  * @author Torbjoern Gannholm
  */
 public class Selector {
+    public record HasRelativeSelector(List<Axis> axes, List<Selector> selectors) {
+        public HasRelativeSelector {
+            if (axes == null || selectors == null || axes.isEmpty() || selectors.isEmpty() || axes.size() != selectors.size()) {
+                throw new IllegalArgumentException("Axes/selectors must be non-empty and same size");
+            }
+        }
+    }
+
     private final Ruleset _parent;
     private Selector chainedSelector;
     private Selector siblingSelector;
@@ -203,6 +211,13 @@ public class Selector {
     public void addLangCondition(String lang) {
         _specificityC++;
         addCondition(Condition.createLangCondition(lang));
+    }
+
+    public void addHasCondition(List<HasRelativeSelector> relativeSelectors, int specificityB, int specificityC, int specificityD) {
+        _specificityB += specificityB;
+        _specificityC += specificityC;
+        _specificityD += specificityD;
+        addCondition(Condition.createHasCondition(relativeSelectors));
     }
 
     /**

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -1202,6 +1202,11 @@ public class CSSParser {
                     throw e;
                 }
             }
+            case "has" -> {
+                HasPseudoClassResult result = parseHasPseudoClass(selector.getRuleset());
+                selector.addHasCondition(result.relativeSelectors(), result.specificityB(), result.specificityC(), result.specificityD());
+                t = result.lastToken();
+            }
             default -> {
                 push(t);
                 throw new CSSParseException(f + " is not a valid function in this context", getCurrentLine());
@@ -1212,6 +1217,120 @@ public class CSSParser {
             push(t);
             throw new CSSParseException(t, Token.TK_RPAREN, getCurrentLine());
         }
+    }
+
+    private HasPseudoClassResult parseHasPseudoClass(Ruleset ruleset) throws IOException {
+        skip_whitespace();
+        List<Selector.HasRelativeSelector> relativeSelectors = new ArrayList<>();
+        int maxSpecificityB = 0;
+        int maxSpecificityC = 0;
+        int maxSpecificityD = 0;
+
+        while (true) {
+            Token t = la();
+            if (t == Token.TK_RPAREN) {
+                if (relativeSelectors.isEmpty()) {
+                    throw new CSSParseException("The :has() pseudo-class requires a non-empty selector argument", getCurrentLine());
+                }
+                return new HasPseudoClassResult(relativeSelectors, maxSpecificityB, maxSpecificityC, maxSpecificityD, next());
+            }
+
+            if (t == Token.TK_COMMA) {
+                throw new CSSParseException("The :has() pseudo-class does not allow empty selectors", getCurrentLine());
+            }
+
+            ParsedRelativeSelector parsed = parseRelativeSelectorInHas(ruleset);
+            relativeSelectors.add(parsed.relativeSelector());
+            maxSpecificityB = Math.max(maxSpecificityB, parsed.specificityB());
+            maxSpecificityC = Math.max(maxSpecificityC, parsed.specificityC());
+            maxSpecificityD = Math.max(maxSpecificityD, parsed.specificityD());
+
+            skip_whitespace();
+            t = next();
+            if (t == Token.TK_COMMA) {
+                skip_whitespace();
+            } else if (t == Token.TK_RPAREN) {
+                return new HasPseudoClassResult(relativeSelectors, maxSpecificityB, maxSpecificityC, maxSpecificityD, t);
+            } else {
+                push(t);
+                throw new CSSParseException(t, new Token[] {Token.TK_COMMA, Token.TK_RPAREN}, getCurrentLine());
+            }
+        }
+    }
+
+    private ParsedRelativeSelector parseRelativeSelectorInHas(Ruleset ruleset) throws IOException {
+        List<Axis> axes = new ArrayList<>();
+        List<Selector> selectors = new ArrayList<>();
+
+        Axis currentAxis = DESCENDANT_AXIS;
+        Token t = la();
+        if (t == Token.TK_PLUS || t == Token.TK_GREATER) {
+            currentAxis = combinatorToAxis(combinator());
+        }
+
+        selectors.add(simple_selector(ruleset));
+        axes.add(currentAxis);
+
+        int specificityB = selectors.get(0).getSpecificityB();
+        int specificityC = selectors.get(0).getSpecificityC();
+        int specificityD = selectors.get(0).getSpecificityD();
+
+        while (true) {
+            t = la();
+            if (t == Token.TK_RPAREN || t == Token.TK_COMMA) {
+                break;
+            }
+            if (t != Token.TK_PLUS && t != Token.TK_GREATER && t != Token.TK_S) {
+                throw new CSSParseException(
+                        t,
+                        new Token[]{Token.TK_PLUS, Token.TK_GREATER, Token.TK_S, Token.TK_COMMA, Token.TK_RPAREN},
+                        getCurrentLine());
+            }
+
+            Axis axis = combinatorToAxis(combinator());
+            t = la();
+            if (!isSimpleSelectorStart(t)) {
+                throw new CSSParseException(
+                        t,
+                        new Token[]{Token.TK_IDENT, Token.TK_ASTERISK, Token.TK_HASH, Token.TK_PERIOD, Token.TK_LBRACKET, Token.TK_COLON},
+                        getCurrentLine());
+            }
+            Selector next = simple_selector(ruleset);
+            selectors.add(next);
+            axes.add(axis);
+            specificityB += next.getSpecificityB();
+            specificityC += next.getSpecificityC();
+            specificityD += next.getSpecificityD();
+        }
+
+        return new ParsedRelativeSelector(new Selector.HasRelativeSelector(axes, selectors), specificityB, specificityC, specificityD);
+    }
+
+    private Axis combinatorToAxis(Token combinator) {
+        if (combinator == Token.TK_PLUS) {
+            return IMMEDIATE_SIBLING_AXIS;
+        }
+        if (combinator == Token.TK_GREATER) {
+            return CHILD_AXIS;
+        }
+        return DESCENDANT_AXIS;
+    }
+
+    private boolean isSimpleSelectorStart(Token t) {
+        return t == Token.TK_IDENT || t == Token.TK_ASTERISK || t == Token.TK_HASH
+                || t == Token.TK_PERIOD || t == Token.TK_LBRACKET || t == Token.TK_COLON
+                || t == Token.TK_VERTICAL_BAR;
+    }
+
+    private record ParsedRelativeSelector(Selector.HasRelativeSelector relativeSelector, int specificityB, int specificityC, int specificityD) {
+    }
+
+    private record HasPseudoClassResult(
+            List<Selector.HasRelativeSelector> relativeSelectors,
+            int specificityB,
+            int specificityC,
+            int specificityD,
+            Token lastToken) {
     }
 
     private void addPseudoElement(Token t, Selector selector) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/ColumnsPropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/ColumnsPropertyBuilder.java
@@ -1,0 +1,83 @@
+package org.xhtmlrenderer.css.parser.property;
+
+import org.w3c.dom.css.CSSPrimitiveValue;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.constants.IdentValue;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+import org.xhtmlrenderer.css.sheet.StylesheetInfo.Origin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.w3c.dom.css.CSSValue.CSS_INHERIT;
+import static org.xhtmlrenderer.css.constants.IdentValue.AUTO;
+
+public class ColumnsPropertyBuilder extends AbstractPropertyBuilder {
+    @Override
+    public List<PropertyDeclaration> buildDeclarations(
+            CSSName cssName, List<? extends CSSPrimitiveValue> values, Origin origin, boolean important, boolean inheritAllowed) {
+        assertFoundUpToValues(cssName, values, 2);
+
+        if (values.size() == 1 && values.get(0).getCssValueType() == CSS_INHERIT) {
+            checkInheritAllowed(values.get(0), inheritAllowed);
+            return List.of(
+                    new PropertyDeclaration(CSSName.COLUMN_WIDTH, values.get(0), important, origin),
+                    new PropertyDeclaration(CSSName.COLUMN_COUNT, values.get(0), important, origin));
+        }
+
+        PropertyValue columnWidth = new PropertyValue(AUTO);
+        PropertyValue columnCount = new PropertyValue(AUTO);
+        boolean widthSpecified = false;
+        boolean countSpecified = false;
+
+        for (CSSPrimitiveValue cssPrimitiveValue : values) {
+            PropertyValue value = (PropertyValue) cssPrimitiveValue;
+            checkInheritAllowed(value, false);
+            short type = value.getPrimitiveType();
+
+            if (type == CSSPrimitiveValue.CSS_IDENT) {
+                IdentValue ident = checkIdent(value);
+                if (ident != AUTO) {
+                    throw new CSSParseException("Only auto is allowed as an identifier in columns", -1);
+                }
+                if (!widthSpecified) {
+                    columnWidth = value;
+                    widthSpecified = true;
+                } else if (!countSpecified) {
+                    columnCount = value;
+                    countSpecified = true;
+                } else {
+                    throw new CSSParseException("Duplicate values in columns shorthand", -1);
+                }
+            } else if (isLength(value)) {
+                if (widthSpecified) {
+                    throw new CSSParseException("Column width specified more than once", -1);
+                }
+                if (value.getFloatValue() < 0.0f) {
+                    throw new CSSParseException("column-width may not be negative", -1);
+                }
+                columnWidth = value;
+                widthSpecified = true;
+            } else if (type == CSSPrimitiveValue.CSS_NUMBER &&
+                    (int) value.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) == Math.round(value.getFloatValue(CSSPrimitiveValue.CSS_NUMBER))) {
+                if (countSpecified) {
+                    throw new CSSParseException("Column count specified more than once", -1);
+                }
+                if (value.getFloatValue() < 1.0f) {
+                    throw new CSSParseException("column-count must be at least 1", -1);
+                }
+                columnCount = value;
+                countSpecified = true;
+            } else {
+                throw new CSSParseException("Invalid value in columns shorthand", -1);
+            }
+        }
+
+        List<PropertyDeclaration> result = new ArrayList<>(2);
+        result.add(new PropertyDeclaration(CSSName.COLUMN_WIDTH, columnWidth, important, origin));
+        result.add(new PropertyDeclaration(CSSName.COLUMN_COUNT, columnCount, important, origin));
+        return result;
+    }
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/PrimitivePropertyBuilders.java
@@ -953,6 +953,49 @@ public class PrimitivePropertyBuilders {
     public static class Color extends GenericColor {
     }
 
+    public static class ColumnCount extends AbstractPropertyBuilder {
+        @Override
+        public List<PropertyDeclaration> buildDeclarations(
+                CSSName cssName, List<? extends CSSPrimitiveValue> values, Origin origin, boolean important, boolean inheritAllowed) {
+            assertFoundSingleValue(cssName, values);
+            PropertyValue value = (PropertyValue) values.get(0);
+            checkInheritAllowed(value, inheritAllowed);
+            if (value.getCssValueType() != CSS_INHERIT) {
+                checkIdentOrIntegerType(cssName, value);
+                if (value.getPrimitiveType() == CSSPrimitiveValue.CSS_IDENT) {
+                    IdentValue ident = checkIdent(value);
+                    if (ident != AUTO) {
+                        throw new CSSParseException("Only auto is allowed for " + cssName, -1);
+                    }
+                } else if (value.getFloatValue() < 1.0f) {
+                    throw new CSSParseException(cssName + " must be at least 1", -1);
+                }
+            }
+            return singletonList(new PropertyDeclaration(cssName, value, important, origin));
+        }
+    }
+
+    public static class ColumnGap extends LengthWithNormal {
+        @Override
+        protected boolean isNegativeValuesAllowed() {
+            return false;
+        }
+    }
+
+    public static class ColumnWidth extends LengthWithIdent {
+        private static final BitSet ALLOWED = setFor(AUTO);
+
+        @Override
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+
+        @Override
+        protected boolean isNegativeValuesAllowed() {
+            return false;
+        }
+    }
+
     public static class Cursor extends SingleIdent {
         // [ [<uri> ,]* [ auto | crosshair | default | pointer | move | e-resize
         // | ne-resize | nw-resize | n-resize | se-resize | sw-resize | s-resize

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
@@ -23,6 +23,7 @@ package org.xhtmlrenderer.layout;
 import org.jspecify.annotations.Nullable;
 import org.xhtmlrenderer.css.constants.CSSName;
 import org.xhtmlrenderer.css.constants.IdentValue;
+import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.LineBox;
@@ -418,9 +419,137 @@ public class BlockBoxing {
         }
         int totalHeight = measureOffset - columnTop;
         for (Box localChild : children) {
-            ((BlockBox) localChild).reset(c);
+            localChild.reset(c);
         }
-        return Math.max(1, (totalHeight + columnCount - 1) / columnCount);
+        if (totalHeight <= 0 || children.isEmpty()) {
+            return Math.max(1, (totalHeight + columnCount - 1) / columnCount);
+        }
+
+        int lo = Math.max(1, (totalHeight + columnCount - 1) / columnCount); // ceil(total/n)
+        int hi = totalHeight;
+        int bestH = hi; // safe fallback
+
+        while (lo <= hi) {
+            int mid = lo + (hi - lo) / 2;
+
+            if (contentFitsInColumns(c, block, children, columnTop, columnCount, mid)) {
+                bestH = mid;   // mid works → try smaller
+                hi = mid - 1;
+            } else {
+                lo = mid + 1;  // mid is too small → try larger
+            }
+        }
+
+        bestH = applyFragmentationRules(c, block, children, columnTop, columnCount, bestH);
+        return Math.max(1, bestH);
+    }
+
+    private static boolean contentFitsInColumns(
+            LayoutContext c, BlockBox block, List<Box> children,
+            int columnTop, int columnCount, int columnH) {
+
+        int usedColumns  = 1;
+        int columnUsed   = 0; // height consumed in the current column
+
+        int measureOffset = columnTop;
+        for (Box localChild : children) {
+            BlockBox child = (BlockBox) localChild;
+
+            // Lay out the child to get its real height.
+            LayoutState state = c.isPrint() ? c.copyStateForRelayout() : null;
+            layoutBlockChild(c, block, child, false, 0, measureOffset, NO_PAGE_TRIM, state);
+            int childHeight = child.getHeight();
+            child.reset(c);
+
+            // Would this child overflow the current column?
+            if (columnUsed + childHeight > columnH) {
+                // Move to the next column.
+                usedColumns++;
+                if (usedColumns > columnCount) {
+                    return false; // needs more columns than allowed → H too small
+                }
+                columnUsed = childHeight; // child starts fresh in the new column
+            } else {
+                columnUsed += childHeight;
+            }
+
+            measureOffset = columnTop + columnUsed; // keep offset in sync
+        }
+
+        return true; // all children fit within columnCount columns
+    }
+
+    private static int applyFragmentationRules(
+            LayoutContext c, BlockBox block, List<Box> children,
+            int columnTop, int columnCount, int initialH) {
+
+        int columnH = initialH;
+        boolean changed = true;
+
+        // Iterate until no more adjustments are needed (usually 1–2 passes).
+        while (changed) {
+            changed = false;
+            int columnUsed = 0;
+
+            int measureOffset = columnTop;
+            for (Box localChild : children) {
+                BlockBox child = (BlockBox) localChild;
+
+                // Lay out child to get its real height.
+                LayoutState state = c.isPrint() ? c.copyStateForRelayout() : null;
+                layoutBlockChild(c, block, child, false, 0, measureOffset, NO_PAGE_TRIM, state);
+                int childHeight = child.getHeight();
+                child.reset(c);
+
+                boolean avoidBreakInside = isBreakInsideAvoid(child);
+
+                if (columnUsed + childHeight > columnH) {
+                    // A column break would occur inside this child.
+                    if (avoidBreakInside && childHeight <= columnH) {
+                        // The child fits in one column on its own but is being split.
+                        // Bump H so the break happens *before* this child (i.e. the
+                        // previous column is extended to exactly columnH, and this
+                        // child starts the next column whole).
+                        // We only need to ensure the previous column's used space
+                        // equals columnH — no change to columnH is needed here;
+                        // the child will simply start in the next column.
+                        // BUT if the child itself is taller than columnH we cannot
+                        // avoid the split — leave it as-is.
+                        columnUsed = childHeight; // child starts fresh in next column
+                    } else if (avoidBreakInside && childHeight > columnH) {
+                        // Child is taller than one column; we must expand columnH
+                        // to at least childHeight so it is never split.
+                        int newH = childHeight;
+                        if (newH > columnH) {
+                            columnH = newH;
+                            changed = true;
+                            break; // restart the pass with the new columnH
+                        }
+                        columnUsed = childHeight;
+                    } else {
+                        // No avoid constraint — normal column break.
+                        columnUsed = childHeight;
+                    }
+                } else {
+                    columnUsed += childHeight;
+                }
+
+                measureOffset = columnTop + columnUsed;
+            }
+        }
+
+        return columnH;
+    }
+
+    private static boolean isBreakInsideAvoid(BlockBox child) {
+        CalculatedStyle style = child.getStyle();
+
+        // CSS 2.1 legacy: page-break-inside
+        if (style.isIdent(CSSName.PAGE_BREAK_INSIDE, IdentValue.AVOID)) {
+            return true;
+        }
+
+        return false;
     }
 
     private static int resolveColumnCount(LayoutContext c, BlockBox block) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/BlockBoxing.java
@@ -51,6 +51,10 @@ public class BlockBoxing {
     }
 
     public static void layoutContent(LayoutContext c, BlockBox block, int contentStart) {
+        if (layoutMultiColumnContent(c, block, contentStart)) {
+            return;
+        }
+
         int offset = -1;
 
         List<Box> localChildren = block.getChildren();
@@ -90,7 +94,7 @@ public class BlockBoxing {
             }
 
             layoutBlockChild(
-                    c, block, child, false, childOffset, NO_PAGE_TRIM,
+                    c, block, child, false, 0, childOffset, NO_PAGE_TRIM,
                     relayoutData == null ? null : relayoutData.getLayoutState());
 
             if (c.isPrint()) {
@@ -103,13 +107,13 @@ public class BlockBoxing {
                         c.restoreStateForRelayout(relayoutData.getLayoutState());
                         child.reset(c);
                         layoutBlockChild(
-                                c, block, child, true, childOffset, pageCount, relayoutData.getLayoutState());
+                                c, block, child, true, 0, childOffset, pageCount, relayoutData.getLayoutState());
 
                         if (tryToAvoidPageBreak && child.crossesPageBreak(c) && !keepWithInline) {
                             c.restoreStateForRelayout(relayoutData.getLayoutState());
                             child.reset(c);
                             layoutBlockChild(
-                                    c, block, child, false, childOffset, pageCount, relayoutData.getLayoutState());
+                                    c, block, child, false, 0, childOffset, pageCount, relayoutData.getLayoutState());
                         }
                     }
                 }
@@ -249,7 +253,7 @@ public class BlockBoxing {
                 c.setMayCheckKeepTogether(false);
             }
             layoutBlockChild(
-                    c, block, child, false, childOffset, NO_PAGE_TRIM, relayoutData.getLayoutState());
+                    c, block, child, false, 0, childOffset, NO_PAGE_TRIM, relayoutData.getLayoutState());
 
             if (mayCheckKeepTogether) {
                 c.setMayCheckKeepTogether(true);
@@ -261,13 +265,13 @@ public class BlockBoxing {
                     c.restoreStateForRelayout(relayoutData.getLayoutState());
                     child.reset(c);
                     layoutBlockChild(
-                            c, block, child, true, childOffset, pageCount, relayoutData.getLayoutState());
+                            c, block, child, true, 0, childOffset, pageCount, relayoutData.getLayoutState());
 
                     if (tryToAvoidPageBreak && child.crossesPageBreak(c) && ! keepWithInline) {
                         c.restoreStateForRelayout(relayoutData.getLayoutState());
                         child.reset(c);
                         layoutBlockChild(
-                                c, block, child, false, childOffset, pageCount, relayoutData.getLayoutState());
+                                c, block, child, false, 0, childOffset, pageCount, relayoutData.getLayoutState());
                     }
                 }
             }
@@ -296,31 +300,150 @@ public class BlockBoxing {
 
     private static void layoutBlockChild(
             LayoutContext c, BlockBox parent, BlockBox child,
-            boolean needPageClear, int childOffset, int trimmedPageCount, LayoutState layoutState) {
-        layoutBlockChild0(c, parent, child, needPageClear, childOffset, trimmedPageCount);
+            boolean needPageClear, int childX, int childOffset, int trimmedPageCount, LayoutState layoutState) {
+        layoutBlockChild0(c, parent, child, needPageClear, childX, childOffset, trimmedPageCount);
         BreakAtLineContext bContext = child.calcBreakAtLineContext(c);
         if (bContext != null) {
             c.setBreakAtLineContext(bContext);
             c.restoreStateForRelayout(layoutState);
             child.reset(c);
-            layoutBlockChild0(c, parent, child, needPageClear, childOffset, trimmedPageCount);
+            layoutBlockChild0(c, parent, child, needPageClear, childX, childOffset, trimmedPageCount);
             c.setBreakAtLineContext(null);
         }
     }
 
     private static void layoutBlockChild0(LayoutContext c, BlockBox parent, BlockBox child,
-            boolean needPageClear, int childOffset, int trimmedPageCount) {
+            boolean needPageClear, int childX, int childOffset, int trimmedPageCount) {
         child.setNeedPageClear(needPageClear);
 
         child.initStaticPos(c, parent, childOffset);
+        child.setX(childX);
 
         child.initContainingLayer(c);
         child.calcCanvasLocation();
 
-        c.translate(0, childOffset);
+        c.translate(childX, childOffset);
         repositionBox(c, child, trimmedPageCount);
         child.layout(c);
         c.translate(-child.getX(), -child.getY());
+    }
+
+    private static boolean layoutMultiColumnContent(LayoutContext c, BlockBox block, int contentStart) {
+        int columnCount = resolveColumnCount(c, block);
+        if (columnCount <= 1) {
+            return false;
+        }
+
+        int columnGap = resolveColumnGap(c, block);
+        int savedContentWidth = block.getContentWidth();
+        int columnsAndGapsWidth = savedContentWidth - Math.max(0, (columnCount - 1) * columnGap);
+        int columnWidth = Math.max(1, columnsAndGapsWidth / columnCount);
+        int columnTop = block.getHeight() + contentStart;
+
+        List<Box> children = block.getChildren();
+        try {
+            // Children must resolve widths against column width, not the multicol element's full width.
+            block.setContentWidth(columnWidth);
+
+            int columnHeight = resolveColumnHeightForMultiColumn(
+                    c, block, contentStart, columnCount, children, columnTop);
+
+            int columnIndex = 0;
+            int childOffset = columnTop;
+            int maxColumnBottom = columnTop;
+
+            for (Box localChild : children) {
+                BlockBox child = (BlockBox) localChild;
+                LayoutState state = c.isPrint() ? c.copyStateForRelayout() : null;
+                int startOffset = childOffset;
+                int childX = columnIndex * (columnWidth + columnGap);
+
+                layoutBlockChild(c, block, child, false, childX, childOffset, NO_PAGE_TRIM, state);
+                childOffset = nextBlockChildOffset(child);
+
+                boolean overflowedColumn = childOffset > columnTop + columnHeight;
+                boolean canMoveToNextColumn = columnIndex < columnCount - 1;
+                boolean isFirstInColumn = startOffset == columnTop;
+                if (overflowedColumn && canMoveToNextColumn && !isFirstInColumn) {
+                    if (state != null) {
+                        c.restoreStateForRelayout(state);
+                    }
+                    child.reset(c);
+                    columnIndex++;
+                    childOffset = columnTop;
+                    childX = columnIndex * (columnWidth + columnGap);
+                    layoutBlockChild(c, block, child, false, childX, childOffset, NO_PAGE_TRIM, state);
+                    childOffset = nextBlockChildOffset(child);
+                }
+
+                maxColumnBottom = Math.max(maxColumnBottom, childOffset);
+            }
+
+            block.setHeight(Math.max(block.getHeight(), maxColumnBottom));
+        } finally {
+            block.setContentWidth(savedContentWidth);
+        }
+        return true;
+    }
+
+    private static int nextBlockChildOffset(BlockBox child) {
+        Dimension relativeOffset = child.getRelativeOffset();
+        if (relativeOffset == null) {
+            return child.getY() + child.getHeight();
+        }
+        return child.getY() - relativeOffset.height + child.getHeight();
+    }
+
+    /**
+     * Column height for balancing: when the multicol block has auto height, split total content
+     * height across columns so columns fill sequentially (CSS multi-column balance behavior).
+     * When height is specified, use that as the column box height.
+     */
+    private static int resolveColumnHeightForMultiColumn(
+            LayoutContext c, BlockBox block, int contentStart, int columnCount,
+            List<Box> children, int columnTop) {
+        if (!block.getStyle().isAutoHeight() && block.getStyle().hasAbsoluteUnit(CSSName.HEIGHT)) {
+            int specifiedHeight = (int) block.getStyle().getFloatPropertyProportionalHeight(CSSName.HEIGHT, 0, c);
+            if (specifiedHeight > 0) {
+                return specifiedHeight;
+            }
+        }
+
+        int measureOffset = columnTop;
+        for (Box localChild : children) {
+            BlockBox child = (BlockBox) localChild;
+            LayoutState state = c.isPrint() ? c.copyStateForRelayout() : null;
+            layoutBlockChild(c, block, child, false, 0, measureOffset, NO_PAGE_TRIM, state);
+            measureOffset = nextBlockChildOffset(child);
+        }
+        int totalHeight = measureOffset - columnTop;
+        for (Box localChild : children) {
+            ((BlockBox) localChild).reset(c);
+        }
+        return Math.max(1, (totalHeight + columnCount - 1) / columnCount);
+    }
+
+    private static int resolveColumnCount(LayoutContext c, BlockBox block) {
+        if (!block.getStyle().isIdent(CSSName.COLUMN_COUNT, IdentValue.AUTO)) {
+            return Math.max(1, (int) block.getStyle().asFloat(CSSName.COLUMN_COUNT));
+        }
+
+        if (block.getStyle().isIdent(CSSName.COLUMN_WIDTH, IdentValue.AUTO)) {
+            return 1;
+        }
+
+        int width = Math.max(1, (int) block.getStyle().getFloatPropertyProportionalWidth(
+                CSSName.COLUMN_WIDTH, block.getContentWidth(), c));
+        int gap = resolveColumnGap(c, block);
+        return Math.max(1, (block.getContentWidth() + gap) / (width + gap));
+    }
+
+    private static int resolveColumnGap(LayoutContext c, BlockBox block) {
+        if (block.getStyle().isIdent(CSSName.COLUMN_GAP, IdentValue.NORMAL)) {
+            return 16;
+        }
+        return Math.max(0, (int) block.getStyle().getFloatPropertyProportionalWidth(
+                CSSName.COLUMN_GAP, block.getContentWidth(), c));
     }
 
     private static void repositionBox(LayoutContext c, BlockBox child, int trimmedPageCount) {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -16,13 +16,16 @@ import org.xhtmlrenderer.css.sheet.Ruleset;
 import org.xhtmlrenderer.css.sheet.Stylesheet;
 import org.xml.sax.InputSource;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_IDENT;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_NUMBER;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PX;
 import static org.w3c.dom.css.CSSPrimitiveValue.CSS_URI;
 import static org.xhtmlrenderer.css.constants.CSSName.BACKGROUND_COLOR;
 import static org.xhtmlrenderer.css.constants.CSSName.BACKGROUND_IMAGE;
@@ -116,6 +119,64 @@ class CSSParserTest {
         assertThat(firstSelector.matches(noChild, attributes, treeResolver)).isFalse();
         assertThat(secondSelector.matches(a1, attributes, treeResolver)).isTrue();
         assertThat(secondSelector.matches(a2, attributes, treeResolver)).isFalse();
+    }
+
+    @Test
+    void parsesMultiColumnProperties() throws IOException {
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            div {
+                column-count: 3;
+                column-gap: 24px;
+                column-width: 180px;
+            }
+            """));
+        Ruleset ruleset = (Ruleset) stylesheet.getContents().get(0);
+        List<PropertyDeclaration> declarations = ruleset.getPropertyDeclarations();
+
+        assertThat(declarations).hasSize(3);
+        assertThat(declarations.get(0).getCSSName()).isEqualTo(CSSName.COLUMN_COUNT);
+        assertThat(declarations.get(0).getValue().getPrimitiveType()).isEqualTo(CSS_NUMBER);
+        assertThat(declarations.get(0).getValue().getFloatValue(CSS_NUMBER)).isEqualTo(3f);
+
+        assertThat(declarations.get(1).getCSSName()).isEqualTo(CSSName.COLUMN_GAP);
+        assertThat(declarations.get(1).getValue().getPrimitiveType()).isEqualTo(CSS_PX);
+        assertThat(declarations.get(1).getValue().getFloatValue(CSS_PX)).isEqualTo(24f);
+
+        assertThat(declarations.get(2).getCSSName()).isEqualTo(CSSName.COLUMN_WIDTH);
+        assertThat(declarations.get(2).getValue().getPrimitiveType()).isEqualTo(CSS_PX);
+        assertThat(declarations.get(2).getValue().getFloatValue(CSS_PX)).isEqualTo(180f);
+    }
+
+    @Test
+    void expandsColumnsShorthand() throws IOException {
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            div { columns: 12em 4; }
+            """));
+        Ruleset ruleset = (Ruleset) stylesheet.getContents().get(0);
+        List<PropertyDeclaration> declarations = ruleset.getPropertyDeclarations();
+
+        assertThat(declarations).hasSize(2);
+        assertThat(declarations.get(0).getCSSName()).isEqualTo(CSSName.COLUMN_WIDTH);
+        assertThat(declarations.get(1).getCSSName()).isEqualTo(CSSName.COLUMN_COUNT);
+        assertThat(declarations.get(1).getValue().getPrimitiveType()).isEqualTo(CSS_NUMBER);
+        assertThat(declarations.get(1).getValue().getFloatValue(CSS_NUMBER)).isEqualTo(4f);
+    }
+
+    @Test
+    void expandsColumnsShorthandWithSingleValue() throws IOException {
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            div { columns: 3; }
+            """));
+        Ruleset ruleset = (Ruleset) stylesheet.getContents().get(0);
+        List<PropertyDeclaration> declarations = ruleset.getPropertyDeclarations();
+
+        assertThat(declarations).hasSize(2);
+        assertThat(declarations.get(0).getCSSName()).isEqualTo(CSSName.COLUMN_WIDTH);
+        assertThat(declarations.get(0).getValue().getPrimitiveType()).isEqualTo(CSS_IDENT);
+        assertThat(declarations.get(0).getValue().getCssText()).isEqualTo("auto");
+        assertThat(declarations.get(1).getCSSName()).isEqualTo(CSSName.COLUMN_COUNT);
+        assertThat(declarations.get(1).getValue().getPrimitiveType()).isEqualTo(CSS_NUMBER);
+        assertThat(declarations.get(1).getValue().getFloatValue(CSS_NUMBER)).isEqualTo(3f);
     }
 
     private static PropertyDeclaration css(CSSName property, FSRGBColor color) {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -4,15 +4,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.extend.AttributeResolver;
+import org.xhtmlrenderer.css.extend.lib.DOMTreeResolver;
+import org.xhtmlrenderer.css.newmatch.Selector;
 import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
 import org.xhtmlrenderer.css.sheet.Ruleset;
 import org.xhtmlrenderer.css.sheet.Stylesheet;
+import org.xml.sax.InputSource;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.w3c.dom.css.CSSPrimitiveValue.CSS_URI;
@@ -73,7 +81,122 @@ class CSSParserTest {
         ));
     }
 
+    @Test
+    void hasPseudoClassParsesAndMatches() throws Exception {
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            section:has(> p.note) { color: red; }
+            article:has(+ article.highlight) { color: blue; }
+            """));
+
+        Ruleset first = (Ruleset) stylesheet.getContents().get(0);
+        Ruleset second = (Ruleset) stylesheet.getContents().get(1);
+        Selector firstSelector = first.getFSSelectors().get(0);
+        Selector secondSelector = second.getFSSelectors().get(0);
+
+        Document document = DocumentBuilderFactory.newDefaultInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader("""
+                    <root>
+                      <section id='has-child'><p class='note'>x</p></section>
+                      <section id='no-child'><p>x</p></section>
+                      <article id='a1'/>
+                      <article id='a2' class='highlight'/>
+                    </root>
+                    """)));
+
+        Element hasChild = elementById(document, "has-child");
+        Element noChild = elementById(document, "no-child");
+        Element a1 = elementById(document, "a1");
+        Element a2 = elementById(document, "a2");
+
+        AttributeResolver attributes = domAttributeResolver();
+        DOMTreeResolver treeResolver = new DOMTreeResolver();
+
+        assertThat(firstSelector.matches(hasChild, attributes, treeResolver)).isTrue();
+        assertThat(firstSelector.matches(noChild, attributes, treeResolver)).isFalse();
+        assertThat(secondSelector.matches(a1, attributes, treeResolver)).isTrue();
+        assertThat(secondSelector.matches(a2, attributes, treeResolver)).isFalse();
+    }
+
     private static PropertyDeclaration css(CSSName property, FSRGBColor color) {
         return new PropertyDeclaration(property, new PropertyValue(color), false, AUTHOR);
+    }
+
+    private static Element elementById(Document document, String id) {
+        Node node = document.getDocumentElement().getFirstChild();
+        while (node != null) {
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                Element element = (Element) node;
+                if (id.equals(element.getAttribute("id"))) {
+                    return element;
+                }
+            }
+            node = node.getNextSibling();
+        }
+        throw new IllegalArgumentException("Element with id '%s' not found".formatted(id));
+    }
+
+    private static AttributeResolver domAttributeResolver() {
+        return new AttributeResolver() {
+            @Override
+            public String getAttributeValue(Node e, String attrName) {
+                return e instanceof Element element && element.hasAttribute(attrName) ? element.getAttribute(attrName) : null;
+            }
+
+            @Override
+            public String getAttributeValue(Node e, String namespaceURI, String attrName) {
+                return getAttributeValue(e, attrName);
+            }
+
+            @Override
+            public String getClass(Node e) {
+                return getAttributeValue(e, "class");
+            }
+
+            @Override
+            public String getID(Node e) {
+                return getAttributeValue(e, "id");
+            }
+
+            @Override
+            public String getNonCssStyling(Node e) {
+                return null;
+            }
+
+            @Override
+            public String getElementStyling(Node e) {
+                return null;
+            }
+
+            @Override
+            public String getLang(Node e) {
+                return getAttributeValue(e, "lang");
+            }
+
+            @Override
+            public boolean isLink(Node e) {
+                return false;
+            }
+
+            @Override
+            public boolean isVisited(Node e) {
+                return false;
+            }
+
+            @Override
+            public boolean isHover(Node e) {
+                return false;
+            }
+
+            @Override
+            public boolean isActive(Node e) {
+                return false;
+            }
+
+            @Override
+            public boolean isFocus(Node e) {
+                return false;
+            }
+        };
     }
 }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/HasPseudoClassTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/HasPseudoClassTest.java
@@ -1,0 +1,31 @@
+package org.xhtmlrenderer.pdf;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static org.xhtmlrenderer.pdf.TestUtils.printFile;
+
+public class HasPseudoClassTest {
+    private static final Logger log = LoggerFactory.getLogger(HasPseudoClassTest.class);
+
+    @Test
+    void hasPseudoClassAffectsRenderedContent() throws IOException {
+        byte[] bytes = generatePdf("has-pseudo-class.html");
+        PDF pdf = printFile(log, bytes, "has-pseudo-class.pdf");
+        assertThat(pdf).containsText("CARD-1x [HAS]", "CARD-2 [PLAIN]");
+    }
+
+    private byte[] generatePdf(String htmlPath) {
+        URL htmlUrl = requireNonNull(currentThread().getContextClassLoader().getResource(htmlPath),
+                () -> "Test resource not found: " + htmlPath);
+        return Html2Pdf.fromUrl(htmlUrl);
+    }
+}

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/MultiColumnLayoutTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/MultiColumnLayoutTest.java
@@ -1,0 +1,126 @@
+package org.xhtmlrenderer.pdf;
+
+import com.codeborne.pdftest.PDF;
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
+import org.apache.pdfbox.pdfparser.PDFParser;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.text.TextPosition;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.data.Offset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.xhtmlrenderer.pdf.TestUtils.printFile;
+
+public class MultiColumnLayoutTest {
+    private static final Logger log = LoggerFactory.getLogger(MultiColumnLayoutTest.class);
+
+    private static final List<String> LEFT_COLUMN_MARKERS = List.of(
+            "COL-ALPHA", "COL-BETA", "COL-GAMMA", "COL-DELTA", "COL-EPSILON", "COL-ZETA");
+    private static final List<String> RIGHT_COLUMN_MARKERS = List.of(
+            "COL-ETA", "COL-THETA", "COL-IOTA", "COL-KAPPA", "COL-LAMBDA", "COL-MU");
+
+    @Test
+    void multiColumnCssParsesAndRendersIntoPdf() throws IOException {
+        byte[] bytes = Html2Pdf.fromClasspathResource("page-with-columns.html");
+        PDF pdf = printFile(log, bytes, "page-with-columns.pdf");
+        com.codeborne.pdftest.assertj.Assertions.assertThat(pdf)
+                .containsText("COL-ALPHA", "COL-BETA", "COL-GAMMA", "COL-DELTA");
+
+        List<String> allMarkers = new ArrayList<>(LEFT_COLUMN_MARKERS.size() + RIGHT_COLUMN_MARKERS.size());
+        allMarkers.addAll(LEFT_COLUMN_MARKERS);
+        allMarkers.addAll(RIGHT_COLUMN_MARKERS);
+        Map<String, Float> xByMarker = extractMarkerXCoordinates(bytes, allMarkers);
+
+        assertThat(xByMarker).hasSize(12);
+
+        float leftBand = averageX(xByMarker, LEFT_COLUMN_MARKERS);
+        float rightBand = averageX(xByMarker, RIGHT_COLUMN_MARKERS);
+        float maxLeft = maxX(xByMarker, LEFT_COLUMN_MARKERS);
+        float minRight = minX(xByMarker, RIGHT_COLUMN_MARKERS);
+        assertThat(maxLeft).isLessThan(minRight - 20f);
+        assertThat(leftBand).isLessThan(rightBand - 20f);
+
+        for (String m : LEFT_COLUMN_MARKERS) {
+            assertThat(xByMarker.get(m)).isCloseTo(leftBand, Offset.offset(8f));
+        }
+        for (String m : RIGHT_COLUMN_MARKERS) {
+            assertThat(xByMarker.get(m)).isCloseTo(rightBand, Offset.offset(8f));
+        }
+    }
+
+    private static float averageX(Map<String, Float> xByMarker, List<String> markers) {
+        double sum = 0;
+        for (String m : markers) {
+            sum += xByMarker.get(m);
+        }
+        return (float) (sum / markers.size());
+    }
+
+    private static float maxX(Map<String, Float> xByMarker, List<String> markers) {
+        float max = Float.NEGATIVE_INFINITY;
+        for (String m : markers) {
+            max = Math.max(max, xByMarker.get(m));
+        }
+        return max;
+    }
+
+    private static float minX(Map<String, Float> xByMarker, List<String> markers) {
+        float min = Float.POSITIVE_INFINITY;
+        for (String m : markers) {
+            min = Math.min(min, xByMarker.get(m));
+        }
+        return min;
+    }
+
+    private static Map<String, Float> extractMarkerXCoordinates(byte[] pdfBytes, List<String> markers) throws IOException {
+        try (RandomAccessRead source = new RandomAccessReadBuffer(pdfBytes);
+             PDDocument document = new PDFParser(source).parse()) {
+            MarkerPositionStripper stripper = new MarkerPositionStripper(markers);
+            stripper.getText(document);
+            return stripper.positions();
+        }
+    }
+
+    private static final class MarkerPositionStripper extends PDFTextStripper {
+        private final List<String> markers;
+        private final Map<String, Float> positions = new HashMap<>();
+
+        private MarkerPositionStripper(List<String> markers) throws IOException {
+            this.markers = markers;
+            setSortByPosition(true);
+        }
+
+        @Override
+        protected void writeString(String text, List<TextPosition> textPositions) throws IOException {
+            super.writeString(text, textPositions);
+            for (String marker : markers) {
+                if (positions.containsKey(marker)) {
+                    continue;
+                }
+                int idx = text.indexOf(marker);
+                if (idx >= 0 && idx + marker.length() <= textPositions.size()) {
+                    float minX = Float.POSITIVE_INFINITY;
+                    for (int i = 0; i < marker.length(); i++) {
+                        minX = Math.min(minX, textPositions.get(idx + i).getXDirAdj());
+                    }
+                    positions.put(marker, minX);
+                }
+            }
+        }
+
+        private Map<String, Float> positions() {
+            return positions;
+        }
+    }
+}

--- a/flying-saucer-pdf/src/test/resources/has-pseudo-class.html
+++ b/flying-saucer-pdf/src/test/resources/has-pseudo-class.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
+    <title>:has() PDF test</title>
+    <style>
+        .card::after {
+            content: " [PLAIN]";
+        }
+
+        .card:has(.flag)::after {
+            content: " [HAS]";
+        }
+    </style>
+</head>
+<body>
+<div class="card">CARD-1<span class="flag">x</span></div>
+<div class="card">CARD-2</div>
+</body>
+</html>

--- a/flying-saucer-pdf/src/test/resources/page-with-columns.html
+++ b/flying-saucer-pdf/src/test/resources/page-with-columns.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Multi-column test</title>
+    <style type="text/css">
+        body {
+            font-family: sans-serif;
+            font-size: 12pt;
+        }
+
+        .multi {
+            columns: 2 120pt;
+            column-count: 2;
+            column-gap: 24pt;
+            column-width: 120pt;
+            width: 600pt;
+        }
+    </style>
+</head>
+<body>
+<div class="multi">
+    <div>COL-ALPHA</div>
+    <div>COL-BETA</div>
+    <div>COL-GAMMA</div>
+    <div>COL-DELTA</div>
+    <div>COL-EPSILON</div>
+    <div>COL-ZETA</div>
+    <div>COL-ETA</div>
+    <div>COL-THETA</div>
+    <div>COL-IOTA</div>
+    <div>COL-KAPPA</div>
+    <div>COL-LAMBDA</div>
+    <div>COL-MU</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds support for two things:

### 1. `:has()` pseudo-class selector

Matches an element if any of the relative selectors passed as arguments match at least one element relative to the `:has()` scope.

**Descendant** (default):
```css
/* Matches .card if it contains a descendant with class .flag */
.card:has(.flag) {
    border: 2px solid red;
}
```

**Direct child** (`>`):
```css
/* Matches .card only if a direct child has class .flag */
.card:has(> .flag) {
    background-color: yellow;
}
```

**Adjacent sibling** (`+`):
```css
/* Matches h2 if it is immediately followed by a p */
h2:has(+ p) {
    margin-bottom: 0;
}
```

**Combined with pseudo-elements**:
```css
.card:has(.flag)::after {
    content: " [HAS]";
}
```

**Multiple selectors** (comma-separated, OR logic):
```css
/* Matches .card if it contains either .flag or .badge */
.card:has(.flag, .badge) {
    font-weight: bold;
}
```

---

### 2. CSS Multi-column layout

Distributes block content across multiple columns. Supports the `columns` shorthand as well as the individual `column-count`, `column-width`, and `column-gap` properties.

**Fixed column count**:
```css
.content {
    column-count: 3;
    column-gap: 20px;
}
```

**Fixed column width** (auto-calculates count):
```css
.content {
    column-width: 200px;
    column-gap: 1em;
}
```

**Shorthand** (`columns: <width> <count>`):
```css
.content {
    columns: 150px 2;
}
```