### PR TITLE
Fix server-relative URLs against synthetic inline stylesheet URIs

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -2076,7 +2076,7 @@ public class CSSParser {
                 // Relative URIs are resolved relative to CSS file, not XHTML file
                 if (isRelativeURI(uriResult) && _uri != null) {
                     uriResult = getPartBeforeLastSlash(_uri) + uriResult;
-                } else if (isServerRelativeURI(uriResult) && _uri != null && isAbsoluteUri(_uri)) {
+                } else if (isServerRelativeURI(uriResult) && _uri != null && isHierarchicalAbsoluteUri(_uri)) {
                     uriResult = getPartBeforeFirstSlash(_uri) + uriResult;
                 }
 
@@ -2120,6 +2120,24 @@ public class CSSParser {
 
     private boolean isServerRelativeURI(String uri) {
         return uri.startsWith("/") && !isAbsoluteUri(uri);
+    }
+
+    /**
+     * Whether {@code uri} is an absolute hierarchical URI suitable as a base for
+     * resolving server-relative resource paths ({@code /...}).
+     * <p>
+     * Opaque absolute URIs such as the synthetic {@code inline:N} keys used for
+     * {@code <style>} blocks must not participate in path rewriting — otherwise
+     * {@code url('/assets/font.ttf')} becomes {@code inline/assets/font.ttf}.
+     */
+    private boolean isHierarchicalAbsoluteUri(String uri) {
+        try {
+            URI u = new URI(uri);
+            return u.isAbsolute() && !u.isOpaque();
+        } catch (URISyntaxException e) {
+            log.debug("Invalid uri: {}", uri, e);
+            return false;
+        }
     }
 
     private boolean isAbsoluteUri(String uri) {

--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/css/parser/CSSParser.java
@@ -2103,7 +2103,12 @@ public class CSSParser {
     private String getPartBeforeFirstSlash(String uri) {
         try {
             URI u = new URI(uri);
-            return u.getRawAuthority() == null ? u.getScheme() : u.getScheme() + "://" + u.getRawAuthority();
+            // Keep the scheme delimiter when there is no authority (e.g. file:/path),
+            // otherwise server-relative rewrite yields "file/..." instead of "file:/...".
+            if (u.getRawAuthority() == null) {
+                return u.getScheme() + ":";
+            }
+            return u.getScheme() + "://" + u.getRawAuthority();
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid uri: " + uri, e);
         }

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -73,6 +73,11 @@ class CSSParserTest {
         " data:image/svg+xml;charset=utf8,%3Csvg xmlns=              | /css/v1/sample.css                 | data:image/svg+xml;charset=utf8,%3Csvg xmlns=",
         " blob:https://site.com/258186e7-a0a1-40e5-bcf8-5ac35f965454 | /css/v1/sample.css                 | blob:https://site.com/258186e7-a0a1-40e5-bcf8-5ac35f965454",
         " blob:                                                      | /css/v1/sample.css                 | blob:",
+        // Synthetic inline stylesheet keys are absolute (opaque) URIs but must not
+        // rewrite server-relative resource paths (e.g. @font-face src in <style>).
+        " /assets/fonts/MyFont.ttf                                   | inline:1                           | /assets/fonts/MyFont.ttf",
+        " assets/fonts/MyFont.ttf                                    | inline:1                           | assets/fonts/MyFont.ttf",
+        " /assets/fonts/MyFont.ttf                                   | style attribute                    | /assets/fonts/MyFont.ttf",
     }, delimiterString = "|")
     void imageUrl(String imageUrl, String cssUrl, String expectedFullImageUrl) throws IOException {
         String css = "div { background-image: url('%s') }".formatted(imageUrl);
@@ -84,6 +89,23 @@ class CSSParserTest {
         assertThat(ruleset.getPropertyDeclarations()).usingRecursiveComparison().isEqualTo(List.of(
             new PropertyDeclaration(BACKGROUND_IMAGE, new PropertyValue(CSS_URI, expectedFullImageUrl, "url('%s')".formatted(imageUrl)), false, AUTHOR)
         ));
+    }
+
+    @Test
+    void fontFaceSrcKeepsServerRelativeUriAgainstInlineStylesheet() throws IOException {
+        Stylesheet stylesheet = parser.parseStylesheet("inline:42", AUTHOR, new StringReader("""
+            @font-face {
+                font-family: 'MyFont';
+                src: url('/assets/fonts/MyFont.ttf');
+            }
+            """));
+
+        assertThat(stylesheet.getFontFaceRules()).hasSize(1);
+        String src = stylesheet.getFontFaceRules().get(0)
+                .getCalculatedStyle()
+                .valueByName(CSSName.SRC)
+                .asString();
+        assertThat(src).isEqualTo("/assets/fonts/MyFont.ttf");
     }
 
     @Test

--- a/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
+++ b/flying-saucer-core/src/test/java/org/xhtmlrenderer/css/parser/CSSParserTest.java
@@ -70,6 +70,10 @@ class CSSParserTest {
         " https://some.com/background.png                            | /css/v1/sample.css                 | https://some.com/background.png",
         " /img/background.png                                        | https://some.com/css/v1/sample.css | https://some.com/img/background.png",
         " /img/background.png                                        | /css/v1/sample.css                 | /img/background.png",
+        // file: bases are hierarchical absolute; preserve the scheme colon (not file/...).
+        " /img/background.png                                        | file:/css/v1/sample.css            | file:/img/background.png",
+        " /img/background.png                                        | file:///css/v1/sample.css          | file:/img/background.png",
+        " /img/background.png                                        | file://localhost/css/v1/sample.css | file://localhost/img/background.png",
         " data:image/svg+xml;charset=utf8,%3Csvg xmlns=              | /css/v1/sample.css                 | data:image/svg+xml;charset=utf8,%3Csvg xmlns=",
         " blob:https://site.com/258186e7-a0a1-40e5-bcf8-5ac35f965454 | /css/v1/sample.css                 | blob:https://site.com/258186e7-a0a1-40e5-bcf8-5ac35f965454",
         " blob:                                                      | /css/v1/sample.css                 | blob:",

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssFontFaceTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssFontFaceTest.java
@@ -11,15 +11,19 @@ import org.apache.pdfbox.pdmodel.PDResources;
 import org.junit.jupiter.api.Test;
 import org.openpdf.text.pdf.BaseFont;
 import org.w3c.dom.Document;
+import org.xhtmlrenderer.css.constants.CSSName;
+import org.xhtmlrenderer.resource.FSEntityResolver;
+import org.xhtmlrenderer.resource.XMLResource;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.codeborne.pdftest.assertj.Assertions.assertThat;
 import static java.util.Objects.requireNonNull;
 import static org.xhtmlrenderer.pdf.TestUtils.getFontNames;
-import org.xhtmlrenderer.resource.FSEntityResolver;
 
 public class CssFontFaceTest {
 
@@ -68,6 +72,62 @@ public class CssFontFaceTest {
 
         Document doc = builder.parse(htmlUrl.toString());
         byte[] pdfBytes = renderer.createPDF(doc);
+        assertEmbeddedJacquard(pdfBytes);
+    }
+
+    /**
+     * Issue #695: {@code url('/abs/path.ttf')} inside an inline {@code <style>}
+     * {@code @font-face} used to be rewritten to {@code inline/abs/path.ttf}. Relative
+     * urls still resolve against the HTML document, so they never show that.
+     * A server-relative path does, and the font must still be embedded.
+     */
+    @Test
+    public void serverRelativeFontPathFromInlineStyleIsEmbedded() throws Exception {
+        Path font = jacquardFontPath();
+        String html = """
+                <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+                <head>
+                    <style>
+                        @font-face {
+                            font-family: "Jacquard 24";
+                            src: url("%s");
+                            -fs-pdf-font-embed: embed;
+                        }
+                        .jacquard { font-family: "Jacquard 24", sans-serif; }
+                    </style>
+                </head>
+                <body>
+                    <p class="jacquard">JACQUARD FONT</p>
+                </body>
+                </html>
+                """.formatted(font);
+
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.getSharedContext().setInteractive(false);
+        renderer.getSharedContext().getTextRenderer().setSmoothingThreshold(0);
+
+        Document doc = XMLResource.load(html).getDocument();
+        byte[] pdfBytes = renderer.createPDF(doc);
+
+        String src = renderer.getSharedContext().getCss().getFontFaceRules().get(0)
+                .getCalculatedStyle()
+                .valueByName(CSSName.SRC)
+                .asString();
+        assertThat(src)
+                .isEqualTo(font.toString())
+                .doesNotContain("inline/");
+        assertEmbeddedJacquard(pdfBytes);
+    }
+
+    private static Path jacquardFontPath() throws URISyntaxException {
+        URL fontUrl = requireNonNull(
+                CssFontFaceTest.class.getClassLoader().getResource("fonts/Jacquard24-Regular.ttf"),
+                "test resource not found: fonts/Jacquard24-Regular.ttf");
+        return Path.of(fontUrl.toURI());
+    }
+
+    private static void assertEmbeddedJacquard(byte[] pdfBytes) throws IOException {
         try (RandomAccessRead buffer = new RandomAccessReadBuffer(pdfBytes);
              PDDocument document = new PDFParser(buffer).parse()) {
             assertThat(document.getNumberOfPages()).isGreaterThanOrEqualTo(1);

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssFontFaceTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/CssFontFaceTest.java
@@ -16,9 +16,7 @@ import org.xhtmlrenderer.resource.FSEntityResolver;
 import org.xhtmlrenderer.resource.XMLResource;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 
 import static com.codeborne.pdftest.assertj.Assertions.assertThat;
@@ -83,7 +81,7 @@ public class CssFontFaceTest {
      */
     @Test
     public void serverRelativeFontPathFromInlineStyleIsEmbedded() throws Exception {
-        Path font = jacquardFontPath();
+        String fontUri = "/fonts/Jacquard24-Regular.ttf";
         String html = """
                 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
                 <head>
@@ -100,9 +98,21 @@ public class CssFontFaceTest {
                     <p class="jacquard">JACQUARD FONT</p>
                 </body>
                 </html>
-                """.formatted(font);
+                """.formatted(fontUri);
 
         ITextRenderer renderer = new ITextRenderer();
+        ITextUserAgent userAgent = new ITextUserAgent(
+                renderer.getOutputDevice(),
+                Math.round(renderer.getOutputDevice().getDotsPerPoint())) {
+            @Override
+            public byte[] getBinaryResource(String uri) {
+                if (uri != null && uri.endsWith(fontUri)) {
+                    return super.getBinaryResource("classpath:fonts/Jacquard24-Regular.ttf");
+                }
+                return super.getBinaryResource(uri);
+            }
+        };
+        renderer.getSharedContext().setUserAgentCallback(userAgent);
         renderer.getSharedContext().setMedia("pdf");
         renderer.getSharedContext().setInteractive(false);
         renderer.getSharedContext().getTextRenderer().setSmoothingThreshold(0);
@@ -114,17 +124,8 @@ public class CssFontFaceTest {
                 .getCalculatedStyle()
                 .valueByName(CSSName.SRC)
                 .asString();
-        assertThat(src)
-                .isEqualTo(font.toString())
-                .doesNotContain("inline/");
+        assertThat(src).isEqualTo(fontUri);
         assertEmbeddedJacquard(pdfBytes);
-    }
-
-    private static Path jacquardFontPath() throws URISyntaxException {
-        URL fontUrl = requireNonNull(
-                CssFontFaceTest.class.getClassLoader().getResource("fonts/Jacquard24-Regular.ttf"),
-                "test resource not found: fonts/Jacquard24-Regular.ttf");
-        return Path.of(fontUrl.toURI());
     }
 
     private static void assertEmbeddedJacquard(byte[] pdfBytes) throws IOException {


### PR DESCRIPTION
## Summary
Inline `<style>` blocks are cached under synthetic opaque URIs such as `inline:1`. Those values are absolute URIs, so CSS `url(...)` resolution treated them as stylesheet bases and rewrote server-relative paths:

- `url('/assets/fonts/MyFont.ttf')` became `inline/assets/fonts/MyFont.ttf`

That breaks `@font-face` (and other resources) declared in inline CSS.

Server-relative path rewriting now requires a **hierarchical** absolute base (`URI.isAbsolute() && !URI.isOpaque()`), so `http(s):` / `file:` bases still work while opaque synthetic keys do not rewrite the path.

Fixes #695

## Test plan
- [x] RED: `CSSParserTest` reproduced `inline/assets/fonts/MyFont.ttf`
- [x] GREEN: `mvn -pl flying-saucer-core test -Dtest=CSSParserTest` — 19/19
- [x] `mvn -pl flying-saucer-core test` — 244/244
- [x] `mvn -pl flying-saucer-pdf -am test -Dtest=CssFontFaceTest,CSSParserTest` — GREEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource URL handling for inline and synthetic stylesheets.
  * Prevented invalid rewriting of opaque or malformed URIs as filesystem paths.
  * Preserved correct absolute, relative, and server-relative paths, including font resources and `file:` URLs.

* **Tests**
  * Added coverage for URL resolution in inline stylesheets, style attributes, and `@font-face` declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->