### PR TITLE
Fix stale tagged-PDF structure cache when ITextOutputDevice is reused

### DIFF
--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -221,6 +221,12 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
     }
 
     public void setWriter(PdfWriter writer) {
+        if (_writer != writer) {
+            // Cached structure elements belong to the previous writer's PDF; carrying them over would
+            // reference objects from a different document when this device is reused across createPDF calls.
+            _structureElements.clear();
+            _documentStructureElement = null;
+        }
         _writer = writer;
     }
 

--- a/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
+++ b/flying-saucer-pdf/src/main/java/org/xhtmlrenderer/pdf/ITextOutputDevice.java
@@ -226,6 +226,7 @@ public class ITextOutputDevice extends AbstractOutputDevice<FSImage, ITextFSFont
             // reference objects from a different document when this device is reused across createPDF calls.
             _structureElements.clear();
             _documentStructureElement = null;
+            _listItemBodies.clear();
         }
         _writer = writer;
     }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -23,6 +23,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PdfTaggingTest {
 
     @Test
+    void tagsSecondDocumentCorrectlyWhenRendererIsReused() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+
+        renderer.setDocumentFromString("<html><body><h1>First document</h1></body></html>");
+        renderer.layout();
+        renderer.createPDF(new ByteArrayOutputStream());
+
+        renderer.setDocumentFromString("<html><body><p>Second document</p></body></html>");
+        renderer.layout();
+
+        withCatalog(renderer, catalog -> {
+            List<PDStructureElement> elements = structureElementsOf(catalog);
+            assertThat(elements)
+                    .extracting(PDStructureElement::getStructureType)
+                    .contains("P")
+                    .doesNotContain("H1");
+        });
+    }
+
+    @Test
     void taggingIsDisabledByDefault() throws IOException {
         ITextRenderer renderer = new ITextRenderer();
         renderer.getSharedContext().setMedia("pdf");

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/PdfTaggingTest.java
@@ -45,6 +45,26 @@ class PdfTaggingTest {
     }
 
     @Test
+    void tagsListItemBodiesFreshOnEachCreatePdfCallForTheSameDocument() throws IOException {
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.getSharedContext().setMedia("pdf");
+        renderer.setTagged(true);
+        renderer.setDocumentFromString("<html><body><ul><li>An item</li></ul></body></html>");
+        renderer.layout();
+
+        renderer.createPDF(new ByteArrayOutputStream());
+
+        ByteArrayOutputStream secondOutput = new ByteArrayOutputStream();
+        renderer.createPDF(secondOutput);
+
+        try (RandomAccessRead buffer = new RandomAccessReadBuffer(secondOutput.toByteArray());
+             PDDocument document = new PDFParser(buffer).parse()) {
+            List<PDStructureElement> elements = structureElementsOf(document.getDocumentCatalog());
+            assertThat(elements).extracting(PDStructureElement::getStructureType).contains("L", "LI", "LBody");
+        }
+    }
+
+    @Test
     void taggingIsDisabledByDefault() throws IOException {
         ITextRenderer renderer = new ITextRenderer();
         renderer.getSharedContext().setMedia("pdf");


### PR DESCRIPTION
## Summary

Addresses a [CodeRabbit review comment on #704](https://github.com/flyingsaucerproject/flyingsaucer/pull/704#discussion_r3770712133), flagged as a data-integrity bug: `ITextOutputDevice.setWriter()` never cleared `_structureElements`/`_documentStructureElement` when handed a new `PdfWriter`. Since `ITextRenderer` keeps a single `ITextOutputDevice` instance across its lifetime, reusing a renderer for multiple `createPDF()` calls (a supported pattern - nothing prevents calling `setDocumentFromString`/`layout`/`createPDF` again on the same instance) carried `PdfStructureElement`s tied to the *previous* document's writer into the new one.

- Verified the bug is real before fixing it: a regression test reusing one `ITextRenderer` for two tagged documents showed the **second PDF's structure tree came back completely empty** instead of containing its own `<p>` tag — a silent correctness bug, not a crash, matching CodeRabbit's "Data Integrity" categorization.
- Fix: `setWriter()` now clears both fields whenever the writer instance actually changes, exactly as CodeRabbit's proposed diff suggested.

## Test plan

- [x] New test `tagsSecondDocumentCorrectlyWhenRendererIsReused` in `PdfTaggingTest`: renders a first tagged document (`<h1>`), then reuses the same renderer for a second, different document (`<p>`) — asserts the second PDF's tree contains `P` and does **not** leak the first document's `H1`. Fails without the fix (empty tree), passes with it.
- [x] `mvn -pl flying-saucer-pdf -am test` — 100 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tagged PDF generation when reusing the renderer for multiple documents.
  - Ensures each newly generated document receives its own correct accessibility structure, without retaining tags from a previous document.
  - Improved repeated PDF creation for list content so list, list-item, and list-body accessibility tags are rebuilt correctly each time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->