### PR TITLE
Add Phase 6 tagged-PDF support: document metadata and artifacts

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -52,8 +52,10 @@ import org.xhtmlrenderer.css.constants.IdentValue;
 import org.xhtmlrenderer.css.parser.FSCMYKColor;
 import org.xhtmlrenderer.css.parser.FSColor;
 import org.xhtmlrenderer.css.parser.FSRGBColor;
+import org.xhtmlrenderer.css.style.CalculatedStyle;
 import org.xhtmlrenderer.css.style.CalculatedStyle.Edge;
 import org.xhtmlrenderer.css.style.CssContext;
+import org.xhtmlrenderer.css.style.derived.BorderPropertySet;
 import org.xhtmlrenderer.css.style.derived.FSLinearGradient;
 import org.xhtmlrenderer.css.value.FontSpecification;
 import org.xhtmlrenderer.extend.FSImage;
@@ -199,6 +201,9 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
     // Table attribute-owner dictionary expects (ISO 32000-2 §14.8.5.7).
     private static final PdfName COLSPAN = new PdfName("ColSpan");
     private static final PdfName ROWSPAN = new PdfName("RowSpan");
+
+    // No PdfName.ARTIFACT constant exists in OpenPDF either.
+    private static final PdfName ARTIFACT = new PdfName("Artifact");
 
     private final Map<Object, PdfStructureElement> _structureElements = new IdentityHashMap<>();
 
@@ -440,9 +445,42 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
 
     @Override
     public void paintBackground(RenderingContext c, Box box) {
-        super.paintBackground(c, box);
+        paintAsArtifact(() -> super.paintBackground(c, box));
 
         processLink(c, box);
+    }
+
+    @Override
+    public void paintBackground(RenderingContext c, CalculatedStyle style, Rectangle bounds, Rectangle bgImageContainer,
+            BorderPropertySet border) {
+        paintAsArtifact(() -> super.paintBackground(c, style, bounds, bgImageContainer, border));
+    }
+
+    @Override
+    public void paintBorder(RenderingContext c, Box box) {
+        paintAsArtifact(() -> super.paintBorder(c, box));
+    }
+
+    @Override
+    public void paintBorder(RenderingContext c, CalculatedStyle style, Rectangle edge, int sides) {
+        paintAsArtifact(() -> super.paintBorder(c, style, edge, sides));
+    }
+
+    @Override
+    public void paintCollapsedBorder(RenderingContext c, BorderPropertySet border, Rectangle bounds, int side) {
+        paintAsArtifact(() -> super.paintCollapsedBorder(c, border, bounds, side));
+    }
+
+    // Decorative chrome (backgrounds/borders) is marked as an Artifact rather than left untagged, so
+    // assistive technology explicitly skips it instead of treating it as unmarked/ambiguous content.
+    private void paintAsArtifact(Runnable painter) {
+        if (isTagged()) {
+            _currentPage.beginMarkedContentSequence(ARTIFACT);
+            painter.run();
+            _currentPage.endMarkedContentSequence();
+        } else {
+            painter.run();
+        }
     }
 
     private org.openpdf.text.Rectangle calcTotalLinkArea(RenderingContext c, Box box) {

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextRenderer.java
@@ -448,6 +448,11 @@ public class ITextRenderer {
 
         if (_tagged) {
             writer.setTagged();
+            writer.setViewerPreferences(PdfWriter.DisplayDocTitle);
+            String lang = _doc.getDocumentElement().getAttribute("lang");
+            if (!lang.isEmpty()) {
+                writer.getExtraCatalog().put(PdfName.LANG, new PdfString(lang));
+            }
         }
 
         if (_pdfAConformance != null) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -257,6 +257,66 @@ class PdfTaggingTest {
         });
     }
 
+    @Test
+    void setsDocumentLanguageWhenTagged() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html lang=\"en\"><body><p>Hello</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> assertThat(catalog.getLanguage()).isEqualTo("en"));
+    }
+
+    @Test
+    void doesNotSetLanguageWhenAbsent() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><p>Hello</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> assertThat(catalog.getLanguage()).isNull());
+    }
+
+    @Test
+    void setsDisplayDocTitleViewerPreferenceWhenTagged() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><p>Hello</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> assertThat(catalog.getViewerPreferences().displayDocTitle()).isTrue());
+    }
+
+    @Test
+    void taggedTableWithBackgroundsAndBordersStillRendersCorrectStructure() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("""
+            <html><body>
+                <table style="border: 1px solid black; background: #eee;">
+                    <tr><td style="border: 1px solid black; background: #ccc;">A</td></tr>
+                </table>
+            </body></html>
+            """);
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+
+            PDStructureElement td = byType(elements, "TD").get(0);
+            PDStructureElement tr = (PDStructureElement) td.getParent();
+            PDStructureElement tbody = (PDStructureElement) tr.getParent();
+
+            assertThat(tr.getStructureType()).isEqualTo("TR");
+            assertThat(tbody.getStructureType()).isEqualTo("TBody");
+            assertThat(parentType(tbody)).isEqualTo("Table");
+        });
+    }
+
     private static List<PDStructureElement> byType(List<PDStructureElement> elements, String type) {
         return elements.stream().filter(e -> type.equals(e.getStructureType())).toList();
     }


### PR DESCRIPTION
## Summary

Stacked on #708 (cell spans) → #707 (links) → #706 (lists) → #705 (tables) → #704 (headings/paragraphs/images). This is the last item on the tagged-PDF accessibility roadmap for #456: document-level metadata plus artifact-marking of decorative chrome.

- **`/Lang`**: set from `<html lang>` on `writer.getExtraCatalog()` when tagging is enabled; skipped when the attribute is absent (`getAttribute("lang")` returns `""` per DOM spec, not `null`, so an explicit emptiness check avoids writing a bogus empty language).
- **`ViewerPreferences/DisplayDocTitle`**: set via the existing `writer.setViewerPreferences(int)` and OpenPDF's `PdfWriter.DisplayDocTitle` bit-flag constant, so PDF viewers show the document title instead of the filename.
- **Artifact-marking**: decorative backgrounds and borders are now wrapped in `BMC /Artifact ... EMC` rather than left completely untagged, so assistive technology explicitly skips them instead of treating them as unmarked/ambiguous content. This required overriding **all five** `OutputDevice` background/border paint entry points (two `paintBackground` overloads, two `paintBorder` overloads, `paintCollapsedBorder`) — confirmed the per-`Box` and per-`CalculatedStyle`/bounds overloads are siblings that each call their own private `...0` implementation rather than one delegating to the other, so wrapping only the common `Box` overload would have missed page backgrounds, table row/section/cell backgrounds, and collapsed table borders.
- All of this is a no-op when tagging isn't enabled (existing, non-tagged documents are byte-for-byte unaffected in behavior).

## Test plan

- [x] New tests in `PdfTaggingTest`: `setsDocumentLanguageWhenTagged`, `doesNotSetLanguageWhenAbsent`, `setsDisplayDocTitleViewerPreferenceWhenTagged`, and `taggedTableWithBackgroundsAndBordersStillRendersCorrectStructure` (renders a table with explicit backgrounds/borders and confirms the structure tree is still correct — proves the artifact BMC/EMC wrapping doesn't corrupt the marked-content sequences used for real tagged content in the same stream).
- [x] `mvn -pl flying-saucer-pdf -am test` — 99 tests pass, no regressions. This phase touches painting entry points used by every rendered document, tagged or not, so the full suite (including all the pre-existing non-tagged PDF-generation tests exercising backgrounds/borders/tables/transforms/SVG) is the strongest signal that the no-op path for untagged documents is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)