### PR TITLE
Add Phase 3 tagged-PDF support: lists

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.xhtmlrenderer.css.constants.CSSName;
 import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.parser.FSCMYKColor;
@@ -189,7 +190,18 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             "h6", PdfName.H6,
             "p", PdfName.P);
 
+    private static final Map<String, PdfName> LIST_ELEMENTS = Map.of(
+            "ul", PdfName.L,
+            "ol", PdfName.L,
+            "li", PdfName.LI);
+
     private final Map<Object, PdfStructureElement> _structureElements = new IdentityHashMap<>();
+
+    // A ListItem's own text is never marked directly against the LI structure element: OpenPDF requires a
+    // structure element's /K entries to be either all marked-content references or all child structure
+    // elements, never a mix — and an <li> can also host a nested <ul>/<ol> (a child L element). So the
+    // item's text goes under its own LBody child instead, keeping LI's kids uniformly structural.
+    private final Map<Element, PdfStructureElement> _listItemBodies = new IdentityHashMap<>();
 
     @Nullable
     private PdfStructureElement _documentStructureElement;
@@ -267,9 +279,18 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
         while (box != null) {
             Element element = box.getElement();
             if (element != null) {
-                PdfName tag = TAGGABLE_ELEMENTS.get(element.getNodeName().toLowerCase(Locale.ROOT));
-                if (tag != null) {
-                    PdfStructureElement struct = structureElementFor(element, tag, documentStructureElement());
+                String tagName = element.getNodeName().toLowerCase(Locale.ROOT);
+                PdfName flatTag = TAGGABLE_ELEMENTS.get(tagName);
+                if (flatTag != null) {
+                    PdfStructureElement struct = structureElementFor(element, flatTag, documentStructureElement());
+                    _currentPage.beginMarkedContentSequence(struct);
+                    return struct;
+                }
+                PdfName listTag = LIST_ELEMENTS.get(tagName);
+                if (listTag != null) {
+                    PdfStructureElement struct = listTag == PdfName.LI
+                            ? listItemBodyStructureElementFor(element)
+                            : listStructureElementFor(element, listTag);
                     _currentPage.beginMarkedContentSequence(struct);
                     return struct;
                 }
@@ -280,6 +301,34 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
                 return struct;
             }
             box = box.getParent();
+        }
+        return null;
+    }
+
+    private PdfStructureElement listItemBodyStructureElementFor(Element liElement) {
+        return _listItemBodies.computeIfAbsent(liElement,
+                e -> new PdfStructureElement(listStructureElementFor(e, PdfName.LI), PdfName.LBODY));
+    }
+
+    private PdfStructureElement listStructureElementFor(Element element, PdfName tag) {
+        PdfStructureElement cached = _structureElements.get(element);
+        if (cached != null) {
+            return cached;
+        }
+        Element parentElement = nearestListAncestor(element.getParentNode());
+        PdfStructureElement parent = parentElement != null
+                ? listStructureElementFor(parentElement, LIST_ELEMENTS.get(parentElement.getNodeName().toLowerCase(Locale.ROOT)))
+                : documentStructureElement();
+        return structureElementFor(element, tag, parent);
+    }
+
+    @Nullable
+    private static Element nearestListAncestor(@Nullable Node node) {
+        while (node instanceof Element element) {
+            if (LIST_ELEMENTS.containsKey(element.getNodeName().toLowerCase(Locale.ROOT))) {
+                return element;
+            }
+            node = element.getParentNode();
         }
         return null;
     }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -140,6 +140,50 @@ class PdfTaggingTest {
         });
     }
 
+    @Test
+    void tagsListsAndListItems() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><ul><li>First</li><li>Second</li></ul></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            assertThat(elements).extracting(PDStructureElement::getStructureType).contains("L");
+            List<PDStructureElement> items = byType(elements, "LI");
+            assertThat(items).hasSize(2);
+            assertThat(items).allMatch(li -> "L".equals(parentType(li)));
+        });
+    }
+
+    @Test
+    void nestsNestedLists() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><ul><li>Item<ul><li>Nested</li></ul></li></ul></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            List<PDStructureElement> lists = byType(elements, "L");
+            assertThat(lists).hasSize(2);
+
+            PDStructureElement innerList = lists.stream()
+                    .filter(l -> "LI".equals(parentType(l)))
+                    .findFirst()
+                    .orElseThrow();
+            PDStructureElement outerItem = (PDStructureElement) innerList.getParent();
+            PDStructureElement outerList = (PDStructureElement) outerItem.getParent();
+
+            assertThat(outerItem.getStructureType()).isEqualTo("LI");
+            assertThat(outerList.getStructureType()).isEqualTo("L");
+        });
+    }
+
     private static List<PDStructureElement> byType(List<PDStructureElement> elements, String type) {
         return elements.stream().filter(e -> type.equals(e.getStructureType())).toList();
     }


### PR DESCRIPTION
## Summary

Stacked on #705 (Phase 2 — tables), which itself stacks on #704 (Phase 1). This PR adds nested structure tags for lists:

- `<ul>`/`<ol>` tagged as `List` (`L`), `<li>` tagged as `ListItem` (`LI`), nested to mirror real DOM ancestry — lists can nest arbitrarily deep, so (like tables, unlike Phase 1's flat heading/paragraph tree) the structure must reflect actual containment.
- Unlike tables, list boxes are never anonymous (confirmed: an `<li>` always becomes an ordinary `BlockBox` built directly from its real DOM element — the bullet/number marker is just a paint-time decoration, not a synthesized wrapper box), so nesting is resolved by walking the real DOM parent chain directly, reusing the generalized `structureElementFor(key, tag, parent)` from #705 with `Element` keys (no `Box`-identity workaround needed here).
- **A real bug surfaced and fixed during testing**: an `<li>`'s own text is now tagged under a dedicated `LBody` child rather than the `LI` element directly. OpenPDF requires a structure element's `/K` kids to be either all marked-content references or all child structure elements, never mixed — and an `<li>` can host both its own text *and* a nested list (a child `L` element). Marking the `LI` directly threw `IllegalArgumentException: the parent has already another function` as soon as a nested-list test was added; wrapping the item's text in `LBody` keeps `LI`'s kids uniformly structural.

Deferred (not attempted here): `Lbl` (the list marker itself, e.g. the bullet/number) as its own structure element, and `<ol start>`/`<li value>` — no PDF/UA equivalent for the latter; the rendered marker text is unaffected by this change.

## Test plan

- [x] New tests in `PdfTaggingTest`: `tagsListsAndListItems` (flat two-item list), `nestsNestedLists` (list-within-list — this is what caught the `LI`/`LBody` mixed-content bug above; without the fix this test fails with the OpenPDF exception described).
- [x] `mvn -pl flying-saucer-pdf -am test` — 91 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)