### PR TITLE
Fix percentage min/max-width on table cells resolving against a zero-width containing block

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/newtable/TableCellBox.java
@@ -148,6 +148,16 @@ public class TableCellBox extends BlockBox {
         return _table;
     }
 
+    @Override
+    protected int getContainingBlockWidth() {
+        // A table row has no width of its own (it always spans the full table), so at the
+        // point cell widths are calculated (TableSectionBox.setCellWidths()) the row's content
+        // width is not yet established. Percentages (e.g. max-width: 10%) must resolve against
+        // the table's width instead, per CSS 2.1 17.4.
+        TableBox table = getTable();
+        return table == null ? super.getContainingBlockWidth() : table.getContentWidth();
+    }
+
     @Nullable
     protected TableSectionBox getSection() {
         if (_section == null) {

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/PercentageMaxWidthTableCellTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/bug/PercentageMaxWidthTableCellTest.java
@@ -1,0 +1,61 @@
+package org.xhtmlrenderer.pdf.bug;
+
+import org.junit.jupiter.api.Test;
+import org.xhtmlrenderer.newtable.TableCellBox;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xhtmlrenderer.render.BlockBox;
+import org.xhtmlrenderer.render.Box;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+/**
+ * Reproducible example for <a href="https://github.com/flyingsaucerproject/flyingsaucer/issues/697">issue 697</a>:
+ * a percentage {@code max-width} on a table cell used to resolve against a containing block
+ * (the table row) whose content width had not been established yet, so it was always clamped to zero.
+ */
+class PercentageMaxWidthTableCellTest {
+    @Test
+    void percentageMaxWidthResolvesAgainstTheTableWidth() {
+        String page = """
+            <html><head><style>
+              table { width: 600pt; }
+            </style></head>
+            <body>
+            <table><tr><td style="max-width: 60pt">fixed length</td></tr></table>
+            <table><tr><td style="max-width: 10%">percentage</td></tr></table>
+            </body></html>""";
+
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.setDocumentFromString(page);
+        renderer.layout();
+
+        BlockBox root = renderer.getRootBox();
+        TableCellBox fixedLengthCell = (TableCellBox) findFirst(root, TableCellBox.class);
+        TableCellBox percentageCell = (TableCellBox) findLast(root, TableCellBox.class);
+
+        // Not byte-exact: the table layout algorithm allocates border-spacing per column, so a
+        // percentage of the table's overall width is not pixel-identical to an equivalent fixed
+        // length. It must, however, be in the same ballpark, not resolve to (near) zero.
+        assertThat(percentageCell.getContentWidth()).isCloseTo(fixedLengthCell.getContentWidth(), withPercentage(5));
+    }
+
+    private static Box findFirst(Box box, Class<?> type) {
+        if (type.isInstance(box)) return box;
+        for (int i = 0; i < box.getChildCount(); i++) {
+            Box found = findFirst(box.getChild(i), type);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static Box findLast(Box box, Class<?> type) {
+        Box last = null;
+        if (type.isInstance(box)) last = box;
+        for (int i = 0; i < box.getChildCount(); i++) {
+            Box found = findLast(box.getChild(i), type);
+            if (found != null) last = found;
+        }
+        return last;
+    }
+}


### PR DESCRIPTION
## Summary
- `TableCellBox` relied on `Box`'s default `getContainingBlockWidth()`, which resolves against its parent `TableRowBox`'s content width — but rows never get an independent content width, so at the point `TableSectionBox.setCellWidths()` applies min/max-width constraints, that width is still `0`.
- This made percentage `max-width`/`min-width` on a table cell always resolve to zero, silently clamping the cell and corrupting its line layout (extra wrapping/spacing).
- Fixed by overriding `getContainingBlockWidth()` in `TableCellBox` to resolve against the table's content width instead, per CSS 2.1 §17.4 — the table's width is already established by the time cell widths are calculated.

Fixes #697

## Test plan
- [x] Added `PercentageMaxWidthTableCellTest`, asserting a `max-width: 10%` cell in a `600pt` table ends up the same width (within tolerance) as an equivalent `max-width: 60pt` cell — previously it collapsed to ~0.
- [x] `mvn -pl flying-saucer-core -am test` passes
- [x] `mvn -pl flying-saucer-pdf -am test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved percentage-based sizing for table cells by resolving widths against the table’s content area.
  * Corrected percentage `max-width` behavior for table cells.

* **Tests**
  * Added regression coverage to verify consistent table-cell widths when using fixed and percentage-based sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->