### PR TITLE
Add Phase 1 tagged-PDF accessibility support

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -39,6 +39,7 @@ import org.openpdf.text.pdf.PdfNumber;
 import org.openpdf.text.pdf.PdfOutline;
 import org.openpdf.text.pdf.PdfReader;
 import org.openpdf.text.pdf.PdfString;
+import org.openpdf.text.pdf.PdfStructureElement;
 import org.openpdf.text.pdf.PdfTextArray;
 import org.openpdf.text.pdf.PdfWriter;
 import org.slf4j.Logger;
@@ -90,7 +91,9 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -173,6 +176,20 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
 
     private final Set<String> _linkTargetAreas = new HashSet<>();
 
+    private static final Map<String, PdfName> TAGGABLE_ELEMENTS = Map.of(
+            "h1", PdfName.H1,
+            "h2", PdfName.H2,
+            "h3", PdfName.H3,
+            "h4", PdfName.H4,
+            "h5", PdfName.H5,
+            "h6", PdfName.H6,
+            "p", PdfName.P);
+
+    private final Map<Element, PdfStructureElement> _structureElements = new IdentityHashMap<>();
+
+    @Nullable
+    private PdfStructureElement _documentStructureElement;
+
     public ITextOutputDevice(float dotsPerPoint) {
         _dotsPerPoint = dotsPerPoint;
     }
@@ -219,8 +236,75 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
 
     @Override
     public void paintReplacedElement(RenderingContext c, BlockBox box) {
+        PdfStructureElement struct = beginImageStructure(box);
         ITextReplacedElement element = (ITextReplacedElement) box.getReplacedElement();
         element.paint(c, this, box);
+        if (struct != null) {
+            _currentPage.endMarkedContentSequence();
+        }
+    }
+
+    @Override
+    public void drawText(RenderingContext c, InlineText inlineText) {
+        PdfStructureElement struct = isTagged() ? beginTextStructure(inlineText) : null;
+        super.drawText(c, inlineText);
+        if (struct != null) {
+            _currentPage.endMarkedContentSequence();
+        }
+    }
+
+    private boolean isTagged() {
+        return _writer != null && _writer.isTagged();
+    }
+
+    @Nullable
+    private PdfStructureElement beginTextStructure(InlineText inlineText) {
+        Box box = inlineText.getParent();
+        while (box != null) {
+            Element element = box.getElement();
+            if (element != null) {
+                PdfName tag = TAGGABLE_ELEMENTS.get(element.getNodeName().toLowerCase(Locale.ROOT));
+                if (tag != null) {
+                    PdfStructureElement struct = structureElementFor(element, tag);
+                    _currentPage.beginMarkedContentSequence(struct);
+                    return struct;
+                }
+            }
+            box = box.getParent();
+        }
+        return null;
+    }
+
+    @Nullable
+    private PdfStructureElement beginImageStructure(BlockBox box) {
+        if (!isTagged()) {
+            return null;
+        }
+        Element element = box.getElement();
+        if (element == null || !"img".equalsIgnoreCase(element.getNodeName())) {
+            return null;
+        }
+        // alt="" marks the image as decorative; don't expose it to assistive technology as a Figure.
+        if (element.hasAttribute("alt") && element.getAttribute("alt").isEmpty()) {
+            return null;
+        }
+        PdfStructureElement struct = structureElementFor(element, PdfName.FIGURE);
+        if (element.hasAttribute("alt")) {
+            struct.put(PdfName.ALT, new PdfString(element.getAttribute("alt")));
+        }
+        _currentPage.beginMarkedContentSequence(struct);
+        return struct;
+    }
+
+    private PdfStructureElement structureElementFor(Element element, PdfName tag) {
+        return _structureElements.computeIfAbsent(element, e -> new PdfStructureElement(documentStructureElement(), tag));
+    }
+
+    private PdfStructureElement documentStructureElement() {
+        if (_documentStructureElement == null) {
+            _documentStructureElement = new PdfStructureElement(_writer.getStructureTreeRoot(), PdfName.DOCUMENT);
+        }
+        return _documentStructureElement;
     }
 
     @Override

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -134,6 +134,8 @@ public class ITextRenderer {
     @Nullable
     private PdfAConformance _pdfAConformance;
 
+    private boolean _tagged;
+
     @Nullable
     private PDFCreationListener _listener;
 
@@ -304,6 +306,19 @@ public class ITextRenderer {
         return _pdfAConformance;
     }
 
+    /**
+     * Requests a tagged PDF: a structure tree describing headings, paragraphs and images (with their
+     * {@code alt} text) so that screen readers and other assistive technology can navigate the document.
+     * See {@link ITextOutputDevice} for which HTML elements are currently tagged.
+     */
+    public void setTagged(boolean tagged) {
+        _tagged = tagged;
+    }
+
+    public boolean isTagged() {
+        return _tagged;
+    }
+
     public void layout() {
         LayoutContext c = newLayoutContext();
         BlockBox root = BoxBuilder.createRootBox(c, _doc);
@@ -429,6 +444,10 @@ public class ITextRenderer {
         }
         if (effectiveXConformance != null) {
             writer.setPDFXConformance(effectiveXConformance);
+        }
+
+        if (_tagged) {
+            writer.setTagged();
         }
 
         if (_pdfAConformance != null) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -1,0 +1,106 @@
+package org.xhtmlrenderer.pdf;
+
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
+import org.apache.pdfbox.pdfparser.PDFParser;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PdfTaggingTest {
+
+    @Test
+    void taggingIsDisabledByDefault() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setDocumentFromString("<html><body><h1>Title</h1><p>Body text</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> assertThat(catalog.getStructureTreeRoot()).isNull());
+    }
+
+    @Test
+    void tagsHeadingsAndParagraphs() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><h1>Title</h1><p>Body text</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements).extracting(PDStructureElement::getStructureType).contains("H1", "P");
+        });
+    }
+
+    @Test
+    void tagsImageAsFigureWithAlt() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><img src=\"classpath:flyingsaucer.png\" alt=\"A cat\" /></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements)
+                    .filteredOn(e -> "Figure".equals(e.getStructureType()))
+                    .extracting(PDStructureElement::getAlternateDescription)
+                    .containsExactly("A cat");
+        });
+    }
+
+    @Test
+    void decorativeImageWithEmptyAltIsNotTaggedAsFigure() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><img src=\"classpath:flyingsaucer.png\" alt=\"\" /></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements).extracting(PDStructureElement::getStructureType).doesNotContain("Figure");
+        });
+    }
+
+    private static void withCatalog(ITextRenderer renderer, Consumer<PDDocumentCatalog> assertions) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        renderer.createPDF(os);
+        byte[] pdfBytes = os.toByteArray();
+
+        try (RandomAccessRead buffer = new RandomAccessReadBuffer(pdfBytes);
+             PDDocument document = new PDFParser(buffer).parse()) {
+            assertions.accept(document.getDocumentCatalog());
+        }
+    }
+
+    private static List<PDStructureElement> structureElementsOf(PDDocumentCatalog catalog) {
+        PDStructureTreeRoot root = catalog.getStructureTreeRoot();
+        assertThat(root).isNotNull();
+
+        List<PDStructureElement> elements = new ArrayList<>();
+        collectStructureElements(root, elements);
+        return elements;
+    }
+
+    private static void collectStructureElements(PDStructureNode node, List<PDStructureElement> elements) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement structureElement) {
+                elements.add(structureElement);
+                collectStructureElements(structureElement, elements);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in `ITextRenderer.setTagged(boolean)` that requests a tagged PDF (calls `PdfWriter.setTagged()` before the document opens).
- Tags `h1`-`h6` and `p` text as `H1`-`H6`/`P` structure elements, and `<img>` as `Figure` with `/Alt` from the `alt` attribute (an explicit `alt=""` is treated as decorative and left untagged, per how screen readers should skip decorative images).
- Everything lives in `flying-saucer-pdf` (`ITextRenderer`/`ITextOutputDevice`) — no changes to the shared `OutputDevice` SPI or `flying-saucer-core`, so Java2D/SWT renderers are unaffected.

This is a first, deliberately scoped slice addressing #456 (accessible/tagged PDF output). Tables, lists, links, `/Lang`, and artifact-marking of decorative chrome (backgrounds/borders) are intentionally left for follow-up PRs once this lands.

## Test plan

- [x] New `PdfTaggingTest` (4 cases): tagging off by default, headings/paragraphs get `H1`/`P` tags, `<img alt="...">` gets `Figure` + `/Alt`, `<img alt="">` is not tagged as `Figure`. Verified via PDFBox's structure-tree API against the produced PDF bytes.
- [x] `mvn -pl flying-saucer-pdf -am test` — 86 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tagged PDF generation for improved accessibility.
  * Added structure tags for headings, paragraphs, text, and images.
  * Preserved image alternative text as PDF accessibility metadata.
  * Distinguished decorative images from meaningful images during tagging.
  * Added controls to enable or disable tagged PDF output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->