### PR TITLE
feat(css): apply letter-spacing at layout and paint time

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/ContentFunctionFactory.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/context/ContentFunctionFactory.java
@@ -28,6 +28,7 @@ import org.xhtmlrenderer.css.parser.PropertyValue;
 import org.xhtmlrenderer.layout.CounterFunction;
 import org.xhtmlrenderer.layout.InlineBoxing;
 import org.xhtmlrenderer.layout.LayoutContext;
+import org.xhtmlrenderer.layout.TextUtil;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.InlineLayoutBox;
 import org.xhtmlrenderer.render.InlineText;
@@ -242,10 +243,8 @@ public class ContentFunctionFactory {
             // Otherwise, there might be a small gap on the right side. This is
             // necessary because a TextRenderer usually use double/float for width.
             String tmp = value.repeat(100);
-            float valueWidth = c.getTextRenderer().getWidth(c.getFontContext(),
-                    iB.getStyle().getFSFont(c), tmp) / 100.0f;
-            int spaceWidth = c.getTextRenderer().getWidth(c.getFontContext(),
-                    iB.getStyle().getFSFont(c), " ");
+            float valueWidth = TextUtil.textWidth(c, iB.getStyle(), iB.getStyle().getFSFont(c), tmp) / 100.0f;
+            int spaceWidth = TextUtil.textWidth(c, iB.getStyle(), iB.getStyle().getFSFont(c), " ");
 
             // compute leader width and necessary count of values
             int leaderWidth = iB.getContainingBlockWidth() - iB.getLineBox().getWidth() + text.getWidth();
@@ -254,8 +253,7 @@ public class ContentFunctionFactory {
             String leaderString = ' ' + value.repeat(Math.max(0, count)) + ' ';
 
             // set left margin to ensure that the leader is right aligned (for TOC)
-            int leaderStringWidth = c.getTextRenderer().getWidth(c.getFontContext(),
-                    iB.getStyle().getFSFont(c), leaderString);
+            int leaderStringWidth = TextUtil.textWidth(c, iB.getStyle(), iB.getStyle().getFSFont(c), leaderString);
             iB.setMarginLeft(c, leaderWidth - leaderStringWidth);
 
             return leaderString;

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CalculatedStyle.java
@@ -105,6 +105,9 @@ public class CalculatedStyle {
     private float _lineHeight;
     private boolean _lineHeightResolved;
 
+    private float _letterSpacing;
+    private boolean _letterSpacingResolved;
+
     @Nullable
     private FSFont _FSFont;
     @Nullable
@@ -497,6 +500,21 @@ public class CalculatedStyle {
             _lineHeightResolved = true;
         }
         return _lineHeight;
+    }
+
+    /**
+     * Additional spacing applied after each character of inline text
+     * (the {@code letter-spacing} property), resolved to dots.
+     * Returns {@code 0.0f} for {@code letter-spacing: normal}.
+     */
+    public float letterSpacing(CssContext ctx) {
+        if (!_letterSpacingResolved) {
+            _letterSpacing = isIdent(CSSName.LETTER_SPACING, IdentValue.NORMAL) ?
+                    0.0f :
+                    getFloatPropertyProportionalWidth(CSSName.LETTER_SPACING, 0, ctx);
+            _letterSpacingResolved = true;
+        }
+        return _letterSpacing;
     }
 
     /**

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CssContext.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/style/CssContext.java
@@ -4,6 +4,8 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.xhtmlrenderer.context.StyleReference;
 import org.xhtmlrenderer.css.value.FontSpecification;
+import org.xhtmlrenderer.extend.FontContext;
+import org.xhtmlrenderer.extend.TextRenderer;
 import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.render.FSFontMetrics;
 
@@ -29,6 +31,12 @@ public interface CssContext {
     // and RenderingContext
     @CheckReturnValue
     StyleReference getCss();
+
+    @CheckReturnValue
+    TextRenderer getTextRenderer();
+
+    @CheckReturnValue
+    FontContext getFontContext();
 
     @CheckReturnValue
     FSFontMetrics getFSFontMetrics(FSFont font);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/TextUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/TextUtil.java
@@ -23,6 +23,8 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import org.xhtmlrenderer.css.constants.CSSName;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.style.CalculatedStyle;
+import org.xhtmlrenderer.css.style.CssContext;
+import org.xhtmlrenderer.render.FSFont;
 import org.xhtmlrenderer.util.Uu;
 
 import static java.lang.Character.END_PUNCTUATION;
@@ -112,6 +114,22 @@ public class TextUtil {
         };
     }
 
+
+    /**
+     * Measures the width of {@code text} in dots, including any
+     * {@code letter-spacing} from {@code style} (applied after each character).
+     * The spacing contribution is rounded up so that a width accumulated from
+     * substring measurements never exceeds the recorded width of the whole run.
+     */
+    @CheckReturnValue
+    public static int textWidth(CssContext c, CalculatedStyle style, FSFont font, String text) {
+        int width = c.getTextRenderer().getWidth(c.getFontContext(), font, text);
+        float letterSpacing = style.letterSpacing(c);
+        if (letterSpacing == 0.0f) {
+            return width;
+        }
+        return width + (int) Math.ceil(letterSpacing * text.codePointCount(0, text.length()));
+    }
 
     private static String capitalizeWords(String text) {
         if (text.isEmpty()) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/TextUtil.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/TextUtil.java
@@ -119,7 +119,7 @@ public class TextUtil {
      * Measures the width of {@code text} in dots, including any
      * {@code letter-spacing} from {@code style} (applied after each character).
      * The spacing contribution is rounded up so that a width accumulated from
-     * substring measurements never exceeds the recorded width of the whole run.
+     * substring measurements never understates the width of the whole run.
      */
     @CheckReturnValue
     public static int textWidth(CssContext c, CalculatedStyle style, FSFont font, String text) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/layout/breaker/Breaker.java
@@ -48,8 +48,7 @@ public class Breaker {
             int avail, CalculatedStyle style) {
         FSFont font = style.getFSFont(c);
         context.setEnd(getFirstLetterEnd(context.getMaster(), context.getStart()));
-        context.setWidth(c.getTextRenderer().getWidth(
-                c.getFontContext(), font, context.getCalculatedSubstring()));
+        context.setWidth(TextUtil.textWidth(c, style, font, context.getCalculatedSubstring()));
 
         if (context.getWidth() > avail) {
             context.setNeedsNewLine(true);
@@ -82,8 +81,7 @@ public class Breaker {
         // ====== handle nowrap
         if (whitespace == IdentValue.NOWRAP) {
             context.setEnd(context.getLast());
-            context.setWidth(c.getTextRenderer().getWidth(
-                    c.getFontContext(), font, context.getCalculatedSubstring()));
+            context.setWidth(TextUtil.textWidth(c, style, font, context.getCalculatedSubstring()));
             return;
         }
 
@@ -94,14 +92,12 @@ public class Breaker {
             int n = context.getStartSubstring().indexOf(WhitespaceStripper.EOL);
             if (n > -1) {
                 context.setEnd(context.getStart() + n + 1);
-                context.setWidth(c.getTextRenderer().getWidth(
-                        c.getFontContext(), font, context.getCalculatedSubstring()));
+                context.setWidth(TextUtil.textWidth(c, style, font, context.getStartSubstring().substring(0, n)));
                 context.setNeedsNewLine(true);
                 context.setEndsOnNL(true);
             } else if (whitespace == IdentValue.PRE) {
                 context.setEnd(context.getLast());
-                context.setWidth(c.getTextRenderer().getWidth(
-                        c.getFontContext(), font, context.getCalculatedSubstring()));
+                context.setWidth(TextUtil.textWidth(c, style, font, context.getCalculatedSubstring()));
             }
         }
 
@@ -116,10 +112,6 @@ public class Breaker {
         boolean tryToBreakAnywhere = style.getWordBreak() == IdentValue.BREAK_ALL;
 
         doBreakText(c, context, avail, style, tryToBreakAnywhere);
-    }
-
-    private static int getWidth(LayoutContext c, FSFont f, String text) {
-        return c.getTextRenderer().getWidth(c.getFontContext(), f, text);
     }
 
     public static BreakPointsProvider getBreakPointsProvider(String text, LayoutContext c, Element element, CalculatedStyle style) {
@@ -165,7 +157,7 @@ public class Breaker {
         int previousWidth = 0;
         int previousPosition = 0;
         while (bp != null && bp.getPosition() != BreakIterator.DONE) {
-            int currentWidth = getWidth(c, f, currentString.substring(previousPosition, bp.getPosition()) + bp.getHyphen());
+            int currentWidth = TextUtil.textWidth(c, style, f, currentString.substring(previousPosition, bp.getPosition()) + bp.getHyphen());
             int widthWithHyphen = previousWidth + currentWidth;
             previousWidth = widthWithHyphen;
             previousPosition = bp.getPosition();
@@ -184,7 +176,7 @@ public class Breaker {
         }
 
         if (bp != null && bp.getPosition() == BreakIterator.DONE) {
-            context.setWidth(getWidth(c, f, currentString));
+            context.setWidth(TextUtil.textWidth(c, style, f, currentString));
             context.setEnd(context.getMaster().length());
             //It fits!
             return;
@@ -200,14 +192,14 @@ public class Breaker {
 
         if (right > 0) { // found a place to wrap
             context.setEnd(context.getStart() + right);
-            context.setWidth(getWidth(c, f, context.getMaster().substring(context.getStart(), context.getStart() + right)));
+            context.setWidth(TextUtil.textWidth(c, style, f, context.getMaster().substring(context.getStart(), context.getStart() + right)));
             return;
         }
 
         // unbreakable string
         context.setEnd(context.getStart() + currentString.length());
         context.setUnbreakable(true);
-        context.setWidth(getWidth(c, f, context.getCalculatedSubstring()));
+        context.setWidth(TextUtil.textWidth(c, style, f, context.getCalculatedSubstring()));
     }
 
 }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/AbstractOutputDevice.java
@@ -37,6 +37,7 @@ import org.xhtmlrenderer.css.style.derived.LengthValue;
 import org.xhtmlrenderer.css.value.FontSpecification;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.OutputDevice;
+import org.xhtmlrenderer.layout.TextUtil;
 import org.xhtmlrenderer.util.Configuration;
 import org.xhtmlrenderer.util.Uu;
 
@@ -64,20 +65,13 @@ public abstract class AbstractOutputDevice<T extends FSImage, FontType extends F
             setColor(iB.getStyle().getColor());
             setFont((FontType) iB.getStyle().getFSFont(c));
             setFontSpecification(iB.getStyle().getFontSpecification());
-            if (inlineText.getParent().getStyle().isTextJustify()) {
-                JustificationInfo info = inlineText.getParent().getLineBox().getJustificationInfo();
-                if (info != null) {
-                    c.getTextRenderer().drawString(
-                            c.getOutputDevice(),
-                            text,
-                            iB.getAbsX() + inlineText.getX(), iB.getAbsY() + iB.getBaseline(),
-                            info);
-                } else {
-                    c.getTextRenderer().drawString(
-                            c.getOutputDevice(),
-                            text,
-                            iB.getAbsX() + inlineText.getX(), iB.getAbsY() + iB.getBaseline());
-                }
+            JustificationInfo info = justificationInfo(c, inlineText);
+            if (info != null) {
+                c.getTextRenderer().drawString(
+                        c.getOutputDevice(),
+                        text,
+                        iB.getAbsX() + inlineText.getX(), iB.getAbsY() + iB.getBaseline(),
+                        info);
             } else {
                 c.getTextRenderer().drawString(
                         c.getOutputDevice(),
@@ -91,6 +85,28 @@ public abstract class AbstractOutputDevice<T extends FSImage, FontType extends F
         }
     }
 
+    /**
+     * The per-character adjustments to draw {@code inlineText} with: the line's
+     * justification (if any) plus the style's {@code letter-spacing} (if any),
+     * or {@code null} when neither applies.
+     */
+    @Nullable
+    @CheckReturnValue
+    protected JustificationInfo justificationInfo(RenderingContext c, InlineText inlineText) {
+        InlineLayoutBox iB = inlineText.getParent();
+        JustificationInfo info = iB.getStyle().isTextJustify() ?
+                iB.getLineBox().getJustificationInfo() :
+                null;
+
+        float letterSpacing = iB.getStyle().letterSpacing(c);
+        if (letterSpacing == 0.0f) {
+            return info;
+        }
+        return info == null ?
+                new JustificationInfo(letterSpacing, letterSpacing) :
+                new JustificationInfo(info.nonSpaceAdjust() + letterSpacing, info.spaceAdjust() + letterSpacing);
+    }
+
     private void drawFontMetrics(RenderingContext c, InlineText inlineText) {
         InlineLayoutBox iB = inlineText.getParent();
         String text = inlineText.getSubstring();
@@ -98,9 +114,7 @@ public abstract class AbstractOutputDevice<T extends FSImage, FontType extends F
         setColor(new FSRGBColor(0xFF, 0x33, 0xFF));
 
         FSFontMetrics fm = iB.getStyle().getFSFontMetrics(null);
-        int width = c.getTextRenderer().getWidth(
-                c.getFontContext(),
-                iB.getStyle().getFSFont(c), text);
+        int width = TextUtil.textWidth(c, iB.getStyle(), iB.getStyle().getFSFont(c), text);
         int x = iB.getAbsX() + inlineText.getX();
         int y = iB.getAbsY() + iB.getBaseline();
 

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
@@ -181,10 +181,7 @@ public class InlineBox implements Styleable {
 
     @CheckReturnValue
     private int getTextWidth(LayoutContext c, String s) {
-        return c.getTextRenderer().getWidth(
-                c.getFontContext(),
-                c.getFont(getStyle().getFont(c)),
-                s);
+        return TextUtil.textWidth(c, getStyle(), c.getFont(getStyle().getFont(c)), s);
     }
 
     @CheckReturnValue
@@ -238,11 +235,7 @@ public class InlineBox implements Styleable {
 
     @CheckReturnValue
     public int getSpaceWidth(LayoutContext c) {
-        return c.getTextRenderer().getWidth(
-                c.getFontContext(),
-                getStyle().getFSFont(c),
-                WhitespaceStripper.SPACE);
-
+        return TextUtil.textWidth(c, getStyle(), getStyle().getFSFont(c), WhitespaceStripper.SPACE);
     }
 
     @CheckReturnValue

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineBox.java
@@ -186,13 +186,14 @@ public class InlineBox implements Styleable {
 
     @CheckReturnValue
     private int getMaxCharWidth(LayoutContext c, String s) {
-        char[] chars = s.toCharArray();
         int result = 0;
-        for (char aChar : chars) {
-            int width = getTextWidth(c, Character.toString(aChar));
+        for (int i = 0; i < s.length(); ) {
+            int codePoint = s.codePointAt(i);
+            int width = getTextWidth(c, new String(Character.toChars(codePoint)));
             if (width > result) {
                 result = width;
             }
+            i += Character.charCount(codePoint);
         }
         return result;
     }

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineText.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/InlineText.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Text;
 import org.xhtmlrenderer.extend.FSGlyphVector;
 import org.xhtmlrenderer.layout.FunctionData;
 import org.xhtmlrenderer.layout.LayoutContext;
+import org.xhtmlrenderer.layout.TextUtil;
 import org.xhtmlrenderer.layout.WhitespaceStripper;
 import org.xhtmlrenderer.util.Uu;
 
@@ -65,7 +66,7 @@ public class InlineText implements InlineChild {
     public void trimTrailingSpace(LayoutContext c) {
         if (! isEmpty() && _masterText.charAt(_end-1) == ' ') {
             _end--;
-            setWidth(c.getTextRenderer().getWidth(c.getFontContext(),
+            setWidth(TextUtil.textWidth(c, getParent().getStyle(),
                     getParent().getStyle().getFSFont(c),
                     getSubstring()));
             setTrimmedTrailingSpace();
@@ -166,9 +167,8 @@ public class InlineText implements InlineChild {
         _start = 0;
         _end = value.length();
         _masterText = value;
-        _width = c.getTextRenderer().getWidth(
-                c.getFontContext(), getParent().getStyle().getFSFont(c),
-                value);
+        _width = TextUtil.textWidth(c, getParent().getStyle(),
+                getParent().getStyle().getFSFont(c), value);
     }
 
     @Override

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/LineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/LineBox.java
@@ -230,9 +230,12 @@ public class LineBox extends Box implements InlinePaintable {
 
                 CharCounts counts = countJustifiableChars();
 
-                JustificationInfo info = !getParent().getStyle().isIdent(LETTER_SPACING, NORMAL) ?
-                        new JustificationInfo(0.0f, (float) toAdd / counts.getSpaceCount()) :
-                        justificationInfo(counts, toAdd);
+                boolean isSpaceOnly = !getParent().getStyle().isIdent(LETTER_SPACING, NORMAL) &&
+                        counts.getSpaceCount() > 0;
+
+                JustificationInfo info = isSpaceOnly ?
+                        justificationInfo(counts, toAdd, 0.0f, 1.0f) :
+                        justificationInfo(counts, toAdd, JUSTIFY_NON_SPACE_SHARE, JUSTIFY_SPACE_SHARE);
 
                 adjustChildren(info);
                 setJustificationInfo(info);
@@ -240,13 +243,14 @@ public class LineBox extends Box implements InlinePaintable {
         }
     }
 
-    private static JustificationInfo justificationInfo(CharCounts counts, int toAdd) {
+    private static JustificationInfo justificationInfo(CharCounts counts, int toAdd,
+                                                       float nonSpaceShare, float spaceShare) {
         float nonSpaceAdjust = counts.getNonSpaceCount() > 1 ?
-                toAdd * JUSTIFY_NON_SPACE_SHARE / (counts.getNonSpaceCount() - 1) :
+                toAdd * nonSpaceShare / (counts.getNonSpaceCount() - 1) :
                 0.0f;
 
         float spaceAdjust = counts.getSpaceCount() > 0 ?
-                toAdd * JUSTIFY_SPACE_SHARE / counts.getSpaceCount() :
+                toAdd * spaceShare / counts.getSpaceCount() :
                 0.0f;
 
         return new JustificationInfo(nonSpaceAdjust, spaceAdjust);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/LineBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/render/LineBox.java
@@ -230,12 +230,14 @@ public class LineBox extends Box implements InlinePaintable {
 
                 CharCounts counts = countJustifiableChars();
 
-                boolean isSpaceOnly = !getParent().getStyle().isIdent(LETTER_SPACING, NORMAL) &&
-                        counts.getSpaceCount() > 0;
-
-                JustificationInfo info = isSpaceOnly ?
-                        justificationInfo(counts, toAdd, 0.0f, 1.0f) :
-                        justificationInfo(counts, toAdd, JUSTIFY_NON_SPACE_SHARE, JUSTIFY_SPACE_SHARE);
+                JustificationInfo info;
+                if (counts.getSpaceCount() == 0) {
+                    info = justificationInfo(counts, toAdd, 1.0f, 0.0f);
+                } else if (!getParent().getStyle().isIdent(LETTER_SPACING, NORMAL)) {
+                    info = justificationInfo(counts, toAdd, 0.0f, 1.0f);
+                } else {
+                    info = justificationInfo(counts, toAdd, JUSTIFY_NON_SPACE_SHARE, JUSTIFY_SPACE_SHARE);
+                }
 
                 adjustChildren(info);
                 setJustificationInfo(info);

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DOutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DOutputDevice.java
@@ -119,9 +119,9 @@ public class Java2DOutputDevice extends AbstractOutputDevice<AWTFSImage, AWTFSFo
             String string = inlineText.getSubstring();
             float adjust = 0.0f;
             int end = Math.min(inlineText.getSelectionEnd(), vector.getNumGlyphs());
-            for (int i = inlineText.getSelectionStart(); i < end; i++) {
+            for (int i = 0; i < end; i++) {
                 char ch = string.charAt(i);
-                if (i != 0) {
+                if (i != 0 && i >= inlineText.getSelectionStart()) {
                     Point2D point = vector.getGlyphPosition(i);
                     vector.setGlyphPosition(
                             i, new Point2D.Double(point.getX() + adjust, point.getY()));

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DOutputDevice.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DOutputDevice.java
@@ -114,25 +114,26 @@ public class Java2DOutputDevice extends AbstractOutputDevice<AWTFSImage, AWTFSFo
         for (int i = inlineText.getSelectionEnd(); i < inlineText.getSubstring().length(); i++) {
             vector.setGlyphPosition(i, new Point2D.Float(-100000, -100000));
         }
-        if(inlineText.getParent().getStyle().isTextJustify()) {
-            JustificationInfo info = inlineText.getParent().getLineBox().getJustificationInfo();
-            if(info!=null) {
-                String string = inlineText.getSubstring();
-                float adjust = 0.0f;
-                for (int i = inlineText.getSelectionStart(); i < inlineText.getSelectionEnd(); i++) {
-                    char ch = string.charAt(i);
-                    if (i != 0) {
-                        Point2D point = vector.getGlyphPosition(i);
-                        vector.setGlyphPosition(
-                                i, new Point2D.Double(point.getX() + adjust, point.getY()));
-                    }
-                    if (ch == ' ' || ch == '\u00a0' || ch == '\u3000') {
-                        adjust += info.spaceAdjust();
-                    } else {
-                        adjust += info.nonSpaceAdjust();
-                    }
+        JustificationInfo info = justificationInfo(c, inlineText);
+        if (info != null) {
+            String string = inlineText.getSubstring();
+            float adjust = 0.0f;
+            int end = Math.min(inlineText.getSelectionEnd(), vector.getNumGlyphs());
+            for (int i = inlineText.getSelectionStart(); i < end; i++) {
+                char ch = string.charAt(i);
+                if (i != 0) {
+                    Point2D point = vector.getGlyphPosition(i);
+                    vector.setGlyphPosition(
+                            i, new Point2D.Double(point.getX() + adjust, point.getY()));
                 }
-
+                if (Character.isHighSurrogate(ch)) {
+                    continue;
+                }
+                if (ch == ' ' || ch == '\u00a0' || ch == '\u3000') {
+                    adjust += info.spaceAdjust();
+                } else {
+                    adjust += info.nonSpaceAdjust();
+                }
             }
         }
         c.getTextRenderer().drawGlyphVector(

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DTextRenderer.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/swing/Java2DTextRenderer.java
@@ -129,12 +129,17 @@ public class Java2DTextRenderer implements TextRenderer<Java2DOutputDevice, Java
     private void adjustGlyphPositions(
             String string, JustificationInfo info, GlyphVector vector) {
         float adjust = 0.0f;
-        for (int i = 0; i < string.length(); i++) {
+        for (int i = 0; i < string.length() && i < vector.getNumGlyphs(); i++) {
             char c = string.charAt(i);
             if (i != 0) {
                 Point2D point = vector.getGlyphPosition(i);
                 vector.setGlyphPosition(
                         i, new Point2D.Double(point.getX() + adjust, point.getY()));
+            }
+            // a supplementary character occupies two chars (and two glyph slots,
+            // the second invisible) but receives only one spacing adjustment
+            if (Character.isHighSurrogate(c)) {
+                continue;
             }
             if (c == ' ' || c == '\u00a0' || c == '\u3000') {
                 adjust += info.spaceAdjust();

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/simple/Graphics2DRendererTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/simple/Graphics2DRendererTest.java
@@ -33,6 +33,16 @@ public class Graphics2DRendererTest {
     }
 
     @Test
+    public void rendersLetterSpacedTextWithSupplementaryCharacters() {
+        URL source = requireNonNull(Thread.currentThread().getContextClassLoader().getResource("letter-spacing-astral.html"));
+
+        BufferedImage image = Graphics2DRenderer.renderToImage(source.toExternalForm(), 600, 200);
+
+        assertThat(image.getWidth()).isEqualTo(600);
+        assertThat(image.getHeight()).isEqualTo(200);
+    }
+
+    @Test
     public void rendersHtmlToImage_hamlet() throws IOException {
         URL source = requireNonNull(Thread.currentThread().getContextClassLoader().getResource("hamlet.xhtml"));
         File output = File.createTempFile("flying-saucer-" + getClass().getSimpleName(), ".png");

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/simple/Graphics2DRendererTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/simple/Graphics2DRendererTest.java
@@ -40,6 +40,19 @@ public class Graphics2DRendererTest {
 
         assertThat(image.getWidth()).isEqualTo(600);
         assertThat(image.getHeight()).isEqualTo(200);
+        assertThat(countInkPixels(image)).isGreaterThan(0);
+    }
+
+    private static long countInkPixels(BufferedImage image) {
+        long count = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if ((image.getRGB(x, y) & 0xFFFFFF) != 0xFFFFFF) {
+                    count++;
+                }
+            }
+        }
+        return count;
     }
 
     @Test

--- a/flying-saucer-core/src/test/resources/letter-spacing-astral.html
+++ b/flying-saucer-core/src/test/resources/letter-spacing-astral.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <title>letter-spacing with supplementary characters</title>

--- a/flying-saucer-core/src/test/resources/letter-spacing-astral.html
+++ b/flying-saucer-core/src/test/resources/letter-spacing-astral.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+    <title>letter-spacing with supplementary characters</title>
+</head>
+<body style="letter-spacing: 2px;">
+    <p>Hi &#128512;&#128512; there</p>
+</body>
+</html>

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -635,10 +635,11 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
     private PdfTextArray makeJustificationArray(String s, JustificationInfo info) {
         PdfTextArray array = new PdfTextArray();
         int len = s.length();
-        for (int i = 0; i < len; i++) {
+        for (int i = 0; i < len; ) {
             char c = s.charAt(i);
-            array.add(Character.toString(c));
-            if (i != len - 1) {
+            int end = s.offsetByCodePoints(i, 1);
+            array.add(s.substring(i, end));
+            if (end != len) {
                 float offset;
                 if (c == ' ' || c == '\u00a0' || c == '\u3000') {
                     offset = info.spaceAdjust();
@@ -647,6 +648,7 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
                 }
                 array.add((-offset / _dotsPerPoint) * 1000 / (_font.getSize2D() / _dotsPerPoint));
             }
+            i = end;
         }
         return array;
     }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LetterSpacingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LetterSpacingTest.java
@@ -51,10 +51,15 @@ class LetterSpacingTest {
 
     @Test
     void letterSpacingIsIncludedInLineBreaking() throws IOException {
-        // "aaa aaa" fits a 100px paragraph on one line, but with 12px of
-        // letter-spacing it must wrap: one text run for the plain paragraph
-        // plus two for the spaced one, each at its own vertical position
-        assertThat(baselines(pageContent(WRAPPED))).hasSize(3);
+        String content = pageContent(WRAPPED);
+
+        // the plain paragraph keeps "aaa aaa" on one line, drawn as a single string
+        assertThat(content).contains("(aaa aaa)Tj");
+
+        // the letter-spaced paragraph no longer fits 100px and wraps into two
+        // kerned runs ("aaa" / "aaa"), so the page has three distinct baselines
+        assertThat(content.split("]TJ", -1)).hasSize(3);
+        assertThat(baselines(content)).hasSize(3);
     }
 
     private static byte[] render(String resource) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LetterSpacingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/LetterSpacingTest.java
@@ -1,0 +1,83 @@
+package org.xhtmlrenderer.pdf;
+
+import com.codeborne.pdftest.PDF;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.within;
+import static org.xhtmlrenderer.pdf.TestUtils.pageContent;
+import static org.xhtmlrenderer.pdf.TestUtils.printFile;
+
+/**
+ * The {@code letter-spacing} property should both widen the layout (line breaking)
+ * and space out the glyphs actually painted to the page.
+ *
+ * See <a href="https://github.com/flyingsaucerproject/flyingsaucer/issues/356">issue #356</a>.
+ */
+class LetterSpacingTest {
+    private static final Logger log = LoggerFactory.getLogger(LetterSpacingTest.class);
+
+    private static final byte[] SPACED = render("letter-spacing.html");
+    private static final byte[] WRAPPED = render("letter-spacing-wrap.html");
+
+    @Test
+    void positiveLetterSpacingSpacesOutGlyphs() throws IOException {
+        // 0.25em of extra spacing is 250/1000 of the em square, drawn as a
+        // TJ kerning array: [(W) -250 (i) -250 (d) -250 (e)] TJ
+        assertThat(kernBetween(pageContent(SPACED), 'W', 'i')).isCloseTo(-250.0f, within(0.5f));
+    }
+
+    @Test
+    void negativeLetterSpacingTightensGlyphs() throws IOException {
+        // -1px at font-size 12px is -83.3/1000 of the em square; positive
+        // TJ adjustments move the following glyph closer
+        assertThat(kernBetween(pageContent(SPACED), 'T', 'i')).isCloseTo(250.0f / 3, within(0.5f));
+    }
+
+    @Test
+    void normalLetterSpacingDrawsPlainStrings() throws IOException {
+        assertThat(new PDF(SPACED)).containsText("Hello");
+        assertThat(pageContent(SPACED)).contains("(Hello)Tj");
+    }
+
+    @Test
+    void letterSpacingIsIncludedInLineBreaking() throws IOException {
+        // "aaa aaa" fits a 100px paragraph on one line, but with 12px of
+        // letter-spacing it must wrap: one text run for the plain paragraph
+        // plus two for the spaced one, each at its own vertical position
+        assertThat(baselines(pageContent(WRAPPED))).hasSize(3);
+    }
+
+    private static byte[] render(String resource) {
+        try {
+            byte[] bytes = Html2Pdf.fromClasspathResource(resource);
+            printFile(log, bytes, resource.replace(".html", ".pdf"));
+            return bytes;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to render " + resource, e);
+        }
+    }
+
+    private static float kernBetween(String content, char first, char second) {
+        Matcher matcher = Pattern.compile("\\(%s\\)\\s*(-?[0-9.]+)\\s*\\(%s\\)".formatted(first, second)).matcher(content);
+        assertThat(matcher.find())
+                .as("expected a TJ kerning adjustment between (%s) and (%s) in:%n%s", first, second, content)
+                .isTrue();
+        return Float.parseFloat(matcher.group(1));
+    }
+
+    private static Set<String> baselines(String content) {
+        return Pattern.compile("1 0 0 1 [0-9.]+ ([0-9.]+) Tm").matcher(content).results()
+                .map(match -> match.group(1))
+                .collect(toSet());
+    }
+}

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TestUtils.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TestUtils.java
@@ -1,17 +1,21 @@
 package org.xhtmlrenderer.pdf;
 
 import com.codeborne.pdftest.PDF;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDResources;
+import org.openpdf.text.pdf.PdfReader;
 import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
 public class TestUtils {
+    @CanIgnoreReturnValue
     public static PDF printFile(Logger log, byte[] pdf, String filename) throws IOException {
         File file = new File("target", filename);
         try (FileOutputStream o = new FileOutputStream(file)) {
@@ -19,6 +23,12 @@ public class TestUtils {
         }
         log.info("Generated PDF: {}", file.getAbsolutePath());
         return new PDF(pdf);
+    }
+
+    public static String pageContent(byte[] pdf) throws IOException {
+        try (PdfReader reader = new PdfReader(pdf)) {
+            return new String(reader.getPageContent(1), StandardCharsets.ISO_8859_1);
+        }
     }
 
     public static List<String> getFontNames(PDResources res) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/TransformTest.java
@@ -2,14 +2,13 @@ package org.xhtmlrenderer.pdf;
 
 import com.codeborne.pdftest.PDF;
 import org.junit.jupiter.api.Test;
-import org.openpdf.text.pdf.PdfReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static com.codeborne.pdftest.assertj.Assertions.assertThat;
+import static org.xhtmlrenderer.pdf.TestUtils.pageContent;
 import static org.xhtmlrenderer.pdf.TestUtils.printFile;
 
 class TransformTest {
@@ -22,14 +21,12 @@ class TransformTest {
 
         assertThat(pdf).containsText("Not transformed", "Rotated");
 
-        try (PdfReader reader = new PdfReader(bytes)) {
-            String content = new String(reader.getPageContent(1), StandardCharsets.ISO_8859_1);
+        String content = pageContent(bytes);
 
-            // The rotated box's text is drawn with a 45-degree rotation baked into its text matrix
-            // (cos45 = sin45 = 0.70711), while the untransformed box uses the identity "1 0 0 1 ... Tm".
-            assertThat(content).contains("1 0 0 1 42 789.11 Tm");
-            assertThat(content).containsPattern("0\\.70711 -0\\.70711 0\\.70711 0\\.70711 [0-9.]+ [0-9.]+ Tm");
-        }
+        // The rotated box's text is drawn with a 45-degree rotation baked into its text matrix
+        // (cos45 = sin45 = 0.70711), while the untransformed box uses the identity "1 0 0 1 ... Tm".
+        assertThat(content).contains("1 0 0 1 42 789.11 Tm");
+        assertThat(content).containsPattern("0\\.70711 -0\\.70711 0\\.70711 0\\.70711 [0-9.]+ [0-9.]+ Tm");
     }
 
     @Test
@@ -39,13 +36,9 @@ class TransformTest {
 
         assertThat(pdf).containsText("absolute");
 
-        try (PdfReader reader = new PdfReader(bytes)) {
-            String content = new String(reader.getPageContent(1), StandardCharsets.ISO_8859_1);
-
-            // The "position: absolute" descendant establishes its own layer; unless that layer is
-            // painted as part of its transformed ancestor's stacking context, this text would be drawn
-            // with the identity matrix instead of a 90-degree rotation (cos90=0, sin90=1).
-            assertThat(content).containsPattern("0 -1 1 0 [0-9.]+ [0-9.]+ Tm");
-        }
+        // The "position: absolute" descendant establishes its own layer; unless that layer is
+        // painted as part of its transformed ancestor's stacking context, this text would be drawn
+        // with the identity matrix instead of a 90-degree rotation (cos90=0, sin90=1).
+        assertThat(pageContent(bytes)).containsPattern("0 -1 1 0 [0-9.]+ [0-9.]+ Tm");
     }
 }

--- a/flying-saucer-pdf/src/test/resources/letter-spacing-wrap.html
+++ b/flying-saucer-pdf/src/test/resources/letter-spacing-wrap.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <title>letter-spacing wrap</title>

--- a/flying-saucer-pdf/src/test/resources/letter-spacing-wrap.html
+++ b/flying-saucer-pdf/src/test/resources/letter-spacing-wrap.html
@@ -1,0 +1,13 @@
+<html lang="en">
+<head>
+    <title>letter-spacing wrap</title>
+    <style>
+        p { width: 100px; font-size: 12px; }
+        .spaced { letter-spacing: 12px; }
+    </style>
+</head>
+<body>
+    <p>aaa aaa</p>
+    <p class="spaced">aaa aaa</p>
+</body>
+</html>

--- a/flying-saucer-pdf/src/test/resources/letter-spacing.html
+++ b/flying-saucer-pdf/src/test/resources/letter-spacing.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <title>letter-spacing</title>

--- a/flying-saucer-pdf/src/test/resources/letter-spacing.html
+++ b/flying-saucer-pdf/src/test/resources/letter-spacing.html
@@ -1,0 +1,15 @@
+<html lang="en">
+<head>
+    <title>letter-spacing</title>
+    <style>
+        body { font-size: 12px; }
+        .wide { letter-spacing: 0.25em; }
+        .tight { letter-spacing: -1px; }
+    </style>
+</head>
+<body>
+    <p>Hello</p>
+    <p class="wide">Wide</p>
+    <p class="tight">Tight</p>
+</body>
+</html>

--- a/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTTextRenderer.java
+++ b/flying-saucer-swt/src/main/java/org/xhtmlrenderer/swt/SWTTextRenderer.java
@@ -102,8 +102,21 @@ public final class SWTTextRenderer implements TextRenderer<SWTOutputDevice, SWTF
     @Override
     public void drawString(SWTOutputDevice outputDevice, String string, float x, float y,
             JustificationInfo info) {
-        // TODO handle justification
-        drawString(outputDevice, string, x, y);
+        GC gc = outputDevice.getGC();
+        float xc = x;
+        for (int i = 0; i < string.length(); ) {
+            char c = string.charAt(i);
+            int end = string.offsetByCodePoints(i, 1);
+            String character = string.substring(i, end);
+            drawString(outputDevice, character, xc, y);
+            xc += gc.stringExtent(character).x;
+            if (c == ' ' || c == '\u00a0' || c == '\u3000') {
+                xc += info.spaceAdjust();
+            } else {
+                xc += info.nonSpaceAdjust();
+            }
+            i = end;
+        }
     }
 
     @Override


### PR DESCRIPTION
Hey there!

We use this library at @lightyeardev. So first, thank you for creating and maintaining it!

So, what is this PR? It adds letter-spacing support. 

We updated our font last year, which has super tight default letter spacing, and our statements are a bit unreadable in places - so this has been on the menu for a while.

Claude goes into more detail below. Awaiting your thoughts and ideas.

## Summary

Implements the `letter-spacing` CSS property, which has been parsed but never applied at layout or paint time (fixes #356).

### Approach

The property was already parsed (`PrimitivePropertyBuilders.LetterSpacing`) and even partially anticipated by `LineBox.justify()`, but no code ever resolved or applied it. This PR threads it through both halves of the pipeline:

**Measurement** — `CalculatedStyle.letterSpacing(ctx)` resolves the property to dots (`0` for `normal`, cached like line-height). A new `TextUtil.textWidth(c, style, font, text)` adds one spacing increment per code point on top of `TextRenderer.getWidth(...)`, and every inline-text measurement site now goes through it: line breaking (`Breaker`), trailing-space trims and dynamic functions (`InlineText`), intrinsic min/max widths (`InlineBox`), and `leader()` width computation (`ContentFunctionFactory`). The spacing contribution is rounded up so a width accumulated from substring measurements (the breaker's fit loop) never exceeds the recorded width of the whole run.

**Paint** — `AbstractOutputDevice.drawText` folds the resolved spacing into the `JustificationInfo` it already passes to text renderers, so every output device reuses the existing per-character adjustment machinery. No `TextRenderer`/`OutputDevice` SPI changes.

To collapse what would otherwise be duplicate overloads, `CssContext` gains `getTextRenderer()`/`getFontContext()` — both existing implementations already provided them, and the interface itself carried a FIXME about being "the only common interface of LayoutContext and RenderingContext".

### Fixes to adjacent code this newly exercises

Letter-spacing routes ordinary (non-justified) text through the justification paint paths, which surfaced a few latent issues that are fixed here because they'd otherwise become reachable regressions:

- `ITextOutputDevice.makeJustificationArray` split text per UTF-16 char, breaking surrogate pairs (emoji, CJK extensions) into lone surrogates in the TJ array. It now groups by code point.
- The Java2D glyph-adjustment loops added one spacing increment per UTF-16 unit; supplementary characters now receive exactly one increment (Java2D glyph vectors keep one glyph slot per char, so indexing stays char-based).
- `SWTTextRenderer.drawString(..., JustificationInfo)` dropped the info entirely ("TODO handle justification"); it now draws per code point with the adjustments applied, keeping SWT paint consistent with the shared (now spacing-aware) layout. I could not exercise SWT visually — review of this hunk appreciated.
- Swing selection repaint (`Java2DOutputDevice.drawSelectedText`) applied only line justification; it now uses the same composed adjustments as normal painting.
- `LineBox.justify()`'s space-only distribution (taken when letter-spacing is set) divided by `spaceCount` without a guard; a justified line with no spaces produced `Infinity` adjustments. It now falls back to the standard distribution.
- `pre`/`pre-wrap` line measurement included the invisible trailing newline, which would have received a spacing increment.

### Semantics

Spacing is applied after every character including the last (classic browser behaviour, matching Chrome/Firefox box widths), once per code point. `letter-spacing: normal` resolves to `0` and takes the exact pre-existing code paths — a no-op by construction.

Known limitations, kept out of scope deliberately: list markers measure *and* paint without spacing (self-consistent, but a marker won't match spaced item content), and Swing selection *hit-testing* still uses natural glyph positions (repaint is consistent; click targets drift slightly on spaced text).

### Testing

- `LetterSpacingTest` (flying-saucer-pdf) asserts exact TJ kern values in the content stream — `0.25em` → `-250`/1000 em, `-1px` at 12px → `+83.33` — that `normal` still produces plain `(text)Tj`, and that spacing participates in line breaking.
- `Graphics2DRendererTest` gains a Java2D render of letter-spaced text containing supplementary characters.
- Full `flying-saucer-core` (241) and `flying-saucer-pdf` (75) suites pass.
- Validated against a production corpus: 21 real-world PDF templates (invoices, statements, regulatory forms with embedded TTFs via Identity-H) rendered on stock vs. patched builds and pixel-diffed — every visual change traces to a declared `letter-spacing` value taking effect, templates declaring only `letter-spacing: 0` render pixel-identical, and no line wraps changed.

---
_Generated by [Claude Code](https://claude.ai/code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded CSS `letter-spacing` support across screen, PDF, and SWT rendering.
  * Improved text wrapping, justification, and spacing for supplementary Unicode characters.

* **Bug Fixes**
  * Corrected selection and text justification behavior, including lines without spaces.
  * Improved glyph positioning and prevented spacing issues with surrogate pairs.

* **Tests**
  * Added rendering and PDF coverage for positive, negative, and wrapping `letter-spacing` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->