### PR TITLE
log "unsupported features" warning under a dedicated logger name `Html5Support`

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Html5Support.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Html5Support.java
@@ -1,0 +1,24 @@
+package org.xhtmlrenderer.layout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+import static java.util.stream.Collectors.joining;
+
+public class Html5Support {
+    private static final Logger log = LoggerFactory.getLogger(Html5Support.class);
+
+    public static void logUnsupportedFeatures(Set<String> tags, Set<String> cssFeatures) {
+        if (!tags.isEmpty()) {
+            log.warn("Encountered HTML5 elements which are not supported by FlyingSaucer: {}. Rendering may be incorrect.",
+                tags.stream().map(tag -> String.format("<%s>", tag)).collect(joining(", ")));
+        }
+
+        if (!cssFeatures.isEmpty()) {
+            log.warn("Encountered CSS3 features not supported by FlyingSaucer: {}. Rendering may be incorrect.",
+                cssFeatures.stream().map(feature -> '"' + feature + '"').collect(joining(", ")));
+        }
+    }
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/SharedContext.java
@@ -21,7 +21,6 @@ package org.xhtmlrenderer.layout;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -61,7 +60,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 
 /**
  * The SharedContext is that which is kept between successive layout and render runs.
@@ -583,16 +581,7 @@ public final class SharedContext {
         return unsupportedTags;
     }
 
-    public void logUnsupportedFeatures(Logger log) {
-        if (!unsupportedTags.isEmpty()) {
-            log.warn("Encountered HTML5 elements which are not supported by FlyingSaucer: {}. Rendering may be incorrect.",
-                unsupportedTags.stream().map(tag -> String.format("<%s>", tag)).collect(joining(", ")));
-        }
-
-        Set<String> features = getCss().getUnsupportedCssFeatures();
-        if (!features.isEmpty()) {
-            log.warn("Encountered CSS3 features not supported by FlyingSaucer: {}. Rendering may be incorrect.",
-                features.stream().map(feature -> '"' + feature + '"').collect(joining(", ")));
-        }
+    public void logUnsupportedFeatures() {
+        Html5Support.logUnsupportedFeatures(unsupportedTags, getCss().getUnsupportedCssFeatures());
     }
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
@@ -20,8 +20,6 @@
 package org.xhtmlrenderer.swing;
 
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xhtmlrenderer.extend.NamespaceHandler;
@@ -76,7 +74,6 @@ import static org.xhtmlrenderer.util.ImageUtil.withGraphics;
  * <p>Not thread-safe.</p>
  */
 public class Java2DRenderer {
-    private static final Logger log = LoggerFactory.getLogger(Java2DRenderer.class);
     private static final int DEFAULT_HEIGHT = 1000;
     private static final int DEFAULT_DOTS_PER_POINT = 1;
     private static final int DEFAULT_DOTS_PER_PIXEL = 1;
@@ -298,7 +295,7 @@ public class Java2DRenderer {
         BlockBox root = BoxBuilder.createRootBox(c, doc);
         root.setContainingBlock(new ViewportBox(rect));
         root.layout(c);
-        c.getSharedContext().logUnsupportedFeatures(log);
+        c.getSharedContext().logUnsupportedFeatures();
         this.root = root;
     }
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/RootPanel.java
@@ -21,7 +21,6 @@ package org.xhtmlrenderer.swing;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSPrimitiveValue;
@@ -298,7 +297,7 @@ public class RootPanel extends JPanel implements Scrollable, UserInterface, FSCa
             long end = System.currentTimeMillis();
 
             XRLog.layout(Level.INFO, "Layout took " + (end - start) + "ms");
-            c.getSharedContext().logUnsupportedFeatures(LoggerFactory.getLogger(getClass()));
+            c.getSharedContext().logUnsupportedFeatures();
 
             // if there is a fixed child then we need to set opaque to false
             // so that the entire viewport will be repainted. this is slower

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -26,8 +26,6 @@ import org.openpdf.text.pdf.PdfName;
 import org.openpdf.text.pdf.PdfPageEvent;
 import org.openpdf.text.pdf.PdfString;
 import org.openpdf.text.pdf.PdfWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -77,8 +75,6 @@ import static java.util.Objects.requireNonNull;
 import static org.xhtmlrenderer.layout.Layer.PagedMode.PAGED_MODE_PRINT;
 
 public class ITextRenderer {
-    private static final Logger log = LoggerFactory.getLogger(ITextRenderer.class);
-
     // These two defaults combine to produce an effective resolution of 96 px to the inch
     public static final float DEFAULT_DOTS_PER_POINT = 20.0f * 4.0f / 3.0f;
     public static final int DEFAULT_DOTS_PER_PIXEL = 20;
@@ -291,7 +287,7 @@ public class ITextRenderer {
         BlockBox root = BoxBuilder.createRootBox(c, _doc);
         root.setContainingBlock(new ViewportBox(getInitialExtents(c)));
         root.layout(c);
-        c.getSharedContext().logUnsupportedFeatures(log);
+        c.getSharedContext().logUnsupportedFeatures();
         _dim = root.getLayer().getPaintingDimension(c);
         root.getLayer().trimEmptyPages(_dim.height);
         root.getLayer().layoutPages(c);

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/BasicRenderer.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/BasicRenderer.java
@@ -627,7 +627,7 @@ public class BasicRenderer extends Canvas implements PaintListener, UserInterfac
 
             long end = System.currentTimeMillis();
             XRLog.layout(Level.INFO, "Layout took " + (end - start) + "ms");
-            _sharedContext.logUnsupportedFeatures(log);
+            _sharedContext.logUnsupportedFeatures();
         } catch (Throwable e) {
             exception(e.getMessage(), e);
             log.error(e.toString(), e);

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/PrinterRenderer.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/PrinterRenderer.java
@@ -25,8 +25,6 @@ import org.eclipse.swt.printing.Printer;
 import org.eclipse.swt.printing.PrinterData;
 import org.eclipse.swt.widgets.Shell;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xhtmlrenderer.css.style.CalculatedStyle.Edge;
@@ -59,8 +57,6 @@ import static org.xhtmlrenderer.layout.Layer.PagedMode.PAGED_MODE_PRINT;
  * @author Vianney le Clément
  */
 public class PrinterRenderer implements UserInterface {
-    private static final Logger log = LoggerFactory.getLogger(PrinterRenderer.class);
-
     private final Printer _printer;
     private final SharedContext _sharedContext;
 
@@ -139,7 +135,7 @@ public class PrinterRenderer implements UserInterface {
 
                 long end = System.currentTimeMillis();
                 XRLog.layout(Level.INFO, "Layout took " + (end - start) + "ms");
-                _sharedContext.logUnsupportedFeatures(log);
+                _sharedContext.logUnsupportedFeatures();
             } catch (Throwable e) {
                 XRLog.exception(e.getMessage(), e);
                 return;


### PR DESCRIPTION
It allows users to suppress these warnings (in Logback/Slf4j/Log4j conf) if they are not interested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reporting when documents contain unsupported HTML5 tags or CSS3 features.
  * Warnings now consistently identify unsupported elements and features and indicate that rendering may be affected.
  * Standardized unsupported-feature reporting across Java2D, PDF, SWT, and printer rendering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->