### PR TITLE
fix(security): harden DocumentBuilderFactory usage against XXE

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DRenderer.java
@@ -35,9 +35,9 @@ import org.xhtmlrenderer.render.RenderingContext;
 import org.xhtmlrenderer.render.ViewportBox;
 import org.xhtmlrenderer.simple.extend.XhtmlNamespaceHandler;
 import org.xhtmlrenderer.util.ImageUtil;
+import org.xhtmlrenderer.util.XMLUtil;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -358,7 +358,7 @@ public class Java2DRenderer {
     }
 
     public static BufferedImage htmlAsImage(InputStream source, int widthInPixels) throws SAXException, IOException, ParserConfigurationException {
-        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(source);
+        Document document = XMLUtil.newDocumentBuilder().parse(source);
         return new Java2DRenderer(document, widthInPixels).getImage();
     }
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/XMLUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/XMLUtil.java
@@ -56,12 +56,23 @@ public class XMLUtil {
      * documents rely on them (e.g. for named entities like {@code &nbsp;}).
      */
     public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-
-        DocumentBuilder builder = factory.newDocumentBuilder();
+        DocumentBuilder builder = newSecureDocumentBuilderFactory().newDocumentBuilder();
         builder.setEntityResolver(FSEntityResolver.instance());
         return builder;
+    }
+
+    /**
+     * Defense-in-depth on top of {@link FSEntityResolver}: denies external DTD/schema access at
+     * the JAXP level itself, so a bug or future refactor that drops the entity resolver would
+     * still not open an attacker-controlled URL.
+     */
+    static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setXIncludeAware(false);
+        return factory;
     }
 
     private static DocumentBuilder createDocumentBuilder()

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/XMLUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/XMLUtil.java
@@ -21,8 +21,10 @@
 package org.xhtmlrenderer.util;
 
 import org.w3c.dom.Document;
+import org.xhtmlrenderer.resource.FSEntityResolver;
 import org.xml.sax.InputSource;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -46,12 +48,26 @@ public class XMLUtil {
         return createDocumentBuilder().parse(new File(filename).toURI().toURL().openStream());
     }
 
+    /**
+     * A {@link DocumentBuilder} hardened against XXE: external entities are routed through
+     * {@link FSEntityResolver} (which serves local/known DTDs and empty content for anything
+     * else, instead of fetching attacker-supplied URLs), and secure processing is enabled to
+     * bound entity expansion. DOCTYPE declarations are still allowed, since real-world X/HTML
+     * documents rely on them (e.g. for named entities like {@code &nbsp;}).
+     */
+    public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setEntityResolver(FSEntityResolver.instance());
+        return builder;
+    }
+
     private static DocumentBuilder createDocumentBuilder()
         throws ParserConfigurationException {
 
-        DocumentBuilderFactory fact = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = fact.newDocumentBuilder();
-
+        DocumentBuilder builder = newDocumentBuilder();
         builder.setErrorHandler( null );
 
         return builder;

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
@@ -3,11 +3,16 @@ package org.xhtmlrenderer.util;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.DocumentBuilder;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class XMLUtilTest {
     @Test
@@ -47,5 +52,22 @@ class XMLUtilTest {
         Document document = XMLUtil.documentFromString(xml);
 
         assertThat(document.getDocumentElement().getTextContent()).isEqualTo("a b\"c");
+    }
+
+    @Test
+    void newSecureDocumentBuilderFactory_deniesExternalDtdAccessAtTheJaxpLevel() throws Exception {
+        // Defense-in-depth: even without FSEntityResolver attached, the factory itself must
+        // refuse to fetch an external DTD.
+        DocumentBuilder builder = XMLUtil.newSecureDocumentBuilderFactory().newDocumentBuilder();
+
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE root SYSTEM "http://127.0.0.1:1/unreachable.dtd">
+                <root/>
+                """;
+
+        assertThatThrownBy(() -> builder.parse(new InputSource(new StringReader(xml))))
+                .isInstanceOf(SAXException.class)
+                .hasMessageContaining("accessExternalDTD");
     }
 }

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
@@ -1,0 +1,51 @@
+package org.xhtmlrenderer.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class XMLUtilTest {
+    @Test
+    void documentFromString_doesNotResolveExternalEntities(@TempDir Path tempDir) throws Exception {
+        Path secretFile = tempDir.resolve("secret.txt");
+        Files.writeString(secretFile, "top-secret-content");
+
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE root [
+                  <!ENTITY xxe SYSTEM "%s">
+                ]>
+                <root>&xxe; Hello</root>
+                """.formatted(secretFile.toUri());
+
+        Document document = XMLUtil.documentFromString(xml);
+
+        assertThat(document.getDocumentElement().getTextContent()).doesNotContain("top-secret-content");
+        assertThat(document.getDocumentElement().getTextContent()).isEqualTo(" Hello");
+    }
+
+    @Test
+    void documentFromString_parsesRegularXml() throws Exception {
+        Document document = XMLUtil.documentFromString("<root><child>hello</child></root>");
+
+        assertThat(document.getDocumentElement().getTextContent()).isEqualTo("hello");
+    }
+
+    @Test
+    void documentFromString_stillResolvesXhtmlNamedEntitiesFromLocalDtd() throws Exception {
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+                <html><body><p>a&nbsp;b&quot;c</p></body></html>
+                """;
+
+        Document document = XMLUtil.documentFromString(xml);
+
+        assertThat(document.getDocumentElement().getTextContent()).isEqualTo("a b\"c");
+    }
+}

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/util/XMLUtilTest.java
@@ -55,6 +55,32 @@ class XMLUtilTest {
     }
 
     @Test
+    void documentFromString_rejectsBillionLaughsEntityExpansion() {
+        // Each &lolN; expands to 10 copies of the previous one, so &lol9; alone would expand to
+        // 10^9 "lol"s if fully resolved. FEATURE_SECURE_PROCESSING caps entity expansion, so
+        // this must be rejected instead of exhausting memory/CPU.
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE lolz [
+                 <!ENTITY lol "lol">
+                 <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+                 <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+                 <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+                 <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+                 <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+                 <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+                 <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+                 <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+                ]>
+                <lolz>&lol9;</lolz>
+                """;
+
+        assertThatThrownBy(() -> XMLUtil.documentFromString(xml))
+                .isInstanceOf(SAXException.class)
+                .hasMessageContaining("entity expansions");
+    }
+
+    @Test
     void newSecureDocumentBuilderFactory_deniesExternalDtdAccessAtTheJaxpLevel() throws Exception {
         // Defense-in-depth: even without FSEntityResolver attached, the factory itself must
         // refuse to fetch an external DTD.

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/Html2Pdf.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/Html2Pdf.java
@@ -2,11 +2,10 @@ package org.xhtmlrenderer.pdf;
 
 import org.openpdf.text.DocumentException;
 import org.w3c.dom.Document;
-import org.xhtmlrenderer.resource.FSEntityResolver;
+import org.xhtmlrenderer.util.XMLUtil;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URL;
@@ -27,9 +26,7 @@ public class Html2Pdf {
         renderer.getSharedContext().getTextRenderer().setSmoothingThreshold(0);
 
         try {
-            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            builder.setEntityResolver(FSEntityResolver.instance());
-
+            DocumentBuilder builder = XMLUtil.newDocumentBuilder();
             Document doc = builder.parse(html.toString());
             return renderer.createPDF(doc);
         }


### PR DESCRIPTION
## Summary
- `XMLUtil.documentFromString`/`documentFromFile` and `Java2DRenderer.htmlAsImage` built a `DocumentBuilder` with no `EntityResolver` and no hardening, so a caller-supplied document with `<!ENTITY xxe SYSTEM "file:///etc/passwd">` would have that entity resolved directly by the default JAXP parser — classic XXE (file read / SSRF).
- `Html2Pdf.fromUrl` already wired up `FSEntityResolver` (blocking classic entity-exfiltration) but didn't enable `FEATURE_SECURE_PROCESSING`.
- Adds `XMLUtil.newDocumentBuilder()`, a shared hardened builder: entity resolution is routed through `FSEntityResolver` (serves local/known DTDs and empty content for anything else, never fetching an attacker-controlled URL) and `FEATURE_SECURE_PROCESSING` is enabled (which also caps entity expansion, so billion-laughs-style payloads are rejected). `DOCTYPE` itself stays allowed, since real-world X/HTML relies on it for named entities like `&nbsp;`.
- Also denies external DTD/schema access at the JAXP level itself (`ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` = `""`, `setXIncludeAware(false)`) as defense-in-depth, via a new package-private `XMLUtil.newSecureDocumentBuilderFactory()` — so even if `FSEntityResolver` were ever dropped by a future refactor, the factory itself still refuses external access.
  - Deliberately **not** disabling `external-general-entities`/`external-parameter-entities`: verified experimentally that doing so silently breaks resolution of named XHTML entities (`&nbsp;`, `&copy;`, ...) declared in the external DTD subset, since disabling that feature stops the parser from reading the subset at all — even through a registered `EntityResolver`.
- All three original call sites now use the shared helper.

Fixes #678

## Test plan
- [x] New `XMLUtilTest`:
  - `documentFromString_doesNotResolveExternalEntities` — external `SYSTEM` entity referencing a local temp file resolves to empty content, not the file's contents (verified the old unguarded parse *would* leak it).
  - `documentFromString_stillResolvesXhtmlNamedEntitiesFromLocalDtd` — `&nbsp;`/`&quot;` in an XHTML 1.0 Strict document still resolve correctly via the local DTD catalog, confirming the hardening doesn't break legitimate entity use.
  - `documentFromString_rejectsBillionLaughsEntityExpansion` — a classic exponential-entity payload (`&lol9;` → 10^9 `"lol"`s) is rejected with `SAXParseException: JAXP00010001 ... more than 64000 entity expansions`, instead of exhausting memory/CPU.
  - `newSecureDocumentBuilderFactory_deniesExternalDtdAccessAtTheJaxpLevel` — with no entity resolver attached, parsing a DOCTYPE with an external `SYSTEM` DTD throws instead of attempting network access, proving the JAXP-level defense-in-depth actually works standalone.
  - `documentFromString_parsesRegularXml` — baseline sanity check.
- [x] `mvn -pl flying-saucer-core -am test -Dtest=XMLUtilTest,Java2DRendererTest` passes.
- [x] `mvn -pl flying-saucer-pdf -am compile` passes (Html2Pdf change compiles cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened XML parsing used during HTML image rendering and HTML-to-PDF conversion to better prevent XXE attacks by disabling external DTD/schema access, blocking unsafe entity resolution, and turning off XInclude.
  * Continued support for standard XHTML named entities.
* **Bug Fixes**
  * Improved consistency of XML parsing setup between rendering and PDF conversion.
* **Tests**
  * Added/extended coverage to verify external `DOCTYPE` access is blocked and that entity-expansion payloads are rejected, while safe XML continues to parse correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->