### PR TITLE
#633 add flying-saucer-chrome-pdf module

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,6 +44,11 @@ jobs:
           distribution: temurin
           java-version: ${{matrix.java}}
           cache: maven
+      - name: Cache chrome-headless-shell
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/flying-saucer
+          key: chrome-headless-shell-${{ runner.os }}
       - name: Build with Maven
         run: mvn -B package
       - name: 'Upload test results'

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -103,9 +103,6 @@
     </inspection_tool>
     <inspection_tool class="ImplicitDefaultCharsetUsage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="InnerClassReferencedViaSubclass" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InstanceVariableInitialization" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="m_ignorePrimitives" value="false" />
-    </inspection_tool>
     <inspection_tool class="InstanceVariableUninitializedUse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignorePrimitives" value="false" />
       <option name="annotationNamesString" value="" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,11 @@ mvn versions:set -DnewVersion=X.Y.Z             # bump version across all poms (
 
 Surefire only picks up tests under `org/**` (see `pom.xml`). JUnit 4 (`junit:junit`) is banned by the enforcer plugin — write tests in **JUnit 5 (Jupiter)** with **AssertJ**; PDF assertions use `com.codeborne:pdf-test`.
 
+## Test conventions
+
+- **Use AssertJ's type-specific matchers** instead of unwrapping. E.g. for `AtomicInteger`: `assertThat(counter).hasValue(0)` — never `assertThat(counter.get()).isZero()`. Same idea for `Optional`, `Path`, `File`, collections, etc.: assert on the wrapper, not on a manually extracted value.
+- **Static-import common helpers** to keep tests terse: `org.assertj.core.api.Assertions.assertThat`, `java.util.Objects.requireNonNull`, and any project test utility (e.g. `TestUtils.printFile`). Avoid qualifying these inline.
+
 ## Compilation specifics
 
 - `maven-compiler-plugin` runs **Error Prone** as a `-Xplugin`. A handful of checks are disabled globally (`MissingSummary`, `JdkObsolete`, `ReferenceEquality`, `OperatorPrecedence`) and `Lexer.java` is excluded entirely. If you hit unexpected compile errors, suspect Error Prone before suspecting javac.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ New releases of Flying Saucer are distributed through Maven. The available artif
 * `org.xhtmlrenderer:flying-saucer-core` - Core library and Java2D rendering
 * `org.xhtmlrenderer:flying-saucer-pdf` - PDF output using OpenPDF (ex. iText 2.x)
 * `org.xhtmlrenderer:flying-saucer-pdf-openpdf` - not supported anymore (replaced by `flying-saucer-pdf`)
+* `org.xhtmlrenderer:flying-saucer-chrome-pdf` - PDF output by delegating to `chrome-headless-shell` (supports modern HTML5/CSS3)
 * `org.xhtmlrenderer:flying-saucer-swt` - SWT output
 * `org.xhtmlrenderer:flying-saucer-log4j` - Logging plugin for log4j
 

