### PR TITLE
Add Phase 4 tagged-PDF support: links

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -294,6 +294,11 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
                     _currentPage.beginMarkedContentSequence(struct);
                     return struct;
                 }
+                if ("a".equals(tagName) && _sharedContext.getNamespaceHandler().getLinkUri(element) != null) {
+                    PdfStructureElement struct = structureElementFor(element, PdfName.LINK, documentStructureElement());
+                    _currentPage.beginMarkedContentSequence(struct);
+                    return struct;
+                }
             }
             if (box instanceof TableCellBox cell) {
                 PdfStructureElement struct = tableStructureElementFor(cell);

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -184,6 +184,34 @@ class PdfTaggingTest {
         });
     }
 
+    @Test
+    void tagsLinkText() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><a href=\"https://example.com\">Click here</a></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements).extracting(PDStructureElement::getStructureType).contains("Link");
+        });
+    }
+
+    @Test
+    void doesNotTagAnchorWithoutHref() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><a name=\"anchor\">Text</a></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements).extracting(PDStructureElement::getStructureType).doesNotContain("Link");
+        });
+    }
+
     private static List<PDStructureElement> byType(List<PDStructureElement> elements, String type) {
         return elements.stream().filter(e -> type.equals(e.getStructureType())).toList();
     }


### PR DESCRIPTION
## Summary

Stacked on #706 (Phase 3 — lists), which stacks on #705 (tables) → #704 (headings/paragraphs/images). This PR tags `<a href>` anchor text as a `Link` structure element.

- Reuses the exact flat-parenting mechanism Phase 1 uses for headings/paragraphs (`structureElementFor(element, PdfName.LINK, documentStructureElement())`) — no new resolver needed, since a link doesn't need containment semantics the way a table cell or list item does.
- Guards on `NamespaceHandler.getLinkUri(element) != null`, the same check `processLink` (`ITextOutputDevice.java:414-419`) already uses to decide whether to emit a link annotation — so an anchor without a resolvable `href` isn't tagged as a link.
- **Deliberately scoped down**, per discussion: full PDF/UA link tagging cross-references the `Link` structure element to the actual clickable annotation via an `OBJR`/`StructParent`/`ParentTree` entry. OpenPDF 3.0.5 has the relevant `PdfName` constants but no supporting API to build this — it would mean hand-rolling internal, unsupported plumbing. This PR skips that; the link's clickability is unaffected either way since it's driven entirely by the existing `PdfAnnotation` in `processLink`. The gap is documented as a known limitation for a future pass.

## Test plan

- [x] New tests in `PdfTaggingTest`: `tagsLinkText` (anchor with `href` gets tagged `Link`), `doesNotTagAnchorWithoutHref` (anchor without `href` doesn't).
- [x] `mvn -pl flying-saucer-pdf -am test` — 93 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)