### PR TITLE
Make SharedContext non-final, so it can be extended

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
@@ -68,7 +68,7 @@ import static java.util.stream.Collectors.joining;
  *
  * @author empty
  */
-public final class SharedContext {
+public class SharedContext {
     private static final Set<String> PAGED_MEDIA_TYPES = Set.of("print", "projection", "embossed", "handheld", "tv");
 
     private TextRenderer textRenderer;


### PR DESCRIPTION
Our use-case is to suppress some of the recent "unsupportedFeatures". For example #589 but also some CSS-features where we just accept that they are unsupported.