### PR TITLE
Add PDF/A-1b conformance support

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextFontResolver.java
@@ -140,6 +140,22 @@ public class ITextFontResolver implements FontResolver {
         }
     }
 
+    /**
+     * Names of {@code @font-face} families that were registered without embedding (see
+     * {@code -fs-pdf-font-embed}). PDF/A requires every font used in the document to be embedded, so
+     * callers requesting PDF/A conformance should ensure this returns an empty list before generating
+     * the PDF.
+     */
+    public List<String> getNonEmbeddedFontFaceFamilies() {
+        return getFonts().values().stream()
+                .flatMap(family -> family.getFontDescriptions().stream())
+                .filter(FontDescription::isFromFontFace)
+                .filter(description -> !description.getFont().isEmbedded())
+                .map(description -> description.getFont().getPostscriptFontName())
+                .distinct()
+                .toList();
+    }
+
     public void addEmbedFontFace(String fontFamily, String encoding) {
         _embedFontFaces.put(fontFamily, encoding);
     }

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -58,6 +58,8 @@ import javax.xml.transform.stream.StreamResult;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -128,6 +130,9 @@ public class ITextRenderer {
 
     @Nullable
     private Integer _pdfXConformance;
+
+    @Nullable
+    private PdfAConformance _pdfAConformance;
 
     @Nullable
     private PDFCreationListener _listener;
@@ -282,6 +287,24 @@ public class ITextRenderer {
         return _pdfXConformance == null ? '0' : _pdfXConformance;
     }
 
+    /**
+     * Requests PDF/A conformance for the generated document: registers an sRGB ICC output intent and
+     * document-level XMP metadata in addition to setting the underlying PDF/X conformance flag. See
+     * {@link PdfAConformance} for the font-embedding caveat that this setting cannot enforce on its own.
+     * <p>
+     * PDF/A forbids encryption, so combining this with {@link #setPDFEncryption(PDFEncryption)} will fail
+     * at {@link #createPDF(OutputStream)} time.
+     */
+    public void setPdfAConformance(@Nullable PdfAConformance pdfAConformance) {
+        _pdfAConformance = pdfAConformance;
+        _pdfXConformance = pdfAConformance == null ? null : pdfAConformance.pdfXConformance();
+    }
+
+    @Nullable
+    public PdfAConformance getPdfAConformance() {
+        return _pdfAConformance;
+    }
+
     public void layout() {
         LayoutContext c = newLayoutContext();
         BlockBox root = BoxBuilder.createRootBox(c, _doc);
@@ -358,8 +381,7 @@ public class ITextRenderer {
 
     public void finishPDF() {
         if (_pdfDoc != null) {
-            fireOnClose();
-            _pdfDoc.close();
+            closeDocument(_pdfDoc, _writer);
         }
     }
 
@@ -403,6 +425,17 @@ public class ITextRenderer {
             writer.setPDFXConformance(_pdfXConformance);
         }
 
+        if (_pdfAConformance != null) {
+            if (_pdfEncryption != null) {
+                throw new IllegalStateException("PDF/A conformance and PDF encryption are mutually exclusive");
+            }
+            List<String> nonEmbeddedFonts = getFontResolver().getNonEmbeddedFontFaceFamilies();
+            if (!nonEmbeddedFonts.isEmpty()) {
+                throw new IllegalStateException(
+                        "PDF/A conformance requires all fonts to be embedded; not embedded: " + nonEmbeddedFonts);
+            }
+        }
+
         if (pdfPageEvent != null) {
             writer.setPageEvent(pdfPageEvent);
         }
@@ -417,12 +450,32 @@ public class ITextRenderer {
         firePreOpen();
         doc.open();
 
+        if (_pdfAConformance != null) {
+            setOutputIntent(writer);
+        }
+
         writePDF(pages, c, firstPageSize, doc, writer);
 
         if (finish) {
-            fireOnClose();
-            doc.close();
+            closeDocument(doc, writer);
         }
+    }
+
+    private static void setOutputIntent(PdfWriter writer) {
+        try {
+            ICC_Profile srgb = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+            writer.setOutputIntents("", "sRGB IEC61966-2.1", "http://www.color.org", "sRGB IEC61966-2.1", srgb);
+        } catch (IOException e) {
+            throw new DocumentException(e);
+        }
+    }
+
+    private void closeDocument(org.openpdf.text.Document doc, @Nullable PdfWriter writer) {
+        if (_pdfAConformance != null && writer != null) {
+            writer.createXmpMetadata();
+        }
+        fireOnClose();
+        doc.close();
     }
 
     private void firePreOpen() {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -297,7 +297,6 @@ public class ITextRenderer {
      */
     public void setPdfAConformance(@Nullable PdfAConformance pdfAConformance) {
         _pdfAConformance = pdfAConformance;
-        _pdfXConformance = pdfAConformance == null ? null : pdfAConformance.pdfXConformance();
     }
 
     @Nullable
@@ -417,12 +416,19 @@ public class ITextRenderer {
         info.put(PdfName.CREATOR, new PdfString(pdfCreator));
 
         if (compressionEnabled) {
-            writer.setFullCompression();
             writer.setCompressionLevel(compression);
+            // Object/cross-reference streams are a PDF 1.5+ feature; PDF/A-1 is pinned to PDF 1.4 and forbids them.
+            if (_pdfAConformance != PdfAConformance.PDF_A_1B) {
+                writer.setFullCompression();
+            }
         }
 
-        if (_pdfXConformance != null) {
-            writer.setPDFXConformance(_pdfXConformance);
+        Integer effectiveXConformance = _pdfXConformance;
+        if (_pdfAConformance != null) {
+            effectiveXConformance = _pdfAConformance.pdfXConformance();
+        }
+        if (effectiveXConformance != null) {
+            writer.setPDFXConformance(effectiveXConformance);
         }
 
         if (_pdfAConformance != null) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/PdfAConformance.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/PdfAConformance.java
@@ -1,0 +1,26 @@
+package org.xhtmlrenderer.pdf;
+
+import org.openpdf.text.pdf.PdfWriter;
+
+/**
+ * PDF/A conformance levels supported by {@link ITextRenderer#setPdfAConformance(PdfAConformance)}.
+ * <p>
+ * Note that PDF/A conformance also requires every font used in the document to be embedded. The
+ * built-in base-14 fonts (Helvetica, Times, Courier, Symbol, ZapfDingbats) can never be embedded by
+ * OpenPDF, so a document that falls back to one of them cannot be PDF/A conformant regardless of this
+ * setting.
+ */
+public enum PdfAConformance {
+    PDF_A_1B(PdfWriter.PDFA1B),
+    PDF_A_3B(PdfWriter.PDFA3B);
+
+    private final int pdfXConformance;
+
+    PdfAConformance(int pdfXConformance) {
+        this.pdfXConformance = pdfXConformance;
+    }
+
+    int pdfXConformance() {
+        return pdfXConformance;
+    }
+}

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextRendererTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextRendererTest.java
@@ -1,6 +1,7 @@
 package org.xhtmlrenderer.pdf;
 
 import org.junit.jupiter.api.Test;
+import org.openpdf.text.pdf.PdfWriter;
 
 import java.io.ByteArrayOutputStream;
 
@@ -24,7 +25,6 @@ class ITextRendererTest {
     void getAndSetPdfAConformance() {
         cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
         assertThat(cut.getPdfAConformance()).isEqualTo(PdfAConformance.PDF_A_1B);
-        assertThat(cut.getPDFXConformance()).isEqualTo(PdfAConformance.PDF_A_1B.pdfXConformance());
     }
 
     @Test
@@ -32,6 +32,17 @@ class ITextRendererTest {
         cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
         cut.setPdfAConformance(null);
         assertThat(cut.getPdfAConformance()).isNull();
+    }
+
+    @Test
+    void settingOrClearingPdfAConformanceDoesNotAffectPdfXConformance() {
+        cut.setPDFXConformance(PdfWriter.PDFX1A2001);
+
+        cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        assertThat(cut.getPDFXConformance()).isEqualTo(PdfWriter.PDFX1A2001);
+
+        cut.setPdfAConformance(null);
+        assertThat(cut.getPDFXConformance()).isEqualTo(PdfWriter.PDFX1A2001);
     }
 
     @Test

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextRendererTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/ITextRendererTest.java
@@ -2,6 +2,8 @@ package org.xhtmlrenderer.pdf;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -11,6 +13,37 @@ class ITextRendererTest {
     @Test
     void versionIsNullByDefault() {
         assertThat(cut.getPDFVersion()).isNull();
+    }
+
+    @Test
+    void pdfAConformanceIsNullByDefault() {
+        assertThat(cut.getPdfAConformance()).isNull();
+    }
+
+    @Test
+    void getAndSetPdfAConformance() {
+        cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        assertThat(cut.getPdfAConformance()).isEqualTo(PdfAConformance.PDF_A_1B);
+        assertThat(cut.getPDFXConformance()).isEqualTo(PdfAConformance.PDF_A_1B.pdfXConformance());
+    }
+
+    @Test
+    void canClearPdfAConformance() {
+        cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        cut.setPdfAConformance(null);
+        assertThat(cut.getPdfAConformance()).isNull();
+    }
+
+    @Test
+    void pdfAConformanceAndEncryptionAreMutuallyExclusive() {
+        cut.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        cut.setPDFEncryption(new PDFEncryption("user".getBytes(), "owner".getBytes()));
+        cut.setDocumentFromString("<html><body>Hello</body></html>");
+        cut.layout();
+
+        assertThatThrownBy(() -> cut.createPDF(new ByteArrayOutputStream()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("PDF/A conformance and PDF encryption are mutually exclusive");
     }
 
     @Test

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfAConformanceTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfAConformanceTest.java
@@ -49,6 +49,9 @@ class PdfAConformanceTest {
              PDDocument document = new PDFParser(buffer).parse()) {
             assertThat(document.isEncrypted()).isFalse();
 
+            // PDF/A-1 is pinned to PDF 1.4 and forbids cross-reference/object streams (a PDF 1.5+ feature).
+            assertThat(document.getDocument().isXRefStream()).isFalse();
+
             PDDocumentCatalog catalog = document.getDocumentCatalog();
             assertThat(catalog.getOutputIntents()).isNotEmpty();
 

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfAConformanceTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfAConformanceTest.java
@@ -1,0 +1,82 @@
+package org.xhtmlrenderer.pdf;
+
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
+import org.apache.pdfbox.pdfparser.PDFParser;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PdfAConformanceTest {
+
+    /**
+     * Every character painted must come from the embedded "Jacquard 24" font - falling back to any
+     * base-14 font (e.g. via an unstyled element) would make OpenPDF itself reject the document with
+     * a {@code PdfXConformanceException}, since base-14 fonts can never be embedded.
+     */
+    private static final String ALL_TEXT_IN_EMBEDDED_FONT = """
+        <html><head><style>
+            @font-face {
+                font-family: "Jacquard 24";
+                src: url("classpath:fonts/Jacquard24-Regular.ttf");
+                -fs-pdf-font-embed: embed;
+            }
+            body { font-family: "Jacquard 24"; }
+        </style></head>
+        <body><p>Hello PDF/A</p></body></html>
+        """;
+
+    @Test
+    void generatesOutputIntentAndDocumentXmpMetadata() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        renderer.setDocumentFromString(ALL_TEXT_IN_EMBEDDED_FONT);
+        renderer.layout();
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        renderer.createPDF(os);
+        byte[] pdfBytes = os.toByteArray();
+
+        try (RandomAccessRead buffer = new RandomAccessReadBuffer(pdfBytes);
+             PDDocument document = new PDFParser(buffer).parse()) {
+            assertThat(document.isEncrypted()).isFalse();
+
+            PDDocumentCatalog catalog = document.getDocumentCatalog();
+            assertThat(catalog.getOutputIntents()).isNotEmpty();
+
+            String xmp = new String(catalog.getMetadata().exportXMPMetadata().readAllBytes(), UTF_8);
+            assertThat(xmp).contains("pdfaid:part").contains("pdfaid:conformance");
+        }
+    }
+
+    @Test
+    void rejectsNonEmbeddedFontFace() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setPdfAConformance(PdfAConformance.PDF_A_1B);
+        renderer.setDocumentFromString("""
+            <html><head><style>
+                @font-face {
+                    font-family: "Jacquard 24";
+                    src: url("classpath:fonts/Jacquard24-Regular.ttf");
+                }
+                .jacquard { font-family: "Jacquard 24"; }
+            </style></head>
+            <body><p class="jacquard">Not embedded</p></body></html>
+            """);
+        renderer.layout();
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        assertThatThrownBy(() -> renderer.createPDF(os))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("PDF/A conformance requires all fonts to be embedded");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the gap identified in #700: `ITextRenderer.setPDFXConformance(int)` previously only forwarded the raw conformance flag to OpenPDF's `PdfWriter`, with none of the supporting machinery real PDF/A conformance requires — most real documents would either throw `PdfXConformanceException` or silently produce a non-conformant file.

This adds a new opt-in `ITextRenderer.setPdfAConformance(PdfAConformance)` API (leaving `setPDFXConformance` unchanged for existing PDF/X callers) that:

- Registers an sRGB ICC output intent (`PdfWriter.setOutputIntents`, using the JDK's built-in sRGB profile — no new profile file/dependency needed).
- Creates document-level XMP metadata (`PdfWriter.createXmpMetadata()`) on close, so validators see the correct `pdfaid:part`/`pdfaid:conformance` schema.
- Throws `IllegalStateException` if combined with `setPDFEncryption(...)`, since PDF/A forbids encryption (previously this combination silently produced an invalid file).
- Throws `IllegalStateException` before layout if any `@font-face` font was registered without `-fs-pdf-font-embed: embed` — PDF/A requires every font to be embedded, and OpenPDF has no way to embed the standard base-14 fonts (Helvetica/Times/Courier/Symbol/ZapfDingbats) at all, so falling back to one of those can never be PDF/A conformant. This is documented on `PdfAConformance` rather than enforced (OpenPDF's own `PdfXConformanceException` will still catch base-14 usage at paint time).

The already-existing link-annotation `Print` flag fix (from a prior commit, required for PDF/A-1a) is untouched — it already satisfied its part of the spec.

PDF/A-3b (`PdfAConformance.PDF_A_3B`) reuses the same mechanism; embedded-file attachments (if ever wanted) would be a separate follow-up.

## Test plan

- [x] `mvn -pl flying-saucer-pdf test -Dtest=ITextRendererTest` — new unit tests for the setter/getter and the encryption/PDF-A mutual-exclusion guard
- [x] `mvn -pl flying-saucer-pdf test -Dtest=PdfAConformanceTest` — new integration tests asserting the generated PDF has an `/OutputIntents` entry and XMP metadata with `pdfaid:part`/`pdfaid:conformance`, and that a non-embedded `@font-face` is rejected
- [x] `mvn -pl flying-saucer-pdf -am test` — full module test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating PDF/A-1B and PDF/A-3B compliant documents.
  * Added configuration and status controls for PDF/A conformance.
  * Generated required PDF/A metadata and sRGB output intent automatically.
  * Added validation to prevent encryption and non-embedded fonts when PDF/A is enabled.
  * Added reporting for registered fonts that are not embedded.

* **Bug Fixes**
  * Improved document closing while preserving close callbacks and PDF/A metadata generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->