--- a/flying-saucer-chrome-pdf/pom.xml
+++ b/flying-saucer-chrome-pdf/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.xhtmlrenderer</groupId>
+    <artifactId>flying-saucer-parent</artifactId>
+    <version>10.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>flying-saucer-chrome-pdf</artifactId>
+
+  <packaging>jar</packaging>
+
+  <name>Flying Saucer Chrome PDF Rendering</name>
+  <description>HTML to PDF conversion by delegating to a headless Chromium binary (chrome-headless-shell).</description>
+
+  <licenses>
+    <license>
+      <name>GNU Lesser General Public License (LGPL), version 2.1 or later</name>
+      <url>http://www.gnu.org/licenses/lgpl.html</url>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20260522</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xhtmlrenderer</groupId>
+      <artifactId>flying-saucer-pdf</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>../</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE*</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>flying.saucer.chrome.pdf</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeBinaryDownloader.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeBinaryDownloader.java
@@ -1,0 +1,89 @@
+package org.xhtmlrenderer.chrome;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Set;
+
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+
+class ChromeBinaryDownloader {
+    private static final Logger log = LoggerFactory.getLogger(ChromeBinaryDownloader.class);
+
+    private final ZipExtractor zipExtractor = new ZipExtractor();
+
+    Path download(ChromeVersion chromeVersion, ChromePlatform platform, Path versionDir) throws IOException {
+        Files.createDirectories(versionDir);
+        URI url = chromeVersion.url();
+        Path zipFile = Files.createTempFile("chrome-headless-shell-", ".zip");
+        try {
+            log.info("Downloading chrome-headless-shell from {}", url);
+            httpGetToFile(url, zipFile);
+            zipExtractor.extract(zipFile, versionDir);
+        } finally {
+            Files.deleteIfExists(zipFile);
+        }
+        Path executable = findExecutable(versionDir, platform);
+        makeExecutable(executable);
+        return executable;
+    }
+
+    void httpGetToFile(URI url, Path target) throws IOException {
+        HttpRequest request = HttpRequest.newBuilder(url)
+                .timeout(Duration.ofMinutes(5))
+                .GET()
+                .build();
+        try (HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build()) {
+            HttpResponse<Path> response = client.send(request,
+                    HttpResponse.BodyHandlers.ofFile(target, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING));
+            if (response.statusCode() != 200) {
+                throw new IOException("Failed to download " + url + ": HTTP " + response.statusCode());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while downloading " + url, e);
+        }
+    }
+
+    private Path findExecutable(Path versionDir, ChromePlatform platform) throws IOException {
+        // chrome-for-testing zips extract to a subdirectory like "chrome-headless-shell-linux64/chrome-headless-shell"
+        Path nested = versionDir
+                .resolve("chrome-headless-shell-" + platform.id())
+                .resolve(platform.executableName());
+        if (Files.exists(nested)) {
+            return nested;
+        }
+        Path direct = versionDir.resolve(platform.executableName());
+        if (Files.exists(direct)) {
+            return direct;
+        }
+        throw new IOException("chrome-headless-shell binary not found under " + versionDir);
+    }
+
+    private void makeExecutable(Path executable) throws IOException {
+        if (executable.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(executable, Set.of(
+                    OWNER_READ, OWNER_WRITE, OWNER_EXECUTE,
+                    GROUP_READ, GROUP_EXECUTE,
+                    OTHERS_READ, OTHERS_EXECUTE));
+        }
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeBinaryLocator.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeBinaryLocator.java
@@ -1,0 +1,141 @@
+package org.xhtmlrenderer.chrome;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static java.nio.file.Files.getLastModifiedTime;
+import static java.util.concurrent.TimeUnit.DAYS;
+
+public class ChromeBinaryLocator {
+    private static final Logger log = LoggerFactory.getLogger(ChromeBinaryLocator.class);
+
+    private static final String CHROME_INFO_URL = "https://googlechromelabs.github.io/chrome-for-testing/";
+    private static final String LAST_VERSIONS_FILE = "last-known-good-versions-with-downloads.json";
+    private static final String ALL_VERSIONS_FILE = "known-good-versions-with-downloads.json";
+    private static final URI LAST_VERSIONS_URI = URI.create(CHROME_INFO_URL + LAST_VERSIONS_FILE);
+    private static final URI ALL_VERSIONS_URI = URI.create(CHROME_INFO_URL + ALL_VERSIONS_FILE);
+
+    static final String DEFAULT_VERSION = "LATEST";
+
+    @Nullable
+    private final Path explicitPath;
+    private final String version;
+    private final Path cacheDir;
+    private final ChromePlatform platform;
+    private final ChromeBinaryDownloader downloader;
+
+    public ChromeBinaryLocator() {
+        this(null, DEFAULT_VERSION, defaultCacheDir(), ChromePlatform.detect(), new ChromeBinaryDownloader());
+    }
+
+    ChromeBinaryLocator(@Nullable Path explicitPath, String version, Path cacheDir,
+                        ChromePlatform platform, ChromeBinaryDownloader downloader) {
+        this.explicitPath = explicitPath;
+        this.version = version;
+        this.cacheDir = cacheDir;
+        this.platform = platform;
+        this.downloader = downloader;
+    }
+
+    public Path locate() throws IOException {
+        if (explicitPath != null) {
+            if (!Files.exists(explicitPath)) {
+                throw new IOException("chrome-headless-shell binary not found at " + explicitPath);
+            }
+            return explicitPath;
+        }
+        ChromeVersion chromeVersion = resolveChromeVersion(version);
+        Path versionDir = cacheDir.resolve(chromeVersion.version()).resolve(platform.id());
+        Path cached = findCachedExecutable(versionDir);
+        if (cached != null) {
+            log.debug("Using cached chrome-headless-shell at {}", cached);
+            return cached;
+        }
+        return downloader.download(chromeVersion, platform, versionDir);
+    }
+
+    private ChromeVersion resolveChromeVersion(String requestedVersion) throws IOException {
+        if (!DEFAULT_VERSION.equals(requestedVersion)) {
+            return new ChromeVersion(requestedVersion, zipUrl(requestedVersion, platform));
+        }
+        Path knownVersionsFile = downloadIfNeeded(LAST_VERSIONS_FILE, LAST_VERSIONS_URI);
+        return readLatestStableVersion(knownVersionsFile, platform);
+    }
+
+    private Path downloadIfNeeded(String fileName, URI source) throws IOException {
+        Path cachedFile = cacheDir.resolve(fileName);
+        if (!Files.exists(cachedFile) || System.currentTimeMillis() - getLastModifiedTime(cachedFile).toMillis() > DAYS.toMillis(1)) {
+            Files.createDirectories(cacheDir);
+            downloader.httpGetToFile(source, cachedFile);
+        }
+        return cachedFile;
+    }
+
+    static ChromeVersion readLatestStableVersion(Path lastVersionsFile, ChromePlatform platform) throws IOException {
+        String json = Files.readString(lastVersionsFile);
+        JSONObject root = new JSONObject(json);
+        JSONObject stableChannel = root.getJSONObject("channels").getJSONObject("Stable");
+        String version = stableChannel.getString("version");
+        return parseVersionElement(platform, stableChannel, version)
+            .orElseThrow(() -> new IllegalStateException("Cannot find download URL for platform " + platform.id() + " in file " + lastVersionsFile));
+    }
+
+    static URI readDownloadUrl(Path allVersionsFile, ChromePlatform platform, String version) throws IOException {
+        String json = Files.readString(allVersionsFile);
+        JSONObject root = new JSONObject(json);
+        JSONArray versions = root.getJSONArray("versions");
+
+        for (int i = 0; i < versions.length(); i++) {
+            JSONObject versionElement = versions.getJSONObject(i);
+            if (versionElement.getString("version").equals(version)) {
+                return parseVersionElement(platform, versionElement, version)
+                    .map(ver -> ver.url())
+                    .orElseThrow(() ->
+                        new IllegalStateException("Cannot find download URL for version " + version + " and platform " + platform.id() + " in file " + allVersionsFile));
+            }
+        }
+        throw new IllegalStateException("Cannot find download URL for version " + version + " and platform " + platform.id() + " in file " + allVersionsFile);
+    }
+
+    private static Optional<ChromeVersion> parseVersionElement(ChromePlatform platform, JSONObject stableChannel, String version) {
+        JSONArray platforms = stableChannel.getJSONObject("downloads").getJSONArray("chrome-headless-shell");
+        for (int i = 0; i < platforms.length(); i++) {
+            JSONObject platformElement = platforms.getJSONObject(i);
+            if (platformElement.getString("platform").equals(platform.id())) {
+                return Optional.of(new ChromeVersion(version, URI.create(platformElement.getString("url"))));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private URI zipUrl(String version, ChromePlatform platform) throws IOException {
+        Path allVersionsFile = downloadIfNeeded(ALL_VERSIONS_FILE, ALL_VERSIONS_URI);
+        return readDownloadUrl(allVersionsFile, platform, version);
+    }
+
+    @Nullable
+    private Path findCachedExecutable(Path versionDir) {
+        Path nested = versionDir
+            .resolve("chrome-headless-shell-" + platform.id())
+            .resolve(platform.executableName());
+        if (Files.exists(nested)) {
+            return nested;
+        }
+        Path direct = versionDir.resolve(platform.executableName());
+        return Files.exists(direct) ? direct : null;
+    }
+
+    public static Path defaultCacheDir() {
+        return Paths.get(System.getProperty("user.home"), ".cache", "flying-saucer");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromePlatform.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromePlatform.java
@@ -1,0 +1,53 @@
+package org.xhtmlrenderer.chrome;
+
+import static java.util.Locale.ROOT;
+
+public enum ChromePlatform {
+    LINUX64("linux64", "chrome-headless-shell"),
+    MAC_X64("mac-x64", "chrome-headless-shell"),
+    MAC_ARM64("mac-arm64", "chrome-headless-shell"),
+    WIN64("win64", "chrome-headless-shell.exe");
+
+    private final String id;
+    private final String executableName;
+
+    ChromePlatform(String id, String executableName) {
+        this.id = id;
+        this.executableName = executableName;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String executableName() {
+        return executableName;
+    }
+
+    public static ChromePlatform detect() {
+        String arch = System.getProperty("os.arch", "");
+        boolean arm64 = arch.toLowerCase(ROOT).contains("aarch64")
+                || arch.toLowerCase(ROOT).contains("arm64");
+        return detect(System.getProperty("os.name", ""), arch, arm64);
+    }
+
+    static ChromePlatform detect(String os, String arch, boolean arm64) {
+        String o = os.toLowerCase(ROOT);
+        if (o.contains("mac") || o.contains("darwin")) {
+            return arm64 ? MAC_ARM64 : MAC_X64;
+        }
+        if (o.contains("win")) {
+            return WIN64;
+        }
+        if (o.contains("nux") || o.contains("nix")) {
+            if (arm64) {
+                throw new UnsupportedOperationException(
+                        "chrome-for-testing does not publish a Linux arm64 build of chrome-headless-shell " +
+                                "(detected os=" + os + ", arch=" + arch + "). " +
+                                "Install chrome-headless-shell manually and pass its path via ChromiumPdfRenderer.setBinaryPath().");
+            }
+            return LINUX64;
+        }
+        throw new UnsupportedOperationException("Unsupported OS for chrome-for-testing: " + os + " (arch=" + arch + ")");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeVersion.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromeVersion.java
@@ -1,0 +1,9 @@
+package org.xhtmlrenderer.chrome;
+
+import java.net.URI;
+
+record ChromeVersion(
+    String version,
+    URI url
+) {
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfOptions.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfOptions.java
@@ -1,0 +1,49 @@
+package org.xhtmlrenderer.chrome;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+public class ChromiumPdfOptions {
+    private boolean noPdfHeaderFooter = true;
+    private boolean noSandbox = true;
+    private boolean disableGpu = true;
+    private final List<String> extraArgs = new ArrayList<>();
+
+    public ChromiumPdfOptions noPdfHeaderFooter(boolean v) {
+        this.noPdfHeaderFooter = v;
+        return this;
+    }
+
+    public ChromiumPdfOptions noSandbox(boolean v) {
+        this.noSandbox = v;
+        return this;
+    }
+
+    public ChromiumPdfOptions disableGpu(boolean v) {
+        this.disableGpu = v;
+        return this;
+    }
+
+    public ChromiumPdfOptions addExtraArg(String arg) {
+        extraArgs.add(arg);
+        return this;
+    }
+
+    public boolean isNoPdfHeaderFooter() {
+        return noPdfHeaderFooter;
+    }
+
+    public boolean isNoSandbox() {
+        return noSandbox;
+    }
+
+    public boolean isDisableGpu() {
+        return disableGpu;
+    }
+
+    public List<String> getExtraArgs() {
+        return unmodifiableList(extraArgs);
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfRenderer.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfRenderer.java
@@ -1,0 +1,266 @@
+package org.xhtmlrenderer.chrome;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class ChromiumPdfRenderer implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(ChromiumPdfRenderer.class);
+
+    @Nullable
+    private Path binaryPath;
+    private Path cacheDir = ChromeBinaryLocator.defaultCacheDir();
+    private String chromeVersion = ChromeBinaryLocator.DEFAULT_VERSION;
+    private ChromiumPdfOptions options = new ChromiumPdfOptions();
+    private Duration timeout = Duration.ofSeconds(60);
+    private Duration idleProcessTimeout = Duration.ofSeconds(5);
+
+    private final Object lock = new Object();
+    @Nullable
+    private DevToolsSession session;
+    @Nullable
+    private ScheduledExecutorService idleScheduler;
+    @Nullable
+    private ScheduledFuture<?> idleTask;
+    @Nullable
+    private Thread shutdownHook;
+
+    public ChromiumPdfRenderer setBinaryPath(@Nullable Path binaryPath) {
+        this.binaryPath = binaryPath;
+        return this;
+    }
+
+    public ChromiumPdfRenderer setCacheDir(Path cacheDir) {
+        this.cacheDir = cacheDir;
+        return this;
+    }
+
+    public ChromiumPdfRenderer setChromeVersion(String chromeVersion) {
+        this.chromeVersion = chromeVersion;
+        return this;
+    }
+
+    public ChromiumPdfRenderer setOptions(ChromiumPdfOptions options) {
+        this.options = options;
+        return this;
+    }
+
+    public ChromiumPdfRenderer setTimeout(Duration timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    /**
+     * Keep the chrome subprocess alive between renders for this many seconds of inactivity.
+     * Set to {@link Duration#ZERO} to spawn a fresh process per render (slower for batches, no idle process).
+     * Default: 5 seconds.
+     */
+    public ChromiumPdfRenderer setIdleProcessTimeout(Duration idleProcessTimeout) {
+        this.idleProcessTimeout = idleProcessTimeout;
+        return this;
+    }
+
+    public byte[] renderToPdf(URL htmlSource) throws IOException {
+        return renderToPdf(htmlSource.toString());
+    }
+
+    public byte[] renderToPdf(File htmlFile) throws IOException {
+        return renderToPdf(htmlFile.toURI().toString());
+    }
+
+    public byte[] renderFromHtml(String html) throws IOException {
+        Path tempHtml = Files.createTempFile("flying-saucer-chrome-", ".html");
+        try {
+            Files.writeString(tempHtml, html, UTF_8);
+            return renderToPdf(tempHtml.toUri().toString());
+        } finally {
+            Files.deleteIfExists(tempHtml);
+        }
+    }
+
+    public void renderToPdf(URL htmlSource, Path outputPdf) throws IOException {
+        byte[] pdf = renderToPdf(htmlSource);
+        Files.write(outputPdf, pdf);
+    }
+
+    private byte[] renderToPdf(String htmlInput) throws IOException {
+        if (idleProcessTimeout.isZero()) {
+            return renderOneShot(htmlInput);
+        }
+        return renderReusing(htmlInput);
+    }
+
+    private byte[] renderReusing(String htmlInput) throws IOException {
+        synchronized (lock) {
+            cancelIdleClose();
+            if (session != null && !session.isAlive()) {
+                closeSessionLocked();
+            }
+            if (session == null) {
+                Path binary = locateBinary();
+                session = DevToolsSession.start(binary, options, Duration.ofSeconds(30));
+                ensureShutdownHookLocked();
+            }
+            try {
+                return session.printToPdf(htmlInput, options, timeout);
+            } catch (IOException e) {
+                closeSessionLocked();
+                throw e;
+            } finally {
+                scheduleIdleCloseLocked();
+            }
+        }
+    }
+
+    private byte[] renderOneShot(String htmlInput) throws IOException {
+        Path binary = locateBinary();
+        Path outputPdf = Files.createTempFile("flying-saucer-chrome-", ".pdf");
+        try {
+            List<String> command = buildOneShotCommand(binary, outputPdf, htmlInput);
+            runOneShotProcess(command);
+            return Files.readAllBytes(outputPdf);
+        } finally {
+            Files.deleteIfExists(outputPdf);
+        }
+    }
+
+    private Path locateBinary() throws IOException {
+        return new ChromeBinaryLocator(binaryPath, chromeVersion, cacheDir,
+                ChromePlatform.detect(), new ChromeBinaryDownloader()).locate();
+    }
+
+    private List<String> buildOneShotCommand(Path binary, Path outputPdf, String htmlInput) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(binary.toString());
+        cmd.add("--headless");
+        if (options.isDisableGpu()) cmd.add("--disable-gpu");
+        if (options.isNoSandbox()) cmd.add("--no-sandbox");
+        if (options.isNoPdfHeaderFooter()) cmd.add("--no-pdf-header-footer");
+        cmd.addAll(options.getExtraArgs());
+        cmd.add("--print-to-pdf=" + outputPdf);
+        cmd.add(htmlInput);
+        return cmd;
+    }
+
+    private void runOneShotProcess(List<String> command) throws IOException {
+        log.debug("Running: {}", command);
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String output;
+        try (InputStream in = process.getInputStream()) {
+            output = new String(in.readAllBytes(), UTF_8);
+        }
+        boolean finished;
+        try {
+            finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for chrome-headless-shell", e);
+        }
+        if (!finished) {
+            process.destroyForcibly();
+            throw new IOException("chrome-headless-shell timed out after " + timeout + ". Output:\n" + output);
+        }
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            throw new IOException("chrome-headless-shell exited with code " + exitCode + ". Output:\n" + output);
+        }
+        if (!output.isBlank()) {
+            log.debug("chrome-headless-shell output: {}", output);
+        }
+    }
+
+    private void scheduleIdleCloseLocked() {
+        if (idleScheduler == null) {
+            idleScheduler = newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "fs-chrome-idle");
+                t.setDaemon(true);
+                return t;
+            });
+        }
+        idleTask = idleScheduler.schedule(this::onIdle, idleProcessTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void cancelIdleClose() {
+        if (idleTask != null) {
+            idleTask.cancel(false);
+            idleTask = null;
+        }
+    }
+
+    private void onIdle() {
+        synchronized (lock) {
+            closeSessionLocked();
+        }
+    }
+
+    private void closeSessionLocked() {
+        if (session != null) {
+            try {
+                session.close();
+            } catch (Exception e) {
+                log.debug("Error while closing chrome session", e);
+            }
+            session = null;
+        }
+    }
+
+    private void ensureShutdownHookLocked() {
+        if (shutdownHook != null) return;
+        shutdownHook = new Thread(this::closeQuietly, "fs-chrome-shutdown");
+        try {
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        } catch (IllegalStateException alreadyShuttingDown) {
+            log.warn("chrome shutdown already in progress", alreadyShuttingDown);
+            shutdownHook = null;
+        }
+    }
+
+    private void closeQuietly() {
+        try {
+            closeInternal(false);
+        } catch (Exception e) {
+            log.debug("Error during shutdown hook", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        closeInternal(true);
+    }
+
+    private void closeInternal(boolean removeShutdownHook) {
+        synchronized (lock) {
+            cancelIdleClose();
+            closeSessionLocked();
+            if (idleScheduler != null) {
+                idleScheduler.shutdownNow();
+                idleScheduler = null;
+            }
+            if (removeShutdownHook && shutdownHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignored) {
+                    // JVM already shutting down
+                }
+                shutdownHook = null;
+            }
+        }
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/DevToolsSession.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/DevToolsSession.java
@@ -1,0 +1,330 @@
+package org.xhtmlrenderer.chrome;
+
+import org.json.JSONObject;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class DevToolsSession implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(DevToolsSession.class);
+    private static final Pattern LISTENING_LINE = Pattern.compile("DevTools listening on (ws://\\S+)");
+
+    private final Process process;
+    private final HttpClient httpClient;
+    private final WebSocket webSocket;
+    private final AtomicLong messageId = new AtomicLong();
+    private final ConcurrentHashMap<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+    private final AtomicReference<@Nullable CompletableFuture<Void>> currentLoad = new AtomicReference<>();
+    private volatile boolean closed;
+
+    private DevToolsSession(Process process, HttpClient httpClient, WebSocket webSocket) {
+        this.process = process;
+        this.httpClient = httpClient;
+        this.webSocket = webSocket;
+    }
+
+    static DevToolsSession start(Path binary, ChromiumPdfOptions options, Duration startupTimeout) throws IOException {
+        Process proc = new ProcessBuilder(buildCommand(binary, options))
+                .redirectErrorStream(false)
+                .start();
+
+        CompletableFuture<URI> listening = new CompletableFuture<>();
+        startStderrReader(proc, listening);
+
+        URI browserWs;
+        try {
+            browserWs = listening.get(startupTimeout.toMillis(), MILLISECONDS);
+        } catch (Exception e) {
+            proc.destroyForcibly();
+            throw new IOException("chrome-headless-shell failed to start within " + startupTimeout, e);
+        }
+
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        try {
+            URI pageWs = findFirstPageWebSocketUrl(http, browserWs.getPort(), startupTimeout);
+
+            SessionHolder holder = new SessionHolder();
+            WebSocket ws;
+            try {
+                ws = http.newWebSocketBuilder()
+                        .buildAsync(pageWs, holder.listener())
+                        .get(startupTimeout.toMillis(), MILLISECONDS);
+            } catch (Exception e) {
+                throw new IOException("Failed to connect to chrome DevTools WebSocket at " + pageWs, e);
+            }
+
+            DevToolsSession session = new DevToolsSession(proc, http, ws);
+            holder.session = session;
+            session.call("Page.enable", "{}", Duration.ofSeconds(5));
+            return session;
+        } catch (IOException e) {
+            http.close();
+            proc.destroyForcibly();
+            throw e;
+        }
+    }
+
+    private static void startStderrReader(Process proc, CompletableFuture<URI> listening) {
+        Thread reader = new Thread(() -> {
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(proc.getErrorStream(), UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    log.trace("chrome stderr: {}", line);
+                    if (!listening.isDone()) {
+                        Matcher m = LISTENING_LINE.matcher(line);
+                        if (m.find()) {
+                            listening.complete(URI.create(m.group(1)));
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                listening.completeExceptionally(e);
+            }
+        }, "fs-chrome-stderr");
+        reader.setDaemon(true);
+        reader.start();
+    }
+
+    private static URI findFirstPageWebSocketUrl(HttpClient http, int port, Duration timeout) throws IOException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        IOException lastError = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                HttpResponse<String> resp = http.send(
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/json/list"))
+                                .timeout(Duration.ofSeconds(2))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() == 200) {
+                    URI url = findPageWsInJsonArray(resp.body());
+                    if (url != null) return url;
+                }
+            } catch (IOException e) {
+                lastError = e;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for chrome page target", e);
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for chrome page target", e);
+            }
+        }
+        throw new IOException("chrome did not expose a page target on port " + port + " within " + timeout, lastError);
+    }
+
+    private static final Pattern PAGE_WS_URL = Pattern.compile(
+            "\"type\"\\s*:\\s*\"page\".*?\"webSocketDebuggerUrl\"\\s*:\\s*\"(ws://[^\"]+)\"",
+            Pattern.DOTALL);
+
+    @Nullable
+    private static URI findPageWsInJsonArray(String body) {
+        Matcher m = PAGE_WS_URL.matcher(body);
+        return m.find() ? URI.create(m.group(1)) : null;
+    }
+
+    private void onMessage(String json) {
+        JSONObject messageJson = new JSONObject(json);
+        Long id = messageJson.optLongObject("id", null);
+        if (id != null) {
+            CompletableFuture<String> fut = pending.remove(id);
+            if (fut != null) fut.complete(json);
+            return;
+        }
+        String method = messageJson.optString("method", null);
+        if ("Page.loadEventFired".equals(method)) {
+            CompletableFuture<Void> load = currentLoad.get();
+            if (load != null) load.complete(null);
+        }
+    }
+
+    private void onWsClosed() {
+        closed = true;
+        IOException reason = new IOException("DevTools WebSocket closed");
+        for (CompletableFuture<String> f : pending.values()) {
+            f.completeExceptionally(reason);
+        }
+        pending.clear();
+        CompletableFuture<Void> load = currentLoad.getAndSet(null);
+        if (load != null) load.completeExceptionally(reason);
+    }
+
+    String call(String method, String params, Duration timeout) throws IOException {
+        if (closed) throw new IOException("DevTools session is closed");
+        long id = messageId.incrementAndGet();
+        String msg = "{\"id\":" + id + ",\"method\":\"" + method + "\",\"params\":" + params + "}";
+        CompletableFuture<String> fut = new CompletableFuture<>();
+        pending.put(id, fut);
+        try {
+            webSocket.sendText(msg, true).get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            pending.remove(id);
+            throw new IOException("Failed to send " + method, e);
+        }
+        try {
+            String response = fut.get(timeout.toMillis(), MILLISECONDS);
+            JSONObject responseJson = new JSONObject(response);
+            JSONObject error = responseJson.optJSONObject("error");
+            if (error != null) {
+                String errMsg = error.optString("message", responseJson.optString("error", response));
+                throw new IOException("DevTools " + method + " failed: " + errMsg);
+            }
+            return response;
+        } catch (TimeoutException e) {
+            pending.remove(id);
+            throw new IOException("DevTools " + method + " timed out after " + timeout, e);
+        } catch (InterruptedException e) {
+            pending.remove(id);
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted waiting for DevTools " + method, e);
+        } catch (ExecutionException e) {
+            pending.remove(id);
+            throw new IOException("DevTools " + method + " failed", e.getCause());
+        }
+    }
+
+    byte[] printToPdf(String htmlUrl, ChromiumPdfOptions options, Duration timeout) throws IOException {
+        CompletableFuture<Void> load = new CompletableFuture<>();
+        currentLoad.set(load);
+        try {
+            call("Page.navigate", new JSONObject().put("url", htmlUrl).toString(), timeout);
+            try {
+                load.get(timeout.toMillis(), MILLISECONDS);
+            } catch (TimeoutException e) {
+                throw new IOException("Page.loadEventFired did not fire within " + timeout + " for " + htmlUrl, e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted waiting for page load", e);
+            } catch (ExecutionException e) {
+                throw new IOException("Page load failed", e.getCause());
+            }
+        } finally {
+            currentLoad.compareAndSet(load, null);
+        }
+        String pdfResponse = call("Page.printToPDF", buildPrintParams(options), timeout);
+        String base64 = new JSONObject(pdfResponse).getJSONObject("result").getString("data");
+        return Base64.getDecoder().decode(base64);
+    }
+
+    boolean isAlive() {
+        return !closed && process.isAlive();
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        try {
+            webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "bye").get(2, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+            // best-effort
+        }
+        webSocket.abort();
+        process.destroy();
+        try {
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            process.destroyForcibly();
+        }
+        httpClient.close();
+        IOException reason = new IOException("DevTools session closed");
+        for (CompletableFuture<String> f : pending.values()) {
+            f.completeExceptionally(reason);
+        }
+        pending.clear();
+    }
+
+    private static List<String> buildCommand(Path binary, ChromiumPdfOptions options) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(binary.toString());
+        cmd.add("--headless");
+        if (options.isDisableGpu()) cmd.add("--disable-gpu");
+        if (options.isNoSandbox()) cmd.add("--no-sandbox");
+        cmd.add("--remote-debugging-port=0");
+        cmd.addAll(options.getExtraArgs());
+        cmd.add("about:blank");
+        return cmd;
+    }
+
+    private static String buildPrintParams(ChromiumPdfOptions options) {
+        return """
+            {"printBackground":true, "displayHeaderFooter":%s}
+            """.formatted(!options.isNoPdfHeaderFooter()).trim();
+    }
+
+    private static class SessionHolder {
+        volatile @Nullable DevToolsSession session;
+
+        WebSocket.Listener listener() {
+            return new WebSocket.Listener() {
+                final StringBuilder buf = new StringBuilder();
+
+                @Override
+                public void onOpen(WebSocket ws) {
+                    ws.request(1);
+                }
+
+                @Override
+                public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last) {
+                    buf.append(data);
+                    if (last) {
+                        String full = buf.toString();
+                        buf.setLength(0);
+                        DevToolsSession s = session;
+                        if (s != null) s.onMessage(full);
+                    }
+                    ws.request(1);
+                    return null;
+                }
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket ws, int statusCode, String reason) {
+                    DevToolsSession s = session;
+                    if (s != null) s.onWsClosed();
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket ws, Throwable error) {
+                    log.debug("WebSocket error", error);
+                    DevToolsSession s = session;
+                    if (s != null) s.onWsClosed();
+                }
+            };
+        }
+    }
+
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/Html2Pdf.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/Html2Pdf.java
@@ -1,0 +1,45 @@
+package org.xhtmlrenderer.chrome;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+
+public final class Html2Pdf {
+    private static final ChromiumPdfRenderer SHARED = new ChromiumPdfRenderer();
+
+    private Html2Pdf() {
+    }
+
+    public static byte[] fromUrl(URL html) {
+        try {
+            return SHARED.renderToPdf(html);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to render PDF from " + html, e);
+        }
+    }
+
+    public static byte[] fromFile(File html) {
+        try {
+            return SHARED.renderToPdf(html);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to render PDF from " + html, e);
+        }
+    }
+
+    public static byte[] fromHtml(String html) {
+        try {
+            return SHARED.renderFromHtml(html);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to render PDF from inline HTML", e);
+        }
+    }
+
+    public static byte[] fromClasspathResource(String resourcePath) {
+        URL url = requireNonNull(Thread.currentThread().getContextClassLoader().getResource(resourcePath),
+                () -> "Resource not found in classpath: " + resourcePath);
+        return fromUrl(url);
+    }
+}

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ZipExtractor.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ZipExtractor.java
@@ -1,0 +1,31 @@
+package org.xhtmlrenderer.chrome;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+class ZipExtractor {
+    void extract(Path zipFile, Path targetDir) throws IOException {
+        Files.createDirectories(targetDir);
+        try (InputStream in = Files.newInputStream(zipFile);
+             ZipInputStream zip = new ZipInputStream(in)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                Path resolved = targetDir.resolve(entry.getName()).normalize();
+                if (!resolved.startsWith(targetDir)) {
+                    throw new IOException("Zip entry escapes target directory: " + entry.getName());
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(resolved);
+                } else {
+                    Files.createDirectories(resolved.getParent());
+                    Files.copy(zip, resolved, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/BenchmarkTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/BenchmarkTest.java
@@ -1,0 +1,50 @@
+package org.xhtmlrenderer.chrome;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+
+@Disabled("Long-running performance benchmark — run manually with -Dtest=Benchmark")
+class BenchmarkTest {
+    private static final Logger log = LoggerFactory.getLogger(BenchmarkTest.class);
+
+    @Test
+    void compareBackends() {
+        int iterations = Integer.getInteger("benchmark.iterations", 1000);
+        URL html = requireNonNull(
+                getClass().getClassLoader().getResource("org/xhtmlrenderer/chrome/benchmark.html"));
+
+        log.info("Warming up...");
+        byte[] warmupPdfBytes = org.xhtmlrenderer.pdf.Html2Pdf.fromUrl(html);
+        byte[] warmupChromeBytes = Html2Pdf.fromUrl(html);
+        log.info("Warmed up: generated {} bytes by pdf and {} bytes by chrome", warmupPdfBytes.length, warmupChromeBytes.length);
+
+        log.info("Rendering {} PDFs with flying-saucer-pdf...", iterations);
+        long pdfStart = System.nanoTime();
+        long pdfBytes = 0;
+        for (int i = 0; i < iterations; i++) {
+            pdfBytes += org.xhtmlrenderer.pdf.Html2Pdf.fromUrl(html).length;
+        }
+        long pdfMillis = (System.nanoTime() - pdfStart) / 1_000_000;
+
+        log.info("Rendering {} PDFs with flying-saucer-chrome-pdf...", iterations);
+        long chromeStart = System.nanoTime();
+        long chromeBytes = 0;
+        for (int i = 0; i < iterations; i++) {
+            chromeBytes += Html2Pdf.fromUrl(html).length;
+        }
+        long chromeMillis = (System.nanoTime() - chromeStart) / 1_000_000;
+
+        log.info("=== Results (lower is better) ===");
+        log.info("flying-saucer-pdf:        {} ms total | {} ms/pdf | {} bytes/pdf",
+                pdfMillis, pdfMillis / (double) iterations, pdfBytes / iterations);
+        log.info("flying-saucer-chrome-pdf: {} ms total | {} ms/pdf | {} bytes/pdf",
+                chromeMillis, chromeMillis / (double) iterations, chromeBytes / iterations);
+        log.info("Ratio (chrome / pdf):     {}x", chromeMillis / (double) pdfMillis);
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromeBinaryLocatorTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromeBinaryLocatorTest.java
@@ -1,0 +1,132 @@
+package org.xhtmlrenderer.chrome;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.xhtmlrenderer.chrome.ChromeBinaryLocator.readDownloadUrl;
+import static org.xhtmlrenderer.chrome.ChromeBinaryLocator.readLatestStableVersion;
+import static org.xhtmlrenderer.chrome.ChromePlatform.LINUX64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.MAC_ARM64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.MAC_X64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.WIN64;
+
+class ChromeBinaryLocatorTest {
+
+    @TempDir
+    private Path tmp;
+
+    @Test
+    void usesExplicitPathWhenProvided() throws IOException {
+        Path explicit = Files.createFile(tmp.resolve("chrome-headless-shell"));
+        FakeDownloader downloader = new FakeDownloader();
+
+        Path located = new ChromeBinaryLocator(explicit, "1.0.0", tmp.resolve("cache"), LINUX64, downloader).locate();
+
+        assertThat(located).isEqualTo(explicit);
+        assertThat(downloader.callCount).hasValue(0);
+    }
+
+    @Test
+    void failsWhenExplicitPathDoesNotExist() {
+        Path missing = tmp.resolve("nope");
+        ChromeBinaryLocator locator = new ChromeBinaryLocator(missing, "1.0.0", tmp.resolve("cache"), LINUX64, new FakeDownloader());
+
+        assertThatThrownBy(locator::locate)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void usesCachedBinaryWithoutDownloading() throws IOException, URISyntaxException {
+        Path cacheDir = tmp.resolve("cache");
+        Path versionDir = cacheDir.resolve("133.0.6857.0").resolve(LINUX64.id());
+        Path nestedDir = versionDir.resolve("chrome-headless-shell-" + LINUX64.id());
+        Files.createDirectories(nestedDir);
+        Path executable = Files.createFile(nestedDir.resolve(LINUX64.executableName()));
+        Files.copy(allVersionsFile(), cacheDir.resolve(allVersionsFile().getFileName()));
+        FakeDownloader downloader = new FakeDownloader();
+
+        Path located = new ChromeBinaryLocator(null, "133.0.6857.0", cacheDir, LINUX64, downloader).locate();
+
+        assertThat(located).isEqualTo(executable);
+        assertThat(downloader.callCount).hasValue(0);
+    }
+
+    @Test
+    void downloadsWhenCacheIsEmpty() throws IOException, URISyntaxException {
+        Path cacheDir = tmp.resolve("cache");
+        Files.createDirectories(cacheDir);
+        Files.copy(allVersionsFile(), cacheDir.resolve(allVersionsFile().getFileName()));
+        FakeDownloader downloader = new FakeDownloader();
+
+        new ChromeBinaryLocator(null, "133.0.6857.0", cacheDir, MAC_ARM64, downloader).locate();
+
+        assertThat(downloader.callCount).hasValue(1);
+        assertThat(downloader.lastVersion).isEqualTo("133.0.6857.0");
+        assertThat(downloader.lastPlatform).isEqualTo(MAC_ARM64);
+    }
+
+    @Test
+    void parsesJsonWithKnownChromeVersions() throws URISyntaxException, IOException {
+        Path file = lastVersionsFile();
+
+        assertThat(readLatestStableVersion(file, LINUX64).url().toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/linux64/chrome-headless-shell-linux64.zip");
+        assertThat(readLatestStableVersion(file, MAC_X64).url().toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chrome-headless-shell-mac-arm64.zip");
+        assertThat(readLatestStableVersion(file, MAC_ARM64).url().toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chrome-headless-shell-mac-arm64.zip");
+        assertThat(readLatestStableVersion(file, WIN64).url().toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win64/chrome-headless-shell-win64.zip");
+    }
+
+    @Test
+    void parsesCorrectZipUrlForGivenVersionAndPlatform() throws URISyntaxException, IOException {
+        Path file = allVersionsFile();
+
+        assertThat(readDownloadUrl(file, LINUX64, "133.0.6857.0").toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/linux64/chrome-headless-shell-linux64.zip");
+        assertThat(readDownloadUrl(file, MAC_X64, "133.0.6857.0").toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-x64/chrome-headless-shell-mac-x64.zip");
+        assertThat(readDownloadUrl(file, MAC_ARM64, "133.0.6857.0").toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-arm64/chrome-headless-shell-mac-arm64.zip");
+        assertThat(readDownloadUrl(file, WIN64, "133.0.6857.0").toString())
+            .isEqualTo("https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win64/chrome-headless-shell-win64.zip");
+    }
+
+    private Path lastVersionsFile() throws URISyntaxException {
+        String versionsFileName = "/last-known-good-versions-with-downloads.json";
+        URL versionsFile = requireNonNull(getClass().getResource(versionsFileName), () -> "Versions file not found: " + versionsFileName);
+        return Path.of(versionsFile.toURI());
+    }
+
+    private Path allVersionsFile() throws URISyntaxException {
+        String versionsFileName = "/known-good-versions-with-downloads.json";
+        URL versionsFile = requireNonNull(getClass().getResource(versionsFileName), () -> "Versions file not found: " + versionsFileName);
+        return Path.of(versionsFile.toURI());
+    }
+
+    private static class FakeDownloader extends ChromeBinaryDownloader {
+        final AtomicInteger callCount = new AtomicInteger();
+        String lastVersion = "";
+        ChromePlatform lastPlatform = LINUX64;
+        @Override
+        Path download(ChromeVersion chromeVersion, ChromePlatform platform, Path versionDir) throws IOException {
+            callCount.incrementAndGet();
+            lastVersion = chromeVersion.version();
+            lastPlatform = platform;
+            Files.createDirectories(versionDir);
+            return Files.createFile(versionDir.resolve(platform.executableName()));
+        }
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromePlatformTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromePlatformTest.java
@@ -1,0 +1,63 @@
+package org.xhtmlrenderer.chrome;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.xhtmlrenderer.chrome.ChromePlatform.LINUX64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.MAC_ARM64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.MAC_X64;
+import static org.xhtmlrenderer.chrome.ChromePlatform.WIN64;
+
+class ChromePlatformTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "Mac OS X,    x86_64,   false, MAC_X64",
+            "Mac OS X,    aarch64,  true,  MAC_ARM64",
+            "Darwin,      arm64,    true,  MAC_ARM64",
+            "Windows 11,  amd64,    false, WIN64",
+            "Windows 10,  x86_64,   false, WIN64",
+            "Linux,       x86_64,   false, LINUX64",
+            "Linux,       amd64,    false, LINUX64",
+    })
+    void detectsSupportedPlatform(String os, String arch, boolean arm64, ChromePlatform expected) {
+        assertThat(ChromePlatform.detect(os, arch, arm64)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Linux, aarch64, true",
+            "Linux, arm64,   true",
+    })
+    void linuxArm64IsNotSupported(String os, String arch, boolean arm64) {
+        assertThatThrownBy(() -> ChromePlatform.detect(os, arch, arm64))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Linux arm64")
+                .hasMessageContaining("setBinaryPath");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "FreeBSD,  x86_64,  false",
+            "Solaris,  sparc,   false",
+            "'',       x86_64,  false",
+    })
+    void unknownOsIsNotSupported(String os, String arch, boolean arm64) {
+        assertThatThrownBy(() -> ChromePlatform.detect(os, arch, arm64))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Unsupported OS")
+                .hasMessageContaining(arch);
+    }
+
+    @Test
+    void platformIdAndExecutableName() {
+        assertThat(LINUX64.id()).isEqualTo("linux64");
+        assertThat(LINUX64.executableName()).isEqualTo("chrome-headless-shell");
+        assertThat(WIN64.executableName()).isEqualTo("chrome-headless-shell.exe");
+        assertThat(MAC_X64.id()).isEqualTo("mac-x64");
+        assertThat(MAC_ARM64.id()).isEqualTo("mac-arm64");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromiumPdfRendererTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromiumPdfRendererTest.java
@@ -1,0 +1,62 @@
+package org.xhtmlrenderer.chrome;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.xhtmlrenderer.chrome.TestUtils.printFile;
+
+class ChromiumPdfRendererTest {
+    private static final Logger log = LoggerFactory.getLogger(ChromiumPdfRendererTest.class);
+
+    @Test
+    void rendersWithCustomOptions() throws IOException {
+        URL html = requireNonNull(
+                getClass().getClassLoader().getResource("org/xhtmlrenderer/chrome/sample.html"));
+
+        byte[] bytes = new ChromiumPdfRenderer()
+                .setOptions(new ChromiumPdfOptions().addExtraArg("--hide-scrollbars"))
+                .setTimeout(Duration.ofMinutes(2))
+                .renderToPdf(html);
+
+        PDF pdf = printFile(log, bytes, "options-chrome.pdf");
+        assertThat(pdf).containsText("Hello Chromium");
+    }
+
+    @Test
+    void writesToTargetPath(@TempDir Path tmp) throws IOException {
+        URL html = requireNonNull(
+                getClass().getClassLoader().getResource("org/xhtmlrenderer/chrome/sample.html"));
+        Path outputPdf = tmp.resolve("out.pdf");
+
+        new ChromiumPdfRenderer().renderToPdf(html, outputPdf);
+
+        assertThat(Files.size(outputPdf)).isGreaterThan(1000);
+    }
+
+    @Test
+    void failsWithMissingExplicitBinary(@TempDir Path tmp) {
+        Path bogus = tmp.resolve("not-chrome");
+        URL html = requireNonNull(
+                getClass().getClassLoader().getResource("org/xhtmlrenderer/chrome/sample.html"));
+
+        ChromiumPdfRenderer renderer = new ChromiumPdfRenderer().setBinaryPath(bogus);
+
+        assertThatThrownBy(() -> renderer.renderToPdf(html))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not found");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/CompareWithFlyingSaucerPdfTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/CompareWithFlyingSaucerPdfTest.java
@@ -1,0 +1,27 @@
+package org.xhtmlrenderer.chrome;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+import static org.xhtmlrenderer.chrome.TestUtils.printFile;
+
+class CompareWithFlyingSaucerPdfTest {
+    private static final Logger log = LoggerFactory.getLogger(CompareWithFlyingSaucerPdfTest.class);
+
+    @Test
+    void compareHtml5Tags() throws IOException {
+        URL html = requireNonNull(
+            getClass().getClassLoader().getResource("org/xhtmlrenderer/chrome/html5-sample.html"));
+
+        byte[] pdf = org.xhtmlrenderer.pdf.Html2Pdf.fromUrl(html);
+        byte[] chrome = Html2Pdf.fromUrl(html);
+
+        printFile(log, pdf, "sample-pdf.pdf");
+        printFile(log, chrome, "sample-chrome.pdf");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/Html2PdfTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/Html2PdfTest.java
@@ -1,0 +1,32 @@
+package org.xhtmlrenderer.chrome;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static org.xhtmlrenderer.chrome.TestUtils.printFile;
+
+class Html2PdfTest {
+    private static final Logger log = LoggerFactory.getLogger(Html2PdfTest.class);
+
+    @Test
+    void rendersClasspathHtmlToPdf() throws IOException {
+        byte[] bytes = Html2Pdf.fromClasspathResource("org/xhtmlrenderer/chrome/sample.html");
+        PDF pdf = printFile(log, bytes, "sample-chrome.pdf");
+
+        assertThat(pdf).containsText("Hello Chromium");
+        assertThat(pdf).containsText("chrome-headless-shell");
+    }
+
+    @Test
+    void rendersInlineHtmlToPdf() throws IOException {
+        byte[] bytes = Html2Pdf.fromHtml("<!DOCTYPE html><html><body><h1>Inline content</h1></body></html>");
+        PDF pdf = printFile(log, bytes, "inline-chrome.pdf");
+
+        assertThat(pdf).containsText("Inline content");
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/TestUtils.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/TestUtils.java
@@ -1,0 +1,23 @@
+package org.xhtmlrenderer.chrome;
+
+import com.codeborne.pdftest.PDF;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+class TestUtils {
+    static PDF printFile(Logger log, byte[] pdf, String filename) throws IOException {
+        File target = new File("target");
+        if (!target.exists() && !target.mkdirs()) {
+            throw new IOException("Failed to create directory: " + target);
+        }
+        File file = new File(target, filename);
+        try (FileOutputStream o = new FileOutputStream(file)) {
+            o.write(pdf);
+        }
+        log.info("Generated PDF: {}", file.getAbsoluteFile().toURI());
+        return new PDF(pdf);
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ZipExtractorTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ZipExtractorTest.java
@@ -1,0 +1,80 @@
+package org.xhtmlrenderer.chrome;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ZipExtractorTest {
+
+    @Test
+    void extractsFlatZip(@TempDir Path tmp) throws IOException {
+        Path zip = tmp.resolve("flat.zip");
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zip))) {
+            writeEntry(out, "hello.txt", "hello");
+            writeEntry(out, "sub/world.txt", "world");
+        }
+
+        Path target = tmp.resolve("out");
+        new ZipExtractor().extract(zip, target);
+
+        assertThat(Files.readString(target.resolve("hello.txt"))).isEqualTo("hello");
+        assertThat(Files.readString(target.resolve("sub/world.txt"))).isEqualTo("world");
+    }
+
+    @Test
+    void rejectsEntryThatEscapesTargetDir(@TempDir Path tmp) throws IOException {
+        Path zip = tmp.resolve("evil.zip");
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zip))) {
+            writeEntry(out, "../escape.txt", "boom");
+        }
+
+        assertThatThrownBy(() -> new ZipExtractor().extract(zip, tmp.resolve("out")))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("escapes target directory");
+    }
+
+    @Test
+    void createsTargetDirIfMissing(@TempDir Path tmp) throws IOException {
+        Path zip = tmp.resolve("z.zip");
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zip))) {
+            writeEntry(out, "a.txt", "a");
+        }
+        Path target = tmp.resolve("does/not/exist");
+
+        new ZipExtractor().extract(zip, target);
+
+        assertThat(Files.readString(target.resolve("a.txt"))).isEqualTo("a");
+    }
+
+    private static void writeEntry(ZipOutputStream out, String name, String content) throws IOException {
+        out.putNextEntry(new ZipEntry(name));
+        try (OutputStream s = nonClosing(out)) {
+            s.write(content.getBytes(UTF_8));
+        }
+        out.closeEntry();
+    }
+
+    private static OutputStream nonClosing(OutputStream delegate) {
+        return new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                delegate.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                delegate.write(b, off, len);
+            }
+        };
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/resources/known-good-versions-with-downloads.json
+++ b/flying-saucer-chrome-pdf/src/test/resources/known-good-versions-with-downloads.json
@@ -1,0 +1,205 @@
+{
+    "timestamp": "2026-06-07T09:27:03.971Z",
+    "versions": [
+        {
+            "version": "113.0.5672.0",
+            "revision": "1121455",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/113.0.5672.0/win64/chrome-win64.zip"
+                    }
+                ]
+            }
+        },
+        {
+            "version": "114.0.5696.0",
+            "revision": "1126269",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/114.0.5696.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/114.0.5696.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/114.0.5696.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/114.0.5696.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/114.0.5696.0/win64/chrome-win64.zip"
+                    }
+                ]
+            }
+        },
+        {
+            "version": "133.0.6857.0",
+            "revision": "1387357",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/133.0.6857.0/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        },
+        {
+            "version": "151.0.7879.0",
+            "revision": "1642845",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/flying-saucer-chrome-pdf/src/test/resources/last-known-good-versions-with-downloads.json
+++ b/flying-saucer-chrome-pdf/src/test/resources/last-known-good-versions-with-downloads.json
@@ -1,0 +1,297 @@
+{
+    "timestamp": "2026-06-07T09:27:03.966Z",
+    "channels": {
+        "Stable": {
+            "channel": "Stable",
+            "version": "149.0.7827.54",
+            "revision": "1625079",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        },
+        "Beta": {
+            "channel": "Beta",
+            "version": "150.0.7871.4",
+            "revision": "1639810",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/mac-x64/chrome-headless-shell-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/150.0.7871.4/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        },
+        "Dev": {
+            "channel": "Dev",
+            "version": "151.0.7872.0",
+            "revision": "1640418",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7872.0/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        },
+        "Canary": {
+            "channel": "Canary",
+            "version": "151.0.7879.0",
+            "revision": "1642845",
+            "downloads": {
+                "chrome": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chrome-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chrome-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chrome-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chrome-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chrome-win64.zip"
+                    }
+                ],
+                "chromedriver": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chromedriver-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chromedriver-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chromedriver-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chromedriver-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chromedriver-win64.zip"
+                    }
+                ],
+                "chrome-headless-shell": [
+                    {
+                        "platform": "linux64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/linux64/chrome-headless-shell-linux64.zip"
+                    },
+                    {
+                        "platform": "mac-arm64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-arm64/chrome-headless-shell-mac-arm64.zip"
+                    },
+                    {
+                        "platform": "mac-x64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/mac-x64/chrome-headless-shell-mac-x64.zip"
+                    },
+                    {
+                        "platform": "win32",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win32/chrome-headless-shell-win32.zip"
+                    },
+                    {
+                        "platform": "win64",
+                        "url": "https://storage.googleapis.com/chrome-for-testing-public/151.0.7879.0/win64/chrome-headless-shell-win64.zip"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/benchmark.html
+++ b/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/benchmark.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Benchmark Document</title>
+  <style type="text/css">
+    body { font-family: sans-serif; font-size: 11pt; padding: 1em; }
+    h1 { font-size: 16pt; border-bottom: 1px solid #888; }
+    p { margin: 0.5em 0; }
+    table { border-collapse: collapse; margin-top: 1em; }
+    th, td { border: 1px solid #aaa; padding: 4px 8px; }
+    th { background: #eee; }
+  </style>
+</head>
+<body>
+  <h1>Invoice 2026-05-001</h1>
+  <p>Customer: <strong>Acme Corp.</strong></p>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+     veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+     ea commodo consequat.</p>
+  <table>
+    <tr><th>Item</th><th>Qty</th><th>Price</th></tr>
+    <tr><td>Widget</td><td>3</td><td>9.99</td></tr>
+    <tr><td>Gadget</td><td>1</td><td>19.99</td></tr>
+    <tr><td>Sprocket</td><td>12</td><td>2.50</td></tr>
+  </table>
+  <p>Thank you for your business.</p>
+</body>
+</html>

--- a/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/html5-sample.html
+++ b/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/html5-sample.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>HTML5 &amp; CSS3 Combined</title>
+    <style>
+        /* CSS3 Custom Properties (Variables) for easy theme management */
+        :root {
+            --primary-bg: #f4f4f9;
+            --header-bg: #2c3e50;
+            --text-main: #333;
+            --card-bg: #ffffff;
+        }
+
+        /* Basic Reset */
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        /* CSS3 Viewport height and Flexbox on the body to keep the footer at the bottom */
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--primary-bg);
+            color: var(--text-main);
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        /* HTML5 Semantic Elements Styling */
+        header, footer {
+            background-color: var(--header-bg);
+            color: #ffffff;
+            text-align: center;
+            padding: 2rem 1rem;
+        }
+
+        /* Using the HTML5 `main` tag as our CSS3 Flexbox container */
+        main {
+            flex: 1; /* Allows main to grow and push the footer down */
+            display: flex;
+            flex-wrap: wrap; /* Wraps cards on smaller screens */
+            gap: 25px; /* Perfect spacing between cards */
+            padding: 3rem 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+            justify-content: center;
+        }
+
+        /* HTML5 `article` tags styled as interactive CSS3 cards */
+        article {
+            background-color: var(--card-bg);
+            flex: 1 1 300px; /* Grow, shrink, and start at 300px wide */
+            padding: 2rem;
+
+            /* CSS3 Visual Features */
+            border-radius: 12px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        /* CSS3 Hover State */
+        article:hover {
+            transform: translateY(-8px);
+            box-shadow: 0 15px 25px rgba(0, 0, 0, 0.1);
+        }
+
+        article h2 {
+            margin-bottom: 1rem;
+            color: var(--header-bg);
+        }
+
+        article p {
+            line-height: 1.6;
+            color: #555;
+        }
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        @page {
+            size: A4;
+            margin: 20mm;
+
+            @bottom-right {
+                content: "Page " counter(page) " of " counter(pages);
+                font-family: Arial, sans-serif;
+                font-size: 12px;
+                color: #666;
+            }
+        }
+    </style>
+</head>
+<body>
+
+<header>
+    <h1>Modern Web Architecture</h1>
+    <p>Combining Semantic HTML5 with Responsive CSS3</p>
+</header>
+
+<main>
+
+    <article>
+        <h2>Semantic Structure</h2>
+        <p>By using tags like <code>&lt;header&gt;</code>, <code>&lt;main&gt;</code>, and <code>&lt;article&gt;</code>, we tell search engines and screen readers exactly what each part of our page does, improving both SEO and accessibility.</p>
+    </article>
+
+    <article>
+        <h2>Flexible Layouts</h2>
+        <p>We applied CSS3 Flexbox directly to the <code>&lt;main&gt;</code> tag. This allows these article cards to sit side-by-side on desktop screens and automatically stack on top of each other on mobile devices.</p>
+    </article>
+
+    <article>
+        <h2>Interactive Styling</h2>
+        <p>Hover over this card to see CSS3 <code>transform</code> and <code>transition</code> in action. It provides a smooth, floating interactive effect without requiring a single line of JavaScript.</p>
+    </article>
+
+    <article class="page-break">
+        <h2>Another page</h2>
+        <p>This blocks comes on a second page</p>
+    </article>
+
+</main>
+
+<footer>
+    <p>&copy; 2026 Web Development Journal. Built with modern standards.</p>
+</footer>
+
+</body>
+</html>

--- a/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/sample.html
+++ b/flying-saucer-chrome-pdf/src/test/resources/org/xhtmlrenderer/chrome/sample.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Flying Saucer Chrome PDF Sample</title>
+  <style>
+    body { font-family: sans-serif; padding: 2em; }
+    .badge { display: inline-block; padding: 0.25em 0.5em; background: #4caf50; color: white; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Hello Chromium</h1>
+  <p>This document was rendered to PDF by <span class="badge">chrome-headless-shell</span>.</p>
+  <p>It uses modern CSS that flying-saucer-pdf does not support.</p>
+</body>
+</html>

--- a/flying-saucer-core/pom.xml
+++ b/flying-saucer-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-examples/pom.xml
+++ b/flying-saucer-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-fop/pom.xml
+++ b/flying-saucer-fop/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-log4j/pom.xml
+++ b/flying-saucer-log4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-pdf-osgi/pom.xml
+++ b/flying-saucer-pdf-osgi/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-pdf/pom.xml
+++ b/flying-saucer-pdf/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/flying-saucer-swt/pom.xml
+++ b/flying-saucer-swt/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.xhtmlrenderer</groupId>
     <artifactId>flying-saucer-parent</artifactId>
-    <version>10.2.2</version>
+    <version>10.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.xhtmlrenderer</groupId>
   <artifactId>flying-saucer-parent</artifactId>
-  <version>10.2.2</version>
+  <version>10.3.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 
@@ -113,6 +113,7 @@
     <module>flying-saucer-swt</module>
     <module>flying-saucer-examples</module>
     <module>flying-saucer-fop</module>
+    <module>flying-saucer-chrome-pdf</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Summary

Closes #633. Adds a new Maven module `flying-saucer-chrome-pdf` that renders HTML to PDF by delegating to a `chrome-headless-shell` subprocess — intended for projects that need modern HTML5/CSS3 features beyond Flying Saucer's CSS 2.1 renderer.

- **Entry points** mirror `flying-saucer-pdf`: stateful `ChromiumPdfRenderer` + static `Html2Pdf` facade (`fromUrl` / `fromFile` / `fromHtml` / `fromClasspathResource`).
- **Binary lookup**: explicit path (`setBinaryPath`) → on-disk cache → auto-download from chrome-for-testing (`https://storage.googleapis.com/chrome-for-testing-public/...`) into `~/.cache/flying-saucer/<version>/<platform>/`.
- **Platforms supported by auto-download**: linux64, mac-x64, mac-arm64, win64. Linux arm64 has no upstream build — explicit-path fallback only.
- **No dependency on `flying-saucer-core`**: this module is an alternative backend, not a plug-in to the FS rendering SPI.
- Default chrome version: `LATEST` (will check the latest Chrome version and cache for 1 day).
- CI: added `actions/cache` step for the chrome download dir so repeat builds don't re-download.

## Test plan

- [x] `mvn -pl flying-saucer-chrome-pdf -am test` — passes locally (5 unit tests + 5 end-to-end tests against real chrome on mac-arm64).
- [x] `mvn -B package` — full reactor passes (matches CI command).
- [ ] CI green on Java 21 and Java 25 (linux64).
- [ ] Confirm second CI run hits the chrome cache (no re-download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)