### PR TITLE
Add Phase 5 tagged-PDF support: table cell ColSpan/RowSpan

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -195,6 +195,11 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             "ol", PdfName.L,
             "li", PdfName.LI);
 
+    // No PdfName.COLSPAN/ROWSPAN constants exist in OpenPDF; these are the raw key names the PDF/UA
+    // Table attribute-owner dictionary expects (ISO 32000-2 §14.8.5.7).
+    private static final PdfName COLSPAN = new PdfName("ColSpan");
+    private static final PdfName ROWSPAN = new PdfName("RowSpan");
+
     private final Map<Object, PdfStructureElement> _structureElements = new IdentityHashMap<>();
 
     // A ListItem's own text is never marked directly against the LI structure element: OpenPDF requires a
@@ -377,7 +382,28 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
         }
         Box parentBox = box.getParent();
         PdfStructureElement parent = isTableBox(parentBox) ? tableStructureElementFor((BlockBox) parentBox) : documentStructureElement();
-        return structureElementFor(box, tableTag(box), parent);
+        PdfStructureElement struct = structureElementFor(box, tableTag(box), parent);
+        if (box instanceof TableCellBox cell) {
+            addCellSpanAttributes(struct, cell);
+        }
+        return struct;
+    }
+
+    private static void addCellSpanAttributes(PdfStructureElement struct, TableCellBox cell) {
+        int colSpan = cell.getStyle().getColSpan();
+        int rowSpan = cell.getStyle().getRowSpan();
+        if (colSpan <= 1 && rowSpan <= 1) {
+            return;
+        }
+        PdfDictionary attributes = new PdfDictionary();
+        attributes.put(PdfName.O, PdfName.TABLE);
+        if (colSpan > 1) {
+            attributes.put(COLSPAN, new PdfNumber(colSpan));
+        }
+        if (rowSpan > 1) {
+            attributes.put(ROWSPAN, new PdfNumber(rowSpan));
+        }
+        struct.put(PdfName.A, attributes);
     }
 
     private static boolean isTableBox(@Nullable Box box) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -5,9 +5,11 @@ import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDAttributeObject;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
+import org.apache.pdfbox.pdmodel.documentinterchange.taggedpdf.PDTableAttributeObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -120,6 +122,49 @@ class PdfTaggingTest {
             assertThat(tr.getStructureType()).isEqualTo("TR");
             assertThat(tbody.getStructureType()).isEqualTo("TBody");
             assertThat(parentType(tbody)).isEqualTo("Table");
+        });
+    }
+
+    @Test
+    void tagsCellSpanAttributes() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("""
+            <html><body><table>
+                <tr><td colspan="2">Wide</td></tr>
+                <tr><td>A</td><td>B</td></tr>
+            </table></body></html>
+            """);
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            PDStructureElement wideCell = byType(elements, "TD").stream()
+                    .filter(td -> td.getAttributes().size() > 0)
+                    .findFirst()
+                    .orElseThrow();
+            PDAttributeObject attribute = wideCell.getAttributes().getObject(0);
+
+            assertThat(attribute).isInstanceOf(PDTableAttributeObject.class);
+            assertThat(((PDTableAttributeObject) attribute).getColSpan()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void doesNotTagUnspannedCells() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><table><tr><td>A</td></tr></table></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            PDStructureElement td = byType(elements, "TD").get(0);
+            assertThat(td.getAttributes().size()).isZero();
         });
     }
 


### PR DESCRIPTION
## Summary

Stacked on #707 (links) → #706 (lists) → #705 (tables) → #704 (headings/paragraphs/images). Rounds out the table work from #705 by adding `/ColSpan`/`/RowSpan` cell attributes.

- Sets `/ColSpan`/`/RowSpan` on `TD`/`TH` structure elements via a `Table`-owned attribute-object dictionary (`/A`) — `PdfStructureElement` is a plain `PdfDictionary` subclass, so this is just `struct.put(PdfName.A, attributeDict)`, no special API needed.
- Read directly off `TableCellBox.getStyle().getColSpan()/getRowSpan()` (both default to `1`), only writing the attribute when a real span (`> 1`) exists.
- OpenPDF has no `PdfName.COLSPAN`/`ROWSPAN` constants, so those two dictionary keys are built as plain `new PdfName("ColSpan"/"RowSpan")` — the same pattern OpenPDF itself uses internally (e.g. `new PdfName("StructElem")`).
- **Deliberately excludes** `/Headers`/`/Scope` (per discussion): those need heuristically guessing row-vs-column header roles from cell position, which risks shipping incorrect accessibility metadata for non-trivial tables (merged header cells, multi-level headers) — worse than shipping none.

## Test plan

- [x] New tests in `PdfTaggingTest`: `tagsCellSpanAttributes` (a `colspan="2"` cell gets a `Table`-attribute object with `getColSpan() == 2`, verified via PDFBox's typed `PDTableAttributeObject`), `doesNotTagUnspannedCells` (plain cells get no `/A` at all).
- [x] `mvn -pl flying-saucer-pdf -am test` — 95 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)