### PR TITLE
feat(pdf): support inline <svg> elements

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -108,7 +108,8 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
                 style.append(e, "rowspan", "-fs-table-cell-rowspan: ");
                 break;
             }
-            case "img": {
+            case "img":
+            case "svg": {
                 style.appendWidth(e);
                 style.appendHeight(e);
                 break;

--- a/flying-saucer-core/src/main/resources/resources/css/XhtmlNamespaceHandler.css
+++ b/flying-saucer-core/src/main/resources/resources/css/XhtmlNamespaceHandler.css
@@ -75,6 +75,10 @@ img {
     padding: 0;
 }
 
+svg {
+    display: inline-block;
+}
+
 a {
     color: #0000ff;
 }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 public class ITextReplacedElementFactory implements ReplacedElementFactory {
+    private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+
     private final ITextOutputDevice _outputDevice;
 
     private final Map<Element, RadioButtonFormField> _radioButtonsByElem = new HashMap<>();
@@ -118,7 +120,7 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
     private static byte[] serializeToXml(Element e) {
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
             transformer.transform(new DOMSource(e), new StreamResult(out));
             return out.toByteArray();
         } catch (TransformerException ex) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ITextReplacedElementFactory implements ReplacedElementFactory {
+    private static final String SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg";
     private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
 
     private final ITextOutputDevice _outputDevice;
@@ -121,11 +122,26 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
-            transformer.transform(new DOMSource(e), new StreamResult(out));
+            transformer.transform(new DOMSource(ensureSvgNamespace(e)), new StreamResult(out));
             return out.toByteArray();
         } catch (TransformerException ex) {
             throw new XRRuntimeException("Failed to serialize inline <svg> element", ex);
         }
+    }
+
+    /**
+     * Authors commonly copy-paste HTML5 SVG markup, which omits {@code xmlns} since HTML5 parsers infer
+     * the SVG namespace from the tag name. Flying Saucer requires well-formed XML input, so a bare
+     * {@code <svg>} with no {@code xmlns} attribute (and no inherited SVG namespace) would otherwise be
+     * serialized without one, and Batik would then fail to recognize it as SVG.
+     */
+    private static Element ensureSvgNamespace(Element e) {
+        if (SVG_NAMESPACE_URI.equals(e.getNamespaceURI()) || !e.getAttribute("xmlns").isEmpty()) {
+            return e;
+        }
+        Element clone = (Element) e.cloneNode(true);
+        clone.setAttribute("xmlns", SVG_NAMESPACE_URI);
+        return clone;
     }
 
     private void saveResult(Element e, RadioButtonFormField result) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextReplacedElementFactory.java
@@ -28,7 +28,14 @@ import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
+import org.xhtmlrenderer.util.XRRuntimeException;
 
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -68,6 +75,12 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
                 }
 
                 break;
+            case "svg":
+                FSImage svgImage = new SvgImage(serializeToXml(e), ITextUserAgent.getSvgSize(e), "inline-svg");
+                if (cssWidth != -1 || cssHeight != -1) {
+                    svgImage = svgImage.scale(cssWidth, cssHeight);
+                }
+                return new ITextImageElement(svgImage);
             case "input":
                 String type = e.getAttribute("type");
                 switch (type) {
@@ -100,6 +113,17 @@ public class ITextReplacedElementFactory implements ReplacedElementFactory {
         }
 
         return null;
+    }
+
+    private static byte[] serializeToXml(Element e) {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.transform(new DOMSource(e), new StreamResult(out));
+            return out.toByteArray();
+        } catch (TransformerException ex) {
+            throw new XRRuntimeException("Failed to serialize inline <svg> element", ex);
+        }
     }
 
     private void saveResult(Element e, RadioButtonFormField result) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextUserAgent.java
@@ -31,6 +31,7 @@ import org.openpdf.text.pdf.PdfReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.Size;
 import org.xhtmlrenderer.resource.ImageResource;
@@ -154,18 +155,22 @@ public class ITextUserAgent extends NaiveUserAgent {
         SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(XMLResourceDescriptor.getXMLParserClassName());
         try (ByteArrayInputStream in = new ByteArrayInputStream(svgImage)) {
             Document document = factory.createDocument(uri, in);
-            String width = document.getDocumentElement().getAttribute("width");
-            String height = document.getDocumentElement().getAttribute("height");
-            if (!width.isEmpty() && !height.isEmpty()) {
-                return new Size(parseSize(width), parseSize(height));
-            }
-            String[] viewBox = document.getDocumentElement().getAttribute("viewBox").split(" ", 4);
-            if (viewBox.length >= 4) {
-                return new Size(parseSize(viewBox[2]), parseSize(viewBox[3]));
-            }
-
-            return new Size(300, 150); // default size in most browsers
+            return getSvgSize(document.getDocumentElement());
         }
+    }
+
+    static Size getSvgSize(Element svgRoot) {
+        String width = svgRoot.getAttribute("width");
+        String height = svgRoot.getAttribute("height");
+        if (!width.isEmpty() && !height.isEmpty()) {
+            return new Size(parseSize(width), parseSize(height));
+        }
+        String[] viewBox = svgRoot.getAttribute("viewBox").split(" ", 4);
+        if (viewBox.length >= 4) {
+            return new Size(parseSize(viewBox[2]), parseSize(viewBox[3]));
+        }
+
+        return new Size(300, 150); // default size in most browsers
     }
 
     private void scaleToOutputResolution(Image image) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/SvgTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/SvgTest.java
@@ -1,5 +1,6 @@
 package org.xhtmlrenderer.pdf;
 
+import com.codeborne.pdftest.PDF;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,7 @@ import java.net.URL;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SvgTest {
     private static final Logger log = LoggerFactory.getLogger(SvgTest.class);
@@ -47,6 +49,9 @@ public class SvgTest {
                 renderer.createPDF(outputStream);
             }
             log.info("PDF with SVG: {}", result.getAbsolutePath());
+
+            PDF pdf = new PDF(result);
+            assertThat(pdf.text).contains("SVG Star:");
         }
     }
 }

--- a/flying-saucer-pdf/src/test/resources/page-with-svg.html
+++ b/flying-saucer-pdf/src/test/resources/page-with-svg.html
@@ -31,6 +31,12 @@
              style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />
 </svg>
 
+<h3>SVG Star without xmlns (HTML5-style markup):</h3>
+<svg viewBox="0 0 300 200" width="100" height="67">
+    <polygon points="100,10 40,198 190,78 10,78 160,198"
+             style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />
+</svg>
+
 <h3>SVG Star from classpath:</h3>
 <img src="classpath:/star.svg" width="100px"/>
 

--- a/flying-saucer-pdf/src/test/resources/page-with-svg.html
+++ b/flying-saucer-pdf/src/test/resources/page-with-svg.html
@@ -26,6 +26,12 @@
 </div>
 
 <h3>SVG Star:</h3>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="100" height="67">
+    <polygon points="100,10 40,198 190,78 10,78 160,198"
+             style="fill:lime;stroke:purple;stroke-width:5;fill-rule:evenodd;" />
+</svg>
+
+<h3>SVG Star from classpath:</h3>
 <img src="classpath:/star.svg" width="100px"/>
 
 <h3>Img:classpath:</h3>


### PR DESCRIPTION
## Summary
- `<svg>...</svg>` written directly in the document body previously fell through to generic inline layout (its children rendered as unstyled boxes); only `<img src="...svg">` and CSS `background-image` SVGs worked.
- Give `svg` `display: inline-block` in the UA stylesheet and route its `width`/`height` presentational attributes through the same CSS conversion as `img`, so it becomes a proper replaced-element box.
- `ITextReplacedElementFactory` now serializes the inline `<svg>` subtree to XML and rasterizes it through the existing Batik-based `SvgImage`/`PNGTranscoder` pipeline (the same one used for `<img src="...svg">`).
- Extracted the width/height/viewBox sizing logic in `ITextUserAgent` into a reusable `getSvgSize(Element)` so both the URI-based and inline paths share it.

Note: as with any SVG (in a browser too), scaling an inline `<svg>` via `width`/`height` alone only works correctly if it also declares a `viewBox` — without one, the coordinate system stays 1 unit = 1px and shrinking just clips the artwork. `page-with-svg.html` was updated to include a `viewBox` for that reason.

## Test plan
- [x] `mvn -pl flying-saucer-core,flying-saucer-pdf -am test` passes
- [x] `SvgTest` renders `page-with-svg.html` to PDF and asserts the "SVG Star:" text is present
- [x] Manually rasterized the generated PDF to PNG and visually confirmed the inline SVG star renders correctly at its specified size, alongside the existing classpath-SVG/background-image cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)