### PR TITLE
Add Phase 2 tagged-PDF support: table structure

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -58,6 +58,10 @@ import org.xhtmlrenderer.css.value.FontSpecification;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.NamespaceHandler;
 import org.xhtmlrenderer.layout.SharedContext;
+import org.xhtmlrenderer.newtable.TableBox;
+import org.xhtmlrenderer.newtable.TableCellBox;
+import org.xhtmlrenderer.newtable.TableRowBox;
+import org.xhtmlrenderer.newtable.TableSectionBox;
 import org.xhtmlrenderer.render.AbstractOutputDevice;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.Box;
@@ -185,7 +189,7 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             "h6", PdfName.H6,
             "p", PdfName.P);
 
-    private final Map<Element, PdfStructureElement> _structureElements = new IdentityHashMap<>();
+    private final Map<Object, PdfStructureElement> _structureElements = new IdentityHashMap<>();
 
     @Nullable
     private PdfStructureElement _documentStructureElement;
@@ -265,10 +269,15 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             if (element != null) {
                 PdfName tag = TAGGABLE_ELEMENTS.get(element.getNodeName().toLowerCase(Locale.ROOT));
                 if (tag != null) {
-                    PdfStructureElement struct = structureElementFor(element, tag);
+                    PdfStructureElement struct = structureElementFor(element, tag, documentStructureElement());
                     _currentPage.beginMarkedContentSequence(struct);
                     return struct;
                 }
+            }
+            if (box instanceof TableCellBox cell) {
+                PdfStructureElement struct = tableStructureElementFor(cell);
+                _currentPage.beginMarkedContentSequence(struct);
+                return struct;
             }
             box = box.getParent();
         }
@@ -288,7 +297,7 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
         if (element.hasAttribute("alt") && element.getAttribute("alt").isEmpty()) {
             return null;
         }
-        PdfStructureElement struct = structureElementFor(element, PdfName.FIGURE);
+        PdfStructureElement struct = structureElementFor(element, PdfName.FIGURE, tableAncestorStructureElement(box));
         if (element.hasAttribute("alt")) {
             struct.put(PdfName.ALT, new PdfString(element.getAttribute("alt")));
         }
@@ -296,8 +305,50 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
         return struct;
     }
 
-    private PdfStructureElement structureElementFor(Element element, PdfName tag) {
-        return _structureElements.computeIfAbsent(element, e -> new PdfStructureElement(documentStructureElement(), tag));
+    private PdfStructureElement tableAncestorStructureElement(Box box) {
+        Box ancestor = box.getParent();
+        while (ancestor != null) {
+            if (ancestor instanceof TableCellBox cell) {
+                return tableStructureElementFor(cell);
+            }
+            ancestor = ancestor.getParent();
+        }
+        return documentStructureElement();
+    }
+
+    private PdfStructureElement tableStructureElementFor(BlockBox box) {
+        PdfStructureElement cached = _structureElements.get(box);
+        if (cached != null) {
+            return cached;
+        }
+        Box parentBox = box.getParent();
+        PdfStructureElement parent = isTableBox(parentBox) ? tableStructureElementFor((BlockBox) parentBox) : documentStructureElement();
+        return structureElementFor(box, tableTag(box), parent);
+    }
+
+    private static boolean isTableBox(@Nullable Box box) {
+        return box instanceof TableBox || box instanceof TableSectionBox || box instanceof TableRowBox || box instanceof TableCellBox;
+    }
+
+    private static PdfName tableTag(BlockBox box) {
+        if (box instanceof TableBox) {
+            return PdfName.TABLE;
+        }
+        if (box instanceof TableSectionBox section) {
+            return section.isHeader() ? PdfName.THEAD : section.isFooter() ? PdfName.TFOOT : PdfName.TBODY;
+        }
+        if (box instanceof TableRowBox) {
+            return PdfName.TABLEROW;
+        }
+        if (box instanceof TableCellBox cell) {
+            Element element = cell.getElement();
+            return element != null && "th".equalsIgnoreCase(element.getNodeName()) ? PdfName.TH : PdfName.TD;
+        }
+        throw new IllegalArgumentException("Not a table box: " + box);
+    }
+
+    private PdfStructureElement structureElementFor(Object key, PdfName tag, PdfStructureElement parent) {
+        return _structureElements.computeIfAbsent(key, k -> new PdfStructureElement(parent, tag));
     }
 
     private PdfStructureElement documentStructureElement() {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -75,6 +75,79 @@ class PdfTaggingTest {
         });
     }
 
+    @Test
+    void tagsTableSectionsRowsAndCells() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("""
+            <html><body><table>
+                <thead><tr><th>Name</th><th>Age</th></tr></thead>
+                <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
+            </table></body></html>
+            """);
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            assertThat(elements).extracting(PDStructureElement::getStructureType).contains("Table");
+            assertThat(byType(elements, "TH")).allMatch(th -> "TR".equals(parentType(th)));
+            assertThat(byType(elements, "TD")).allMatch(td -> "TR".equals(parentType(td)));
+            assertThat(byType(elements, "TR"))
+                    .extracting(PdfTaggingTest::parentType)
+                    .containsExactlyInAnyOrder("THead", "TBody");
+            assertThat(byType(elements, "THead")).allMatch(section -> "Table".equals(parentType(section)));
+            assertThat(byType(elements, "TBody")).allMatch(section -> "Table".equals(parentType(section)));
+        });
+    }
+
+    @Test
+    void tagsImplicitTbodyForBareRows() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><table><tr><td>A</td></tr></table></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            PDStructureElement td = byType(elements, "TD").get(0);
+            PDStructureElement tr = (PDStructureElement) td.getParent();
+            PDStructureElement tbody = (PDStructureElement) tr.getParent();
+
+            assertThat(tr.getStructureType()).isEqualTo("TR");
+            assertThat(tbody.getStructureType()).isEqualTo("TBody");
+            assertThat(parentType(tbody)).isEqualTo("Table");
+        });
+    }
+
+    @Test
+    void nestsImageInsideTableCell() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString(
+                "<html><body><table><tr><td><img src=\"classpath:flyingsaucer.png\" alt=\"A cat\" /></td></tr></table></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            PDStructureElement figure = byType(elements, "Figure").get(0);
+            assertThat(parentType(figure)).isEqualTo("TD");
+        });
+    }
+
+    private static List<PDStructureElement> byType(List<PDStructureElement> elements, String type) {
+        return elements.stream().filter(e -> type.equals(e.getStructureType())).toList();
+    }
+
+    private static String parentType(PDStructureElement element) {
+        return ((PDStructureElement) element.getParent()).getStructureType();
+    }
+
     private static void withCatalog(ITextRenderer renderer, Consumer<PDDocumentCatalog> assertions) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         renderer.createPDF(os);


### PR DESCRIPTION
## Summary

Stacked on #704 (Phase 1 — headings/paragraphs/images). This PR adds proper nested structure tags for tables:

- `<table>`/`<thead>`/`<tbody>`/`<tfoot>`/`<tr>`/`<td>`/`<th>` are tagged as `Table`/`THead`/`TBody`/`TFoot`/`TR`/`TD`/`TH`, nested to mirror the real containment (`Table → section → TR → TD/TH`) rather than Phase 1's flat "everything under one Document node" tree — screen readers need the real nesting to announce row/column navigation.
- Table box types (`TableBox`/`TableSectionBox`/`TableRowBox`/`TableCellBox`) can be **anonymous** (e.g. an implicit `<tbody>` synthesized for bare `<tr>`s), and an anonymous box's `getElement()` is not reliably meaningful. So the structure-element cache is now keyed by **`Box` identity** for table containers (not `Element`), and header/body/footer role is read off `TableSectionBox.isHeader()/isFooter()` — set correctly by the layout algorithm regardless of whether the section was explicit in the source — rather than trusting the box's (possibly borrowed) DOM element.
- Images inside table cells now nest their `Figure` tag under the owning `TD`/`TH` instead of the flat `Document` node, for the same reason.

Deferred (documented in code/plan, not attempted here): `/ColSpan`/`/RowSpan`/`/Headers`/`/Scope` cell attributes (OpenPDF has no first-class `PdfName` constants for these; they'd need a hand-built `Table`-owned attribute-object dictionary), tagging of completely empty cells (no content is ever painted for them, so no structure element is created), and `<caption>`.

## Test plan

- [x] New tests in `PdfTaggingTest`: `tagsTableSectionsRowsAndCells` (explicit `thead`/`tbody`), `tagsImplicitTbodyForBareRows` (proves the anonymous-section case resolves to the correct `TBody` nesting), `nestsImageInsideTableCell`. All assert real parent/child structure via PDFBox's `PDStructureElement.getParent()`, not just flat presence.
- [x] `mvn -pl flying-saucer-pdf -am test` — 89 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PDF accessibility tagging for tables, including headers, sections, rows, and cells.
  * Added support for correctly nesting text and images within table structures.
  * Bare table rows now receive an implicit table body structure.

* **Bug Fixes**
  * Improved accessibility hierarchy for images displayed inside table cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->