### PR TITLE
ContentTypeDetectingInputStreamWrapper: tolerate UTF-8 BOM in isSvg()

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapper.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapper.java
@@ -34,9 +34,29 @@ public class ContentTypeDetectingInputStreamWrapper extends BufferedInputStream 
 
     private final byte[] firstBytes;
 
+    private static final byte[] UTF_8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+
     private ContentTypeDetectingInputStreamWrapper(InputStream source) throws IOException {
         super(source);
+        skipUtf8BomIfPresent(this);
         this.firstBytes = readFirstBytes(this, MAX_MAGIC_BYTES);
+    }
+
+    /**
+     * If the wrapped stream begins with a UTF-8 BOM (EF BB BF), consume it
+     * so {@link #firstBytes} captures the real first glyph. Otherwise the
+     * magic-byte comparison fails for BOM-prefixed XML / SVG written by
+     * text editors that auto-prepend a BOM (e.g. Notepad on Windows), and
+     * {@link #isSvg()} returns {@code false} for what is clearly an SVG.
+     */
+    private static void skipUtf8BomIfPresent(InputStream in) throws IOException {
+        in.mark(UTF_8_BOM.length);
+        byte[] head = new byte[UTF_8_BOM.length];
+        int bytesRead = in.read(head);
+        if (bytesRead == UTF_8_BOM.length && Arrays.equals(head, UTF_8_BOM)) {
+            return; // BOM consumed; subsequent reads see "<svg…" / "<?xml…"
+        }
+        in.reset();
     }
 
     private static byte[] readFirstBytes(InputStream in, int count) throws IOException {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapperTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/ContentTypeDetectingInputStreamWrapperTest.java
@@ -46,4 +46,41 @@ class ContentTypeDetectingInputStreamWrapperTest {
             assertThat(stream.isPdf()).isFalse();
         }
     }
+
+    /**
+     * Real-world regression: SVGs saved by text editors that auto-prepend a
+     * UTF-8 BOM (Notepad on Windows, some Vim configs) start with the bytes
+     * EF BB BF before the {@code <?xml} or {@code <svg} header. Without
+     * BOM-skipping, {@link #firstBytes} captures EF BB BF 3C and the
+     * byte-exact magic comparison against {@code "<?xm"} / {@code "<svg"}
+     * fails — so a valid SVG fails type detection and downstream
+     * SvgImage / Batik loading is skipped.
+     */
+    @Test
+    void isSvg_withUtf8Bom() throws IOException {
+        byte[] bom = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        byte[] body = "<svg><metadata/></svg>".getBytes(UTF_8);
+        byte[] streamBytes = new byte[bom.length + body.length];
+        System.arraycopy(bom, 0, streamBytes, 0, bom.length);
+        System.arraycopy(body, 0, streamBytes, bom.length, body.length);
+
+        try (var stream = detectContentType(new ByteArrayInputStream(streamBytes))) {
+            assertThat(stream.isSvg()).isTrue();
+            assertThat(stream.isPdf()).isFalse();
+        }
+    }
+
+    @Test
+    void isSvg_withUtf8Bom_andXmlHeader() throws IOException {
+        byte[] bom = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        byte[] body = "<?xml version=\"1.0\"?><svg/>".getBytes(UTF_8);
+        byte[] streamBytes = new byte[bom.length + body.length];
+        System.arraycopy(bom, 0, streamBytes, 0, bom.length);
+        System.arraycopy(body, 0, streamBytes, bom.length, body.length);
+
+        try (var stream = detectContentType(new ByteArrayInputStream(streamBytes))) {
+            assertThat(stream.isSvg()).isTrue();
+            assertThat(stream.isPdf()).isFalse();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`ContentTypeDetectingInputStreamWrapper.isSvg()` does a byte-exact comparison of the first 4 bytes against `"<svg"` / `"<?xm"`. A BOM-prefixed SVG (`EF BB BF` + `<svg…`) fails detection, so the library falls through to raster decoding, returns a null `FSImage`, and the image slot either renders blank or surfaces as a load failure depending on the user agent.

This patch consumes a leading UTF-8 BOM inside the wrapper's constructor so `firstBytes` captures the real first glyph and the magic-byte comparison works as expected. UTF-16 BOMs aren't handled (rare in practice for SVG / XML written by hand).

## Repro

```java
byte[] bom  = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
byte[] body = "<svg><metadata/></svg>".getBytes(UTF_8);
byte[] bytes = concat(bom, body);
var stream = detectContentType(new ByteArrayInputStream(bytes));
assertThat(stream.isSvg()).isTrue();   // fails on main; passes with this patch
```

SVGs saved by Notepad on Windows, some Vim/Emacs configs, or auto-generated by tooling commonly include a leading UTF-8 BOM. Hitting this is purely a function of who produced the SVG asset, not of how the application loads it.

## Test plan

- [x] New `isSvg_withUtf8Bom` and `isSvg_withUtf8Bom_andXmlHeader` tests in `ContentTypeDetectingInputStreamWrapperTest`
- [x] Existing tests in the same file pass unchanged