### PR TITLE
Support CSS transform / transform-origin in PDF output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,15 @@ Surefire only picks up tests under `org/**` (see `pom.xml`). JUnit 4 (`junit:jun
 
 - **Use AssertJ's type-specific matchers** instead of unwrapping. E.g. for `AtomicInteger`: `assertThat(counter).hasValue(0)` — never `assertThat(counter.get()).isZero()`. Same idea for `Optional`, `Path`, `File`, collections, etc.: assert on the wrapper, not on a manually extracted value.
 - **Static-import common helpers** to keep tests terse: `org.assertj.core.api.Assertions.assertThat`, `java.util.Objects.requireNonNull`, and any project test utility (e.g. `TestUtils.printFile`). Avoid qualifying these inline.
+- **Prefer Mockito's no-arg `mock()`** over `mock(SomeClass.class)` — the target type is inferred from the variable/field it's assigned to, e.g. `private final CssContext ctx = mock();` instead of `mock(CssContext.class)`.
 
 ## Compilation specifics
 
 - `maven-compiler-plugin` runs **Error Prone** as a `-Xplugin`. A handful of checks are disabled globally (`MissingSummary`, `JdkObsolete`, `ReferenceEquality`, `OperatorPrecedence`) and `Lexer.java` is excluded entirely. If you hit unexpected compile errors, suspect Error Prone before suspecting javac.
 - `flying-saucer-core` regenerates `org/xhtmlrenderer/css/parser/Lexer.java` from `Lexer.flex` via the **JFlex** plugin during `process-resources`. **Do not hand-edit `Lexer.java`** — change `Lexer.flex` and rebuild.
 - Nullness is annotated with **JSpecify** (`@Nullable`, `@NonNull`); honor those when changing signatures. Indent is 4 spaces (2 for XML), UTF-8 (see `.editorconfig`).
+- Prefer immutability: build immutable objects instead of mutating a collection into shape (`List.of(horizontal, vertical)` instead of `new ArrayList<>(2); add(horizontal); add(vertical)`, or `values.stream().map(...).toList()` instead of populating an `ArrayList` in a loop — reach for a mutable collection only when the final size/contents genuinely can't be expressed as a single literal or stream pipeline); prefer `private final` fields set once (in the constructor or at declaration) over fields reassigned later.
+- Prefer record-style accessor names (`age()`) over JavaBean-style (`getAge()`) in new code, matching Java's `record` convention — but don't rename accessors on existing non-record classes just to match this style.
 
 ## Module layout
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/constants/CSSName.java
@@ -37,6 +37,8 @@ import org.xhtmlrenderer.css.parser.property.PrimitivePropertyBuilders;
 import org.xhtmlrenderer.css.parser.property.PropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.QuotesPropertyBuilder;
 import org.xhtmlrenderer.css.parser.property.SizePropertyBuilder;
+import org.xhtmlrenderer.css.parser.property.TransformOriginPropertyBuilder;
+import org.xhtmlrenderer.css.parser.property.TransformPropertyBuilder;
 import org.xhtmlrenderer.css.sheet.StylesheetInfo;
 import org.xhtmlrenderer.css.style.FSDerivedValue;
 import org.xhtmlrenderer.css.style.derived.DerivedValueFactory;
@@ -1078,6 +1080,24 @@ public final class CSSName implements Comparable<CSSName> {
                     new PrimitivePropertyBuilders.Top()
             );
 
+    public static final CSSName TRANSFORM =
+            addProperty(
+                    "transform",
+                    PRIMITIVE,
+                    "none",
+                    NOT_INHERITED,
+                    new TransformPropertyBuilder()
+            );
+
+    public static final CSSName TRANSFORM_ORIGIN =
+            addProperty(
+                    "transform-origin",
+                    PRIMITIVE,
+                    "50% 50%",
+                    NOT_INHERITED,
+                    new TransformOriginPropertyBuilder()
+            );
+
     /**
      * Unique CSSName instance for CSS2 property.
      */
@@ -1952,8 +1972,8 @@ public final class CSSName implements Comparable<CSSName> {
             // Animations
             "animation", "animation-name", "animation-duration", "animation-timing-function", "animation-delay",
             "animation-iteration-count", "animation-direction", "animation-fill-mode", "animation-play-state",
-            // Transforms
-            "transform", "transform-origin", "transform-style",
+            // Transforms (3D only; 2D transform/transform-origin are supported)
+            "transform-style",
             // Visual effects
             "box-shadow", "text-shadow", "filter", "backdrop-filter",
             // Other common CSS3 properties

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -1510,6 +1510,7 @@ public class CSSParser {
                      EMS,
                      EXS,
                      ANGLE,
+                     DIMENSION,
                      TIME,
                      FREQ,
                      STRING,
@@ -1523,7 +1524,7 @@ public class CSSParser {
                                 Token.TK_NUMBER, Token.TK_PLUS, Token.TK_MINUS,
                                 Token.TK_PERCENTAGE, Token.TK_PX, Token.TK_EMS, Token.TK_EXS,
                                 Token.TK_PC, Token.TK_MM, Token.TK_CM, Token.TK_IN, Token.TK_PT,
-                                Token.TK_ANGLE, Token.TK_TIME, Token.TK_FREQ, Token.TK_STRING,
+                                Token.TK_ANGLE, Token.TK_DIMENSION, Token.TK_TIME, Token.TK_FREQ, Token.TK_STRING,
                                 Token.TK_IDENT, Token.TK_URI, Token.TK_HASH, Token.TK_FUNCTION},
                                 getCurrentLine());
                     } else {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -1592,6 +1592,7 @@ public class CSSParser {
                 short type = switch (unit) {
                     case "deg" -> CSSPrimitiveValue.CSS_DEG;
                     case "rad" -> CSSPrimitiveValue.CSS_RAD;
+                    case "grad" -> CSSPrimitiveValue.CSS_GRAD;
                     default -> throw new CSSParseException("Unsupported CSS unit " + unit, getCurrentLine());
                 };
 
@@ -1603,8 +1604,22 @@ public class CSSParser {
                 skip_whitespace();
             }
 
+            // "turn" isn't a distinct DOM CSSPrimitiveValue unit, so convert it to degrees eagerly.
+            case DIMENSION -> {
+                String unit = extractUnit(t);
+                if (!unit.equals("turn")) {
+                    throw new CSSParseException("Unsupported CSS unit " + unit, getCurrentLine());
+                }
 
-            case TIME, FREQ, DIMENSION -> throw new CSSParseException("Unsupported CSS unit " + extractUnit(t), getCurrentLine());
+                result = new PropertyValue(CSSPrimitiveValue.CSS_DEG,
+                        sign * Float.parseFloat(extractNumber(t)) * 360f,
+                        sign(sign) + getTokenValue(t));
+
+                next();
+                skip_whitespace();
+            }
+
+            case TIME, FREQ -> throw new CSSParseException("Unsupported CSS unit " + extractUnit(t), getCurrentLine());
             case NUMBER -> {
                     result = new PropertyValue(
                             CSS_NUMBER,

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilder.java
@@ -1,0 +1,80 @@
+package org.xhtmlrenderer.css.parser.property;
+
+import org.w3c.dom.css.CSSPrimitiveValue;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.constants.IdentValue;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+import org.xhtmlrenderer.css.sheet.StylesheetInfo.Origin;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_IDENT;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PERCENTAGE;
+import static org.w3c.dom.css.CSSValue.CSS_INHERIT;
+import static org.xhtmlrenderer.css.constants.IdentValue.BOTTOM;
+import static org.xhtmlrenderer.css.constants.IdentValue.CENTER;
+import static org.xhtmlrenderer.css.constants.IdentValue.LEFT;
+import static org.xhtmlrenderer.css.constants.IdentValue.RIGHT;
+import static org.xhtmlrenderer.css.constants.IdentValue.TOP;
+
+/**
+ * Parses {@code transform-origin: [ <length-percentage> | left | center | right ]
+ * [ <length-percentage> | top | center | bottom ]?}. The vertical value defaults to
+ * {@code center} when omitted; keyword reordering (e.g. {@code top left}) is not supported.
+ */
+public class TransformOriginPropertyBuilder extends AbstractPropertyBuilder {
+    @Override
+    public List<PropertyDeclaration> buildDeclarations(
+            CSSName cssName, List<? extends CSSPrimitiveValue> values, Origin origin,
+            boolean important, boolean inheritAllowed) {
+        assertFoundUpToValues(cssName, values, 2);
+
+        PropertyValue first = (PropertyValue) values.get(0);
+        checkInheritAllowed(first, inheritAllowed);
+        if (values.size() == 1 && first.getCssValueType() == CSS_INHERIT) {
+            return singletonList(new PropertyDeclaration(cssName, first, important, origin));
+        }
+
+        PropertyValue horizontal = resolveComponent(cssName, first, true);
+        PropertyValue vertical = values.size() == 2
+                ? resolveComponent(cssName, (PropertyValue) values.get(1), false)
+                : percent(50);
+
+        return singletonList(new PropertyDeclaration(
+                cssName, new PropertyValue(List.of(horizontal, vertical)), important, origin));
+    }
+
+    private PropertyValue resolveComponent(CSSName cssName, PropertyValue value, boolean horizontal) {
+        if (value.getPrimitiveType() == CSS_IDENT) {
+            IdentValue ident = checkIdent(value);
+
+            if (ident == CENTER) {
+                return percent(50);
+            }
+            if (horizontal && ident == LEFT) {
+                return percent(0);
+            }
+            if (horizontal && ident == RIGHT) {
+                return percent(100);
+            }
+            if (!horizontal && ident == TOP) {
+                return percent(0);
+            }
+            if (!horizontal && ident == BOTTOM) {
+                return percent(100);
+            }
+
+            throw new CSSParseException("Invalid keyword '" + ident + "' for " + cssName, -1);
+        }
+
+        checkLengthOrPercentType(cssName, value);
+        return value;
+    }
+
+    private PropertyValue percent(float percent) {
+        return new PropertyValue(CSS_PERCENTAGE, percent, percent + "%");
+    }
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilder.java
@@ -21,9 +21,10 @@ import static org.xhtmlrenderer.css.constants.IdentValue.RIGHT;
 import static org.xhtmlrenderer.css.constants.IdentValue.TOP;
 
 /**
- * Parses {@code transform-origin: [ <length-percentage> | left | center | right ]
- * [ <length-percentage> | top | center | bottom ]?}. The vertical value defaults to
- * {@code center} when omitted; keyword reordering (e.g. {@code top left}) is not supported.
+ * Parses {@code transform-origin}, mirroring the (2-value) {@code background-position} grammar:
+ * a single length/percentage/keyword, or a horizontal/vertical pair. A lone {@code top}/{@code bottom}
+ * keyword implies a centered horizontal axis, and keyword pairs may appear in either order
+ * (e.g. {@code top left} and {@code left top} are equivalent).
  */
 public class TransformOriginPropertyBuilder extends AbstractPropertyBuilder {
     @Override
@@ -33,45 +34,80 @@ public class TransformOriginPropertyBuilder extends AbstractPropertyBuilder {
         assertFoundUpToValues(cssName, values, 2);
 
         PropertyValue first = (PropertyValue) values.get(0);
+        PropertyValue second = values.size() == 2 ? (PropertyValue) values.get(1) : null;
+
         checkInheritAllowed(first, inheritAllowed);
-        if (values.size() == 1 && first.getCssValueType() == CSS_INHERIT) {
+        if (second == null && first.getCssValueType() == CSS_INHERIT) {
             return singletonList(new PropertyDeclaration(cssName, first, important, origin));
         }
-
-        PropertyValue horizontal = resolveComponent(cssName, first, true);
-        PropertyValue vertical = values.size() == 2
-                ? resolveComponent(cssName, (PropertyValue) values.get(1), false)
-                : percent(50);
-
-        return singletonList(new PropertyDeclaration(
-                cssName, new PropertyValue(List.of(horizontal, vertical)), important, origin));
-    }
-
-    private PropertyValue resolveComponent(CSSName cssName, PropertyValue value, boolean horizontal) {
-        if (value.getPrimitiveType() == CSS_IDENT) {
-            IdentValue ident = checkIdent(value);
-
-            if (ident == CENTER) {
-                return percent(50);
-            }
-            if (horizontal && ident == LEFT) {
-                return percent(0);
-            }
-            if (horizontal && ident == RIGHT) {
-                return percent(100);
-            }
-            if (!horizontal && ident == TOP) {
-                return percent(0);
-            }
-            if (!horizontal && ident == BOTTOM) {
-                return percent(100);
-            }
-
-            throw new CSSParseException("Invalid keyword '" + ident + "' for " + cssName, -1);
+        if (second != null) {
+            checkInheritAllowed(second, false);
         }
 
-        checkLengthOrPercentType(cssName, value);
-        return value;
+        checkIdentLengthOrPercentType(cssName, first);
+        if (second == null) {
+            if (first.getPrimitiveType() != CSS_IDENT) {
+                return twoValues(cssName, first, percent(50), important, origin);
+            }
+        } else {
+            checkIdentLengthOrPercentType(cssName, second);
+        }
+
+        IdentValue firstIdent = first.getPrimitiveType() == CSS_IDENT ? checkKeyword(cssName, first) : null;
+        IdentValue secondIdent;
+        if (second == null) {
+            secondIdent = CENTER;
+        } else {
+            secondIdent = second.getPrimitiveType() == CSS_IDENT ? checkKeyword(cssName, second) : null;
+        }
+
+        if (firstIdent == null && secondIdent == null) {
+            return twoValues(cssName, first, second, important, origin);
+        } else if (firstIdent != null && secondIdent != null) {
+            if (firstIdent == TOP || firstIdent == BOTTOM || secondIdent == LEFT || secondIdent == RIGHT) {
+                IdentValue swap = firstIdent;
+                firstIdent = secondIdent;
+                secondIdent = swap;
+            }
+            checkAxisCombination(cssName, firstIdent, secondIdent);
+            return twoValues(cssName, percentForIdent(firstIdent), percentForIdent(secondIdent), important, origin);
+        } else if (firstIdent != null) {
+            checkAxisCombination(cssName, firstIdent, null);
+            return twoValues(cssName, percentForIdent(firstIdent), second, important, origin);
+        } else {
+            checkAxisCombination(cssName, null, secondIdent);
+            return twoValues(cssName, first, percentForIdent(secondIdent), important, origin);
+        }
+    }
+
+    private void checkAxisCombination(CSSName cssName, IdentValue firstIdent, IdentValue secondIdent) {
+        if (firstIdent == TOP || firstIdent == BOTTOM || secondIdent == LEFT || secondIdent == RIGHT) {
+            throw new CSSParseException("Invalid combination of keywords in " + cssName, -1);
+        }
+    }
+
+    private IdentValue checkKeyword(CSSName cssName, PropertyValue value) {
+        IdentValue ident = checkIdent(value);
+        if (ident != LEFT && ident != RIGHT && ident != TOP && ident != BOTTOM && ident != CENTER) {
+            throw new CSSParseException("Invalid keyword '" + ident + "' for " + cssName, -1);
+        }
+        return ident;
+    }
+
+    private PropertyValue percentForIdent(IdentValue ident) {
+        if (ident == LEFT || ident == TOP) {
+            return percent(0);
+        }
+        if (ident == RIGHT || ident == BOTTOM) {
+            return percent(100);
+        }
+        return percent(50);
+    }
+
+    private List<PropertyDeclaration> twoValues(
+            CSSName cssName, PropertyValue horizontal, PropertyValue vertical, boolean important, Origin origin) {
+        return singletonList(new PropertyDeclaration(
+                cssName, new PropertyValue(List.of(horizontal, vertical)), important, origin));
     }
 
     private PropertyValue percent(float percent) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformPropertyBuilder.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/property/TransformPropertyBuilder.java
@@ -1,0 +1,124 @@
+package org.xhtmlrenderer.css.parser.property;
+
+import org.w3c.dom.css.CSSPrimitiveValue;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.FSFunction;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+import org.xhtmlrenderer.css.sheet.StylesheetInfo.Origin;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_DEG;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_GRAD;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_NUMBER;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PERCENTAGE;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_RAD;
+import static org.w3c.dom.css.CSSValue.CSS_INHERIT;
+import static org.xhtmlrenderer.css.parser.PropertyValue.Type.VALUE_TYPE_FUNCTION;
+import static org.xhtmlrenderer.css.parser.PropertyValue.Type.VALUE_TYPE_IDENT;
+import static org.xhtmlrenderer.css.parser.property.TransformPropertyBuilder.ArgumentKind.ANGLE;
+import static org.xhtmlrenderer.css.parser.property.TransformPropertyBuilder.ArgumentKind.LENGTH_PERCENTAGE;
+import static org.xhtmlrenderer.css.parser.property.TransformPropertyBuilder.ArgumentKind.NUMBER;
+
+/**
+ * Parses {@code transform: none | <transform-function>+}, e.g.
+ * {@code translate(10px, 10px) rotate(45deg) scale(2)}.
+ * <p>
+ * Only 2D transform functions are supported, which is all that is meaningful on a flat PDF page:
+ * {@code matrix}, {@code translate}/{@code translateX}/{@code translateY},
+ * {@code scale}/{@code scaleX}/{@code scaleY}, {@code rotate}, {@code skew}/{@code skewX}/{@code skewY}.
+ */
+public class TransformPropertyBuilder extends AbstractPropertyBuilder {
+    enum ArgumentKind { LENGTH_PERCENTAGE, NUMBER, ANGLE }
+
+    private record FunctionSpec(int minArgs, int maxArgs, ArgumentKind argumentKind) {
+    }
+
+    // CSSParser lower-cases FUNCTION tokens (CSS identifiers are case-insensitive), so e.g. "skewX"
+    // always arrives here as "skewx".
+    private static final Map<String, FunctionSpec> FUNCTIONS = Map.ofEntries(
+            Map.entry("matrix", new FunctionSpec(6, 6, NUMBER)),
+            Map.entry("translate", new FunctionSpec(1, 2, LENGTH_PERCENTAGE)),
+            Map.entry("translatex", new FunctionSpec(1, 1, LENGTH_PERCENTAGE)),
+            Map.entry("translatey", new FunctionSpec(1, 1, LENGTH_PERCENTAGE)),
+            Map.entry("scale", new FunctionSpec(1, 2, NUMBER)),
+            Map.entry("scalex", new FunctionSpec(1, 1, NUMBER)),
+            Map.entry("scaley", new FunctionSpec(1, 1, NUMBER)),
+            Map.entry("rotate", new FunctionSpec(1, 1, ANGLE)),
+            Map.entry("skew", new FunctionSpec(1, 2, ANGLE)),
+            Map.entry("skewx", new FunctionSpec(1, 1, ANGLE)),
+            Map.entry("skewy", new FunctionSpec(1, 1, ANGLE))
+    );
+
+    @Override
+    public List<PropertyDeclaration> buildDeclarations(
+            CSSName cssName, List<? extends CSSPrimitiveValue> values, Origin origin,
+            boolean important, boolean inheritAllowed) {
+        if (values.size() == 1) {
+            PropertyValue value = (PropertyValue) values.get(0);
+            checkInheritAllowed(value, inheritAllowed);
+
+            if (value.getCssValueType() == CSS_INHERIT) {
+                return singletonList(new PropertyDeclaration(cssName, value, important, origin));
+            }
+            if (value.getPropertyValueType() == VALUE_TYPE_IDENT && "none".equals(value.getStringValue())) {
+                return singletonList(new PropertyDeclaration(cssName, value, important, origin));
+            }
+        }
+
+        List<PropertyValue> functions = values.stream()
+                .map(rawValue -> {
+                    PropertyValue value = (PropertyValue) rawValue;
+                    if (value.getPropertyValueType() != VALUE_TYPE_FUNCTION) {
+                        throw new CSSParseException(
+                                "Value for " + cssName + " must be 'none' or one or more transform functions", -1);
+                    }
+                    checkFunction(cssName, value.getFunction());
+                    return value;
+                })
+                .toList();
+
+        return singletonList(new PropertyDeclaration(cssName, new PropertyValue(functions), important, origin));
+    }
+
+    private void checkFunction(CSSName cssName, FSFunction function) {
+        FunctionSpec spec = FUNCTIONS.get(function.getName());
+        if (spec == null) {
+            throw new CSSParseException(
+                    "Function " + function.getName() + "() is not a valid value for " + cssName, -1);
+        }
+
+        List<PropertyValue> params = function.getParameters();
+        if (params.size() < spec.minArgs() || params.size() > spec.maxArgs()) {
+            throw new CSSParseException(
+                    "%s() requires between %d and %d argument(s) but %d were given"
+                            .formatted(function.getName(), spec.minArgs(), spec.maxArgs(), params.size()), -1);
+        }
+
+        for (PropertyValue param : params) {
+            checkArgument(cssName, function.getName(), spec.argumentKind(), param);
+        }
+    }
+
+    private void checkArgument(CSSName cssName, String functionName, ArgumentKind kind, PropertyValue value) {
+        boolean valid = switch (kind) {
+            case LENGTH_PERCENTAGE -> isLength(value) || value.getPrimitiveType() == CSS_PERCENTAGE;
+            case NUMBER -> value.getPrimitiveType() == CSS_NUMBER;
+            case ANGLE -> isAngle(value);
+        };
+
+        if (!valid) {
+            throw new CSSParseException(
+                    "Invalid argument '" + value.getCssText() + "' to " + functionName + "() in " + cssName, -1);
+        }
+    }
+
+    private boolean isAngle(CSSPrimitiveValue value) {
+        short type = value.getPrimitiveType();
+        return type == CSS_DEG || type == CSS_RAD || type == CSS_GRAD;
+    }
+}

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
+import static java.util.Collections.emptyList;
 import static org.xhtmlrenderer.css.constants.CSSName.PADDING_SIDE_PROPERTIES;
 import static org.xhtmlrenderer.css.constants.CSSName.cssProperty;
 import static org.xhtmlrenderer.css.style.CssKnowledge.BLOCK_EQUIVALENTS;
@@ -340,6 +341,31 @@ public class CalculatedStyle {
 
     public BackgroundPosition getBackgroundPosition() {
         ListValue result = (ListValue) valueByName(CSSName.BACKGROUND_POSITION);
+        List<PropertyValue> values = result.getValues();
+
+        return new BackgroundPosition(values.get(0), values.get(1));
+    }
+
+    public boolean hasTransform() {
+        return !isIdent(CSSName.TRANSFORM, IdentValue.NONE);
+    }
+
+    /**
+     * The parsed {@code transform} functions, in the order they should be applied, or an empty
+     * list if {@code transform: none}. Each value's {@link FSFunction} name is one of
+     * {@code matrix, translate, translateX, translateY, scale, scaleX, scaleY, rotate, skew, skewX, skewY}.
+     */
+    public List<PropertyValue> getTransforms() {
+        if (!hasTransform()) {
+            return emptyList();
+        }
+
+        FSDerivedValue value = valueByName(CSSName.TRANSFORM);
+        return ((ListValue) value).getValues();
+    }
+
+    public BackgroundPosition getTransformOrigin() {
+        ListValue result = (ListValue) valueByName(CSSName.TRANSFORM_ORIGIN);
         List<PropertyValue> values = result.getValues();
 
         return new BackgroundPosition(values.get(0), values.get(1));
@@ -909,6 +935,10 @@ public class CalculatedStyle {
     }
 
     public boolean requiresLayer() {
+        if (hasTransform()) {
+            return true;
+        }
+
         FSDerivedValue value = valueByName(CSSName.POSITION);
 
         if (value instanceof FunctionValue) {  // running(header)

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/OutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/extend/OutputDevice.java
@@ -84,6 +84,21 @@ public interface OutputDevice<T extends FSImage, FontType extends FSFont> {
 
     void translate(double tx, double ty);
 
+    /**
+     * Applies the box's CSS {@code transform}, if any, around subsequent paint calls for this box
+     * and its descendants; must be paired with a matching {@link #popTransform()}. The default
+     * no-op implementation means CSS {@code transform} only has a visual effect on backends that
+     * override this (currently PDF output only).
+     */
+    default void pushTransform(RenderingContext c, Box box) {
+    }
+
+    /**
+     * Restores the graphics state saved by the matching {@link #pushTransform(RenderingContext, Box)}.
+     */
+    default void popTransform() {
+    }
+
     void setStroke(Stroke s);
     Stroke getStroke();
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
@@ -334,6 +334,7 @@ public final class Layer {
             }
         }
 
+        c.getOutputDevice().pushTransform(c, getMaster());
         try {
             if (! isInline() && ((BlockBox)getMaster()).isReplaced()) {
                 paintLayerBackgroundAndBorder(c);
@@ -375,6 +376,8 @@ public final class Layer {
                 }
             }
         } finally {
+            c.getOutputDevice().popTransform();
+
             // Restore original clip if we applied table cell clipping
             if (needsClipRestore && originalClip != null) {
                 c.getOutputDevice().setClip(originalClip);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/Layer.java
@@ -111,7 +111,11 @@ public final class Layer {
     }
 
     public Layer(@Nullable Layer parent, Box master) {
-        this(parent, master, master.getStyle().isPositioned() && !master.getStyle().isAutoZIndex());
+        // A transformed box must be a stacking context too, otherwise collectLayers() flattens it and
+        // paints its own layered descendants (position:absolute, nested transforms, ...) outside the
+        // transform established by this layer's paint().
+        this(parent, master,
+                (master.getStyle().isPositioned() && !master.getStyle().isAutoZIndex()) || master.getStyle().hasTransform());
     }
 
     Layer(@Nullable Layer parent, Box master, boolean stackingContext) {
@@ -135,7 +139,9 @@ public final class Layer {
 
     @CheckReturnValue
     public int getZIndex() {
-        return (int) _master.getStyle().asFloat(CSSName.Z_INDEX);
+        // A stacking context not established by z-index (e.g. a transformed box with the default
+        // z-index: auto) is treated as z-index: 0 among its sibling stacking contexts.
+        return _master.getStyle().isAutoZIndex() ? 0 : (int) _master.getStyle().asFloat(CSSName.Z_INDEX);
     }
 
     public float getOpacity() {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -216,6 +216,25 @@ class CSSParserTest {
         assertThat(origin.get(1).getFloatValue()).isEqualTo(100f); // bottom
     }
 
+    @Test
+    void parsesTurnAsANonFirstFunctionArgument() throws IOException {
+        // A DIMENSION token (like "turn") appearing after a comma, rather than as the first
+        // argument, is a separate code path in expr() from the one exercised above.
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            div { transform: skew(50grad, 0.25turn); }
+            """));
+        Ruleset ruleset = (Ruleset) stylesheet.getContents().get(0);
+        List<PropertyDeclaration> declarations = ruleset.getPropertyDeclarations();
+
+        assertThat(declarations).hasSize(1);
+        List<PropertyValue> functions = ((PropertyValue) declarations.get(0).getValue()).getValues();
+        List<PropertyValue> args = functions.get(0).getFunction().getParameters();
+
+        assertThat(args.get(0).getPrimitiveType()).isEqualTo(CSS_GRAD);
+        assertThat(args.get(1).getPrimitiveType()).isEqualTo(CSS_DEG);
+        assertThat(args.get(1).getFloatValue()).isEqualTo(90f);
+    }
+
     private static PropertyDeclaration css(CSSName property, FSRGBColor color) {
         return new PropertyDeclaration(property, new PropertyValue(color), false, AUTHOR);
     }

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_DEG;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_GRAD;
 import static org.w3c.dom.css.CSSPrimitiveValue.CSS_IDENT;
 import static org.w3c.dom.css.CSSPrimitiveValue.CSS_NUMBER;
 import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PX;
@@ -177,6 +179,41 @@ class CSSParserTest {
         assertThat(declarations.get(1).getCSSName()).isEqualTo(CSSName.COLUMN_COUNT);
         assertThat(declarations.get(1).getValue().getPrimitiveType()).isEqualTo(CSS_NUMBER);
         assertThat(declarations.get(1).getValue().getFloatValue(CSS_NUMBER)).isEqualTo(3f);
+    }
+
+    @Test
+    void parsesTransformFunctionsAndAngleUnits() throws IOException {
+        Stylesheet stylesheet = parser.parseStylesheet(null, AUTHOR, new StringReader("""
+            div {
+                transform: translate(10px, 20%) rotate(0.25turn) skewX(50grad);
+                transform-origin: right bottom;
+            }
+            """));
+        Ruleset ruleset = (Ruleset) stylesheet.getContents().get(0);
+        List<PropertyDeclaration> declarations = ruleset.getPropertyDeclarations();
+
+        assertThat(declarations).hasSize(2);
+        assertThat(declarations.get(0).getCSSName()).isEqualTo(CSSName.TRANSFORM);
+        assertThat(declarations.get(1).getCSSName()).isEqualTo(CSSName.TRANSFORM_ORIGIN);
+
+        List<PropertyValue> functions = ((PropertyValue) declarations.get(0).getValue()).getValues();
+        assertThat(functions).hasSize(3);
+        // Function names are lower-cased by the tokenizer (CSS identifiers are case-insensitive).
+        assertThat(functions.stream().map(v -> v.getFunction().getName()))
+                .containsExactly("translate", "rotate", "skewx");
+
+        // "turn" has no dedicated DOM unit, so it's normalized to degrees while parsing: 0.25turn == 90deg
+        PropertyValue rotateAngle = functions.get(1).getFunction().getParameters().get(0);
+        assertThat(rotateAngle.getPrimitiveType()).isEqualTo(CSS_DEG);
+        assertThat(rotateAngle.getFloatValue()).isEqualTo(90f);
+
+        PropertyValue skewAngle = functions.get(2).getFunction().getParameters().get(0);
+        assertThat(skewAngle.getPrimitiveType()).isEqualTo(CSS_GRAD);
+        assertThat(skewAngle.getFloatValue()).isEqualTo(50f);
+
+        List<PropertyValue> origin = ((PropertyValue) declarations.get(1).getValue()).getValues();
+        assertThat(origin.get(0).getFloatValue()).isEqualTo(100f); // right
+        assertThat(origin.get(1).getFloatValue()).isEqualTo(100f); // bottom
     }
 
     private static PropertyDeclaration css(CSSName property, FSRGBColor color) {

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilderTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilderTest.java
@@ -1,0 +1,99 @@
+package org.xhtmlrenderer.css.parser.property;
+
+import org.junit.jupiter.api.Test;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+import org.xhtmlrenderer.css.sheet.StylesheetInfo.Origin;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_IDENT;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PERCENTAGE;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PX;
+import static org.xhtmlrenderer.css.constants.CSSName.cssProperty;
+
+class TransformOriginPropertyBuilderTest {
+    private final TransformOriginPropertyBuilder builder = new TransformOriginPropertyBuilder();
+    private final CSSName cssName = cssProperty("transform-origin");
+
+    private static PropertyValue ident(String name) {
+        return new PropertyValue(CSS_IDENT, name, name);
+    }
+
+    private static PropertyValue px(float value) {
+        return new PropertyValue(CSS_PX, value, value + "px");
+    }
+
+    private List<PropertyValue> valuesOf(List<PropertyDeclaration> result) {
+        return ((PropertyValue) result.get(0).getValue()).getValues();
+    }
+
+    @Test
+    void singleLengthDefaultsVerticalToCenter() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(cssName, List.of(px(10)), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(10f);
+        assertThat(values.get(1).getPrimitiveType()).isEqualTo(CSS_PERCENTAGE);
+        assertThat(values.get(1).getFloatValue()).isEqualTo(50f);
+    }
+
+    @Test
+    void keywordsResolveToPercentages() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(ident("right"), ident("bottom")), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(100f);
+        assertThat(values.get(1).getFloatValue()).isEqualTo(100f);
+    }
+
+    @Test
+    void leftAndTopKeywordsResolveToPercent0() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(ident("left"), ident("top")), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(0f);
+        assertThat(values.get(1).getFloatValue()).isEqualTo(0f);
+    }
+
+    @Test
+    void centerKeywordResolvesToPercent50() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(ident("center")), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(50f);
+        assertThat(values.get(1).getFloatValue()).isEqualTo(50f);
+    }
+
+    @Test
+    void lengthAndPercentageCombination() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(px(5), new PropertyValue(CSS_PERCENTAGE, 25f, "25%")), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(5f);
+        assertThat(values.get(1).getFloatValue()).isEqualTo(25f);
+    }
+
+    @Test
+    void rejectsTopAsHorizontalKeyword() {
+        assertThatThrownBy(() -> builder.buildDeclarations(cssName, List.of(ident("top")), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageContaining("top");
+    }
+
+    @Test
+    void rejectsMoreThanTwoValues() {
+        assertThatThrownBy(() -> builder.buildDeclarations(
+                cssName, List.of(px(1), px(2), px(3)), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageStartingWith("Found 3 values for transform-origin");
+    }
+}

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilderTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformOriginPropertyBuilderTest.java
@@ -83,10 +83,60 @@ class TransformOriginPropertyBuilderTest {
     }
 
     @Test
-    void rejectsTopAsHorizontalKeyword() {
-        assertThatThrownBy(() -> builder.buildDeclarations(cssName, List.of(ident("top")), Origin.AUTHOR, false, true))
+    void singleVerticalKeywordImpliesCenteredHorizontalAxis() {
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(ident("top")), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> values = valuesOf(result);
+        assertThat(values.get(0).getFloatValue()).isEqualTo(50f); // horizontal: center
+        assertThat(values.get(1).getFloatValue()).isEqualTo(0f);  // vertical: top
+    }
+
+    @Test
+    void keywordPairsCanAppearInEitherOrder() {
+        List<PropertyDeclaration> topLeft = builder.buildDeclarations(
+                cssName, List.of(ident("top"), ident("left")), Origin.AUTHOR, false, true);
+        List<PropertyValue> topLeftValues = valuesOf(topLeft);
+        assertThat(topLeftValues.get(0).getFloatValue()).isEqualTo(0f);  // horizontal: left
+        assertThat(topLeftValues.get(1).getFloatValue()).isEqualTo(0f); // vertical: top
+
+        // "right" can only be horizontal, so "center" is pushed onto the (otherwise unspecified) vertical axis.
+        List<PropertyDeclaration> centerRight = builder.buildDeclarations(
+                cssName, List.of(ident("center"), ident("right")), Origin.AUTHOR, false, true);
+        List<PropertyValue> centerRightValues = valuesOf(centerRight);
+        assertThat(centerRightValues.get(0).getFloatValue()).isEqualTo(100f); // horizontal: right
+        assertThat(centerRightValues.get(1).getFloatValue()).isEqualTo(50f); // vertical: center
+    }
+
+    @Test
+    void lengthCanBePairedWithAKeywordOnTheOtherAxis() {
+        List<PropertyDeclaration> lengthThenTop = builder.buildDeclarations(
+                cssName, List.of(px(10), ident("top")), Origin.AUTHOR, false, true);
+        List<PropertyValue> lengthThenTopValues = valuesOf(lengthThenTop);
+        assertThat(lengthThenTopValues.get(0).getFloatValue()).isEqualTo(10f);
+        assertThat(lengthThenTopValues.get(1).getFloatValue()).isEqualTo(0f);
+
+        List<PropertyDeclaration> leftThenLength = builder.buildDeclarations(
+                cssName, List.of(ident("left"), px(20)), Origin.AUTHOR, false, true);
+        List<PropertyValue> leftThenLengthValues = valuesOf(leftThenLength);
+        assertThat(leftThenLengthValues.get(0).getFloatValue()).isEqualTo(0f);
+        assertThat(leftThenLengthValues.get(1).getFloatValue()).isEqualTo(20f);
+    }
+
+    @Test
+    void rejectsTwoHorizontalOnlyKeywords() {
+        assertThatThrownBy(() -> builder.buildDeclarations(
+                cssName, List.of(ident("left"), ident("right")), Origin.AUTHOR, false, true))
                 .isInstanceOf(CSSParseException.class)
-                .hasMessageContaining("top");
+                .hasMessageContaining("Invalid combination");
+    }
+
+    @Test
+    void rejectsAVerticalKeywordPairedWithALength() {
+        assertThatThrownBy(() -> builder.buildDeclarations(
+                cssName, List.of(ident("top"), px(10)), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageContaining("Invalid combination");
     }
 
     @Test

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformPropertyBuilderTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/property/TransformPropertyBuilderTest.java
@@ -1,0 +1,116 @@
+package org.xhtmlrenderer.css.parser.property;
+
+import org.junit.jupiter.api.Test;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.parser.CSSParseException;
+import org.xhtmlrenderer.css.parser.FSFunction;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.sheet.PropertyDeclaration;
+import org.xhtmlrenderer.css.sheet.StylesheetInfo.Origin;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_DEG;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_NUMBER;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PX;
+import static org.xhtmlrenderer.css.constants.CSSName.cssProperty;
+import static org.xhtmlrenderer.css.constants.IdentValue.NONE;
+import static org.xhtmlrenderer.css.parser.PropertyValue.Type.VALUE_TYPE_FUNCTION;
+import static org.xhtmlrenderer.css.parser.PropertyValue.Type.VALUE_TYPE_LIST;
+
+class TransformPropertyBuilderTest {
+    private final TransformPropertyBuilder builder = new TransformPropertyBuilder();
+    private final CSSName cssName = cssProperty("transform");
+
+    private static PropertyValue function(String name, PropertyValue... args) {
+        return new PropertyValue(new FSFunction(name, List.of(args)));
+    }
+
+    private static PropertyValue px(float value) {
+        return new PropertyValue(CSS_PX, value, value + "px");
+    }
+
+    private static PropertyValue deg(float value) {
+        return new PropertyValue(CSS_DEG, value, value + "deg");
+    }
+
+    private static PropertyValue number(float value) {
+        return new PropertyValue(CSS_NUMBER, value, String.valueOf(value));
+    }
+
+    @Test
+    void none() {
+        PropertyValue none = new PropertyValue(NONE);
+
+        List<PropertyDeclaration> result = builder.buildDeclarations(cssName, List.of(none), Origin.AUTHOR, false, true);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getValue()).isSameAs(none);
+    }
+
+    @Test
+    void singleFunction() {
+        PropertyValue rotate = function("rotate", deg(45));
+
+        List<PropertyDeclaration> result = builder.buildDeclarations(cssName, List.of(rotate), Origin.AUTHOR, false, true);
+
+        assertThat(result).hasSize(1);
+        PropertyValue value = (PropertyValue) result.get(0).getValue();
+        assertThat(value.getPropertyValueType()).isEqualTo(VALUE_TYPE_LIST);
+
+        List<PropertyValue> functions = value.getValues();
+        assertThat(functions).hasSize(1);
+        assertThat(functions.get(0).getPropertyValueType()).isEqualTo(VALUE_TYPE_FUNCTION);
+        assertThat(functions.get(0).getFunction().getName()).isEqualTo("rotate");
+    }
+
+    @Test
+    void multipleFunctionsKeepOrder() {
+        PropertyValue translate = function("translate", px(10), px(20));
+        PropertyValue rotate = function("rotate", deg(45));
+
+        List<PropertyDeclaration> result = builder.buildDeclarations(
+                cssName, List.of(translate, rotate), Origin.AUTHOR, false, true);
+
+        List<PropertyValue> functions = ((PropertyValue) result.get(0).getValue()).getValues();
+        assertThat(functions.stream().map(v -> v.getFunction().getName())).containsExactly("translate", "rotate");
+    }
+
+    @Test
+    void rejectsUnknownFunction() {
+        PropertyValue unknown = function("rotate3d", deg(45));
+
+        assertThatThrownBy(() -> builder.buildDeclarations(cssName, List.of(unknown), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageContaining("rotate3d");
+    }
+
+    @Test
+    void rejectsWrongArgumentCountForMatrix() {
+        PropertyValue matrix = function("matrix", number(1), number(0), number(0), number(1), number(0));
+
+        assertThatThrownBy(() -> builder.buildDeclarations(cssName, List.of(matrix), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageStartingWith("matrix() requires between 6 and 6 argument(s)");
+    }
+
+    @Test
+    void rejectsNonAngleArgumentForRotate() {
+        PropertyValue rotate = function("rotate", px(45));
+
+        assertThatThrownBy(() -> builder.buildDeclarations(cssName, List.of(rotate), Origin.AUTHOR, false, true))
+                .isInstanceOf(CSSParseException.class)
+                .hasMessageContaining("rotate()");
+    }
+
+    @Test
+    void scaleAcceptsOneOrTwoNumbers() {
+        PropertyValue scale = function("scale", number(2));
+
+        List<PropertyDeclaration> result = builder.buildDeclarations(cssName, List.of(scale), Origin.AUTHOR, false, true);
+
+        assertThat(result).hasSize(1);
+    }
+}

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/BoxBuilderHtml5WarningTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/layout/BoxBuilderHtml5WarningTest.java
@@ -76,7 +76,7 @@ class BoxBuilderHtml5WarningTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"transition", "animation", "transform", "box-shadow", "filter"})
+    @ValueSource(strings = {"transition", "animation", "backdrop-filter", "box-shadow", "filter"})
     void warnsOnCss3PropertyNames(String property) throws Exception {
         String html = """
             <html>

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/CssTransform.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/CssTransform.java
@@ -1,0 +1,102 @@
+package org.xhtmlrenderer.pdf;
+
+import org.jspecify.annotations.Nullable;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.css.parser.FSFunction;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.style.BackgroundPosition;
+import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.css.style.CssContext;
+import org.xhtmlrenderer.css.style.derived.LengthValue;
+import org.xhtmlrenderer.render.Box;
+
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.util.List;
+
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_GRAD;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_RAD;
+
+/**
+ * Builds the {@link AffineTransform} for a box's CSS {@code transform}/{@code transform-origin},
+ * for use by {@link ITextOutputDevice}. Percentages in {@code translate()} and
+ * {@code transform-origin} are resolved against the box's border box, matching the CSS default.
+ */
+final class CssTransform {
+    private CssTransform() {
+    }
+
+    @Nullable
+    static AffineTransform toAffineTransform(CssContext ctx, Box box) {
+        CalculatedStyle style = box.getStyle();
+        List<PropertyValue> functions = style.getTransforms();
+        if (functions.isEmpty()) {
+            return null;
+        }
+
+        Rectangle bounds = box.getPaintingBorderEdge(ctx);
+        BackgroundPosition transformOrigin = style.getTransformOrigin();
+        float originX = bounds.x + resolveLength(ctx, style, transformOrigin.getHorizontal(), bounds.width);
+        float originY = bounds.y + resolveLength(ctx, style, transformOrigin.getVertical(), bounds.height);
+
+        AffineTransform result = new AffineTransform();
+        result.translate(originX, originY);
+        for (PropertyValue function : functions) {
+            result.concatenate(toMatrix(ctx, style, function.getFunction(), bounds));
+        }
+        result.translate(-originX, -originY);
+
+        return result;
+    }
+
+    static AffineTransform toMatrix(CssContext ctx, CalculatedStyle style, FSFunction function, Rectangle bounds) {
+        List<PropertyValue> args = function.getParameters();
+
+        // CSSParser lower-cases FUNCTION tokens (CSS identifiers are case-insensitive), so e.g.
+        // "skewX" always arrives here as "skewx".
+        return switch (function.getName()) {
+            case "matrix" -> new AffineTransform(
+                    number(args, 0), number(args, 1), number(args, 2),
+                    number(args, 3), number(args, 4), number(args, 5));
+            case "translate" -> AffineTransform.getTranslateInstance(
+                    resolveLength(ctx, style, args.get(0), bounds.width),
+                    args.size() == 2 ? resolveLength(ctx, style, args.get(1), bounds.height) : 0);
+            case "translatex" -> AffineTransform.getTranslateInstance(
+                    resolveLength(ctx, style, args.get(0), bounds.width), 0);
+            case "translatey" -> AffineTransform.getTranslateInstance(
+                    0, resolveLength(ctx, style, args.get(0), bounds.height));
+            case "scale" -> {
+                float sx = number(args, 0);
+                yield AffineTransform.getScaleInstance(sx, args.size() == 2 ? number(args, 1) : sx);
+            }
+            case "scalex" -> AffineTransform.getScaleInstance(number(args, 0), 1);
+            case "scaley" -> AffineTransform.getScaleInstance(1, number(args, 0));
+            case "rotate" -> AffineTransform.getRotateInstance(angleToRadians(args.get(0)));
+            case "skew" -> AffineTransform.getShearInstance(
+                    Math.tan(angleToRadians(args.get(0))),
+                    args.size() == 2 ? Math.tan(angleToRadians(args.get(1))) : 0);
+            case "skewx" -> AffineTransform.getShearInstance(Math.tan(angleToRadians(args.get(0))), 0);
+            case "skewy" -> AffineTransform.getShearInstance(0, Math.tan(angleToRadians(args.get(0))));
+            default -> new AffineTransform();
+        };
+    }
+
+    private static float number(List<PropertyValue> args, int index) {
+        return args.get(index).getFloatValue();
+    }
+
+    static double angleToRadians(PropertyValue angle) {
+        float value = angle.getFloatValue();
+        return switch (angle.getPrimitiveType()) {
+            case CSS_RAD -> value;
+            case CSS_GRAD -> Math.toRadians(value * 0.9);
+            default -> Math.toRadians(value); // CSS_DEG (also covers "turn", pre-converted to degrees at parse time)
+        };
+    }
+
+    private static float resolveLength(CssContext ctx, CalculatedStyle style, PropertyValue value, float percentageBase) {
+        return LengthValue.calcFloatProportionalValue(
+                style, CSSName.TRANSFORM, value.getCssText(), value.getFloatValue(),
+                value.getPrimitiveType(), percentageBase, ctx);
+    }
+}

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -84,8 +84,10 @@ import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -125,6 +127,7 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
     private ITextFSFont _font;
 
     private AffineTransform _transform = new AffineTransform();
+    private final Deque<AffineTransform> _transformStack = new ArrayDeque<>();
 
     private Color _color = Color.BLACK;
 
@@ -490,6 +493,21 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
     @Override
     public void translate(double tx, double ty) {
         _transform.translate(tx, ty);
+    }
+
+    @Override
+    public void pushTransform(RenderingContext c, Box box) {
+        _transformStack.push((AffineTransform) _transform.clone());
+
+        AffineTransform boxTransform = CssTransform.toAffineTransform(c, box);
+        if (boxTransform != null) {
+            _transform.concatenate(boxTransform);
+        }
+    }
+
+    @Override
+    public void popTransform() {
+        _transform = _transformStack.pop();
     }
 
     @Nullable

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -341,13 +341,28 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             bounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), c);
         }
 
-        Point2D docCorner = new Point2D.Double(bounds.x, bounds.y + bounds.height);
-        Point2D pdfCorner = new Point2D.Double();
-        _transform.transform(docCorner, pdfCorner);
-        pdfCorner.setLocation(pdfCorner.getX(), normalizeY((float) pdfCorner.getY()));
+        // Transform all four corners (not just one, plus untransformed width/height) so a rotated or
+        // skewed transform still produces the correct axis-aligned bounding box in PDF space.
+        Point2D[] docCorners = {
+                new Point2D.Double(bounds.x, bounds.y),
+                new Point2D.Double(bounds.x + bounds.width, bounds.y),
+                new Point2D.Double(bounds.x, bounds.y + bounds.height),
+                new Point2D.Double(bounds.x + bounds.width, bounds.y + bounds.height),
+        };
 
-        return new org.openpdf.text.Rectangle((float) pdfCorner.getX(), (float) pdfCorner.getY(),
-                (float) pdfCorner.getX() + getDeviceLength(bounds.width), (float) pdfCorner.getY() + getDeviceLength(bounds.height));
+        float minX = Float.MAX_VALUE, maxX = -Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE, maxY = -Float.MAX_VALUE;
+        for (Point2D docCorner : docCorners) {
+            Point2D pdfCorner = _transform.transform(docCorner, null);
+            float x = (float) pdfCorner.getX();
+            float y = normalizeY((float) pdfCorner.getY());
+            minX = Math.min(minX, x);
+            maxX = Math.max(maxX, x);
+            minY = Math.min(minY, y);
+            maxY = Math.max(maxY, y);
+        }
+
+        return new org.openpdf.text.Rectangle(minX, minY, maxX, maxY);
     }
 
     public org.openpdf.text.Rectangle createTargetArea(RenderingContext c, Box box) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssTransformTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssTransformTest.java
@@ -1,0 +1,220 @@
+package org.xhtmlrenderer.pdf;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xhtmlrenderer.css.parser.FSFunction;
+import org.xhtmlrenderer.css.parser.PropertyValue;
+import org.xhtmlrenderer.css.style.BackgroundPosition;
+import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.css.style.CssContext;
+import org.xhtmlrenderer.render.Box;
+
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_DEG;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_GRAD;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_NUMBER;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PERCENTAGE;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_PX;
+import static org.w3c.dom.css.CSSPrimitiveValue.CSS_RAD;
+
+class CssTransformTest {
+    private static final Offset<Double> TOLERANCE = within(0.00001);
+
+    private final CssContext ctx = mock();
+    private final CalculatedStyle style = mock();
+    private final Rectangle bounds = new Rectangle(0, 0, 100, 50);
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.getDotsPerPixel()).thenReturn(1);
+    }
+
+    private static PropertyValue px(float value) {
+        return new PropertyValue(CSS_PX, value, value + "px");
+    }
+
+    private static PropertyValue percent(float value) {
+        return new PropertyValue(CSS_PERCENTAGE, value, value + "%");
+    }
+
+    private static PropertyValue number(float value) {
+        return new PropertyValue(CSS_NUMBER, value, String.valueOf(value));
+    }
+
+    private static PropertyValue deg(float value) {
+        return new PropertyValue(CSS_DEG, value, value + "deg");
+    }
+
+    private static PropertyValue rad(float value) {
+        return new PropertyValue(CSS_RAD, value, value + "rad");
+    }
+
+    private static PropertyValue grad(float value) {
+        return new PropertyValue(CSS_GRAD, value, value + "grad");
+    }
+
+    private static FSFunction function(String name, PropertyValue... args) {
+        return new FSFunction(name, List.of(args));
+    }
+
+    private void assertMatrixEquals(AffineTransform actual, double m00, double m10, double m01, double m11, double m02, double m12) {
+        double[] matrix = new double[6];
+        actual.getMatrix(matrix);
+        assertThat(matrix[0]).isCloseTo(m00, TOLERANCE);
+        assertThat(matrix[1]).isCloseTo(m10, TOLERANCE);
+        assertThat(matrix[2]).isCloseTo(m01, TOLERANCE);
+        assertThat(matrix[3]).isCloseTo(m11, TOLERANCE);
+        assertThat(matrix[4]).isCloseTo(m02, TOLERANCE);
+        assertThat(matrix[5]).isCloseTo(m12, TOLERANCE);
+    }
+
+    @Test
+    void matrix() {
+        AffineTransform result = CssTransform.toMatrix(
+                ctx, style, function("matrix", number(1), number(2), number(3), number(4), number(5), number(6)), bounds);
+
+        assertMatrixEquals(result, 1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void translateWithBothArguments() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("translate", px(10), percent(20)), bounds);
+
+        // percent(20) of bounds.height (50) == 10
+        assertMatrixEquals(result, 1, 0, 0, 1, 10, 10);
+    }
+
+    @Test
+    void translateWithOnlyHorizontalArgumentDefaultsVerticalToZero() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("translate", px(10)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 0, 1, 10, 0);
+    }
+
+    @Test
+    void translateX() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("translatex", px(15)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 0, 1, 15, 0);
+    }
+
+    @Test
+    void translateY() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("translatey", px(15)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 0, 1, 0, 15);
+    }
+
+    @Test
+    void scaleWithOneArgumentAppliesToBothAxes() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("scale", number(2)), bounds);
+
+        assertMatrixEquals(result, 2, 0, 0, 2, 0, 0);
+    }
+
+    @Test
+    void scaleWithTwoArguments() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("scale", number(2), number(3)), bounds);
+
+        assertMatrixEquals(result, 2, 0, 0, 3, 0, 0);
+    }
+
+    @Test
+    void scaleX() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("scalex", number(2)), bounds);
+
+        assertMatrixEquals(result, 2, 0, 0, 1, 0, 0);
+    }
+
+    @Test
+    void scaleY() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("scaley", number(3)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 0, 3, 0, 0);
+    }
+
+    @Test
+    void rotate90Degrees() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("rotate", deg(90)), bounds);
+
+        assertMatrixEquals(result, 0, 1, -1, 0, 0, 0);
+    }
+
+    @Test
+    void skewWithBothArguments() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("skew", deg(45), deg(0)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 1, 1, 0, 0);
+    }
+
+    @Test
+    void skewX() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("skewx", deg(45)), bounds);
+
+        assertMatrixEquals(result, 1, 0, 1, 1, 0, 0);
+    }
+
+    @Test
+    void skewY() {
+        AffineTransform result = CssTransform.toMatrix(ctx, style, function("skewy", deg(45)), bounds);
+
+        assertMatrixEquals(result, 1, 1, 0, 1, 0, 0);
+    }
+
+    @Test
+    void angleToRadiansConvertsDegrees() {
+        assertThat(CssTransform.angleToRadians(deg(180))).isCloseTo(Math.PI, TOLERANCE);
+    }
+
+    @Test
+    void angleToRadiansPassesRadiansThrough() {
+        assertThat(CssTransform.angleToRadians(rad(1.5f))).isCloseTo(1.5, TOLERANCE);
+    }
+
+    @Test
+    void angleToRadiansConvertsGrads() {
+        // 200 grad == 180 deg == pi radians
+        assertThat(CssTransform.angleToRadians(grad(200))).isCloseTo(Math.PI, TOLERANCE);
+    }
+
+    @Test
+    void toAffineTransformReturnsNullWhenThereIsNoTransform() {
+        Box box = mock();
+        when(box.getStyle()).thenReturn(style);
+        when(style.getTransforms()).thenReturn(List.of());
+
+        assertThat(CssTransform.toAffineTransform(ctx, box)).isNull();
+    }
+
+    @Test
+    void toAffineTransformAnchorsRotationAtTheTransformOrigin() {
+        Box box = mock();
+        when(box.getStyle()).thenReturn(style);
+        when(box.getPaintingBorderEdge(ctx)).thenReturn(new Rectangle(10, 20, 100, 50));
+        when(style.getTransforms()).thenReturn(List.of(new PropertyValue(function("rotate", deg(90)))));
+        // transform-origin: left top -- the box's top-left corner, at absolute position (10, 20)
+        when(style.getTransformOrigin()).thenReturn(new BackgroundPosition(percent(0), percent(0)));
+
+        AffineTransform result = CssTransform.toAffineTransform(ctx, box);
+
+        // The origin point itself must stay fixed under a rotation about itself.
+        Point2D origin = result.transform(new Point2D.Float(10, 20), null);
+        assertThat(origin.getX()).isCloseTo(10, TOLERANCE);
+        assertThat(origin.getY()).isCloseTo(20, TOLERANCE);
+
+        // The box's top-right corner (110, 20) is 100 to the right of the origin;
+        // rotating 90 degrees around the origin moves it 100 below the origin instead.
+        Point2D corner = result.transform(new Point2D.Float(110, 20), null);
+        assertThat(corner.getX()).isCloseTo(10, TOLERANCE);
+        assertThat(corner.getY()).isCloseTo(120, TOLERANCE);
+    }
+}

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
@@ -31,4 +31,21 @@ class TransformTest {
             assertThat(content).containsPattern("0\\.70711 -0\\.70711 0\\.70711 0\\.70711 [0-9.]+ [0-9.]+ Tm");
         }
     }
+
+    @Test
+    void positionedDescendantOfATransformedBoxInheritsTheTransform() throws IOException {
+        byte[] bytes = Html2Pdf.fromClasspathResource("transform.html");
+        PDF pdf = printFile(log, bytes, "transform.pdf");
+
+        assertThat(pdf).containsText("absolute");
+
+        try (PdfReader reader = new PdfReader(bytes)) {
+            String content = new String(reader.getPageContent(1), StandardCharsets.ISO_8859_1);
+
+            // The "position: absolute" descendant establishes its own layer; unless that layer is
+            // painted as part of its transformed ancestor's stacking context, this text would be drawn
+            // with the identity matrix instead of a 90-degree rotation (cos90=0, sin90=1).
+            assertThat(content).containsPattern("0 -1 1 0 [0-9.]+ [0-9.]+ Tm");
+        }
+    }
 }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
@@ -1,0 +1,34 @@
+package org.xhtmlrenderer.pdf;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.openpdf.text.pdf.PdfReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static org.xhtmlrenderer.pdf.TestUtils.printFile;
+
+class TransformTest {
+    private static final Logger log = LoggerFactory.getLogger(TransformTest.class);
+
+    @Test
+    void rotatedBoxIsRenderedViaAContentStreamTransform() throws IOException {
+        byte[] bytes = Html2Pdf.fromClasspathResource("transform.html");
+        PDF pdf = printFile(log, bytes, "transform.pdf");
+
+        assertThat(pdf).containsText("Not transformed", "Rotated");
+
+        try (PdfReader reader = new PdfReader(bytes)) {
+            String content = new String(reader.getPageContent(1), StandardCharsets.ISO_8859_1);
+
+            // The rotated box's text is drawn with a 45-degree rotation baked into its text matrix
+            // (cos45 = sin45 = 0.70711), while the untransformed box uses the identity "1 0 0 1 ... Tm".
+            assertThat(content).contains("1 0 0 1 42 789.11 Tm");
+            assertThat(content).containsPattern("0\\.70711 -0\\.70711 0\\.70711 0\\.70711 [0-9.]+ [0-9.]+ Tm");
+        }
+    }
+}

--- a/flying-saucer-pdf/src/test/resources/transform.html
+++ b/flying-saucer-pdf/src/test/resources/transform.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head>
+    <title>TEST</title>
+</head>
+<body>
+    <div style="width: 100px; height: 40px; background-color: cornflowerblue;">Not transformed</div>
+    <div style="width: 100px; height: 40px; background-color: crimson; transform: rotate(45deg);">Rotated</div>
+</body>
+</html>

--- a/flying-saucer-pdf/src/test/resources/transform.html
+++ b/flying-saucer-pdf/src/test/resources/transform.html
@@ -5,5 +5,8 @@
 <body>
     <div style="width: 100px; height: 40px; background-color: cornflowerblue;">Not transformed</div>
     <div style="width: 100px; height: 40px; background-color: crimson; transform: rotate(45deg);">Rotated</div>
+    <div style="width: 100px; height: 100px; transform: rotate(90deg);">
+        <div style="position: absolute;">Nested absolute</div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Parses CSS `transform` (`matrix`, `translate`/`translateX`/`translateY`, `scale`/`scaleX`/`scaleY`, `rotate`, `skew`/`skewX`/`skewY`) and `transform-origin` in `flying-saucer-core`, plus `grad`/`turn` angle-unit support in `CSSParser` (previously only `deg`/`rad` worked).
- Rendering is implemented **only for the PDF backend**: `OutputDevice` gains `pushTransform(RenderingContext, Box)`/`popTransform()` as **default no-op methods**, so Swing/SWT/OSGi require zero changes and keep ignoring `transform` exactly as before. `ITextOutputDevice` overrides them for real, delegating the matrix math (including `transform-origin` resolution against the border box) to the new `CssTransform` helper.
- A non-`none` transform now makes `CalculatedStyle.requiresLayer()` return `true` (like `position`), so a transformed box gets its own `Layer`, and `Layer.paint()` wraps its content-paint block with push/pop — this is the one shared (core) hook the PDF-only rendering depends on.
- Removed `transform`/`transform-origin` from `CSSName.UNSUPPORTED_CSS3_PROPERTIES` (kept `transform-style`, since 3D isn't supported).

Closes #506.

## Test plan
- [x] `TransformPropertyBuilderTest` / `TransformOriginPropertyBuilderTest` — unit tests for the new property parsers (valid/invalid function names, argument counts/types, keyword resolution).
- [x] `CSSParserTest#parsesTransformFunctionsAndAngleUnits` — end-to-end parse of a multi-function `transform` value plus the new `grad`/`turn` units.
- [x] `CssTransformTest` — unit tests for `toMatrix`/`angleToRadians`/`toAffineTransform` (matrix construction per function, angle-unit conversion, and that rotation is correctly anchored at `transform-origin`).
- [x] `TransformTest` (PDF integration) — renders `transform: rotate(45deg)` and inspects the raw PDF content stream, confirming the rotated box's text matrix is `0.70711 -0.70711 0.70711 0.70711 ... Tm` while an untransformed sibling keeps the identity matrix.
- [x] `mvn -B package` (full multi-module build, JDK 21) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSS `transform` and `transform-origin` support to PDF rendering, including `matrix`, `translate*`, `scale*`, `rotate`, and `skew*`.
  * Supports common angle units (deg, rad, grad, turn) and correct transform-origin anchoring.
* **Bug Fixes**
  * Improved parsing/normalization for `turn` angles and `transform-origin` keyword/length combinations.
  * Updated transform handling so layers apply and restore transforms safely during painting.
* **Tests**
  * Added and expanded parser, property-builder, and PDF rendering coverage, including new `transform.html` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->