### PR TITLE
feat(chrome-pdf): add warmup() to pre-download and verify chrome-headless-shell

### DIFF
--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfRenderer.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/ChromiumPdfRenderer.java
@@ -76,6 +76,16 @@ public class ChromiumPdfRenderer implements AutoCloseable {
         return this;
     }
 
+    /**
+     * Ensures the chrome-headless-shell binary is downloaded and ready to use, downloading it if necessary.
+     * Logs the resolved browser version and its location on disk.
+     */
+    public void warmup() throws IOException {
+        Path binary = locateBinary();
+        String version = runProcessCapturingOutput(List.of(binary.toString(), "--version")).strip();
+        log.info("chrome-headless-shell is ready: {} at {}", version, binary);
+    }
+
     public byte[] renderToPdf(URL htmlSource) throws IOException {
         return renderToPdf(htmlSource.toString());
     }
@@ -159,6 +169,13 @@ public class ChromiumPdfRenderer implements AutoCloseable {
     }
 
     private void runOneShotProcess(List<String> command) throws IOException {
+        String output = runProcessCapturingOutput(command);
+        if (!output.isBlank()) {
+            log.debug("chrome-headless-shell output: {}", output);
+        }
+    }
+
+    private String runProcessCapturingOutput(List<String> command) throws IOException {
         log.debug("Running: {}", command);
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         String output;
@@ -181,9 +198,7 @@ public class ChromiumPdfRenderer implements AutoCloseable {
         if (exitCode != 0) {
             throw new IOException("chrome-headless-shell exited with code " + exitCode + ". Output:\n" + output);
         }
-        if (!output.isBlank()) {
-            log.debug("chrome-headless-shell output: {}", output);
-        }
+        return output;
     }
 
     private void scheduleIdleCloseLocked() {

--- a/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/Html2Pdf.java
+++ b/flying-saucer-chrome-pdf/src/main/java/org/xhtmlrenderer/chrome/Html2Pdf.java
@@ -13,6 +13,14 @@ public final class Html2Pdf {
     private Html2Pdf() {
     }
 
+    public static void warmup() {
+        try {
+            SHARED.warmup();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to warm up chrome-headless-shell", e);
+        }
+    }
+
     public static byte[] fromUrl(URL html) {
         try {
             return SHARED.renderToPdf(html);

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromiumPdfRendererTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/ChromiumPdfRendererTest.java
@@ -48,6 +48,11 @@ class ChromiumPdfRendererTest {
     }
 
     @Test
+    void warmsUpAndDownloadsChromeIfMissing() throws IOException {
+        new ChromiumPdfRenderer().warmup();
+    }
+
+    @Test
     void failsWithMissingExplicitBinary(@TempDir Path tmp) {
         Path bogus = tmp.resolve("not-chrome");
         URL html = requireNonNull(

--- a/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/Html2PdfTest.java
+++ b/flying-saucer-chrome-pdf/src/test/java/org/xhtmlrenderer/chrome/Html2PdfTest.java
@@ -29,4 +29,9 @@ class Html2PdfTest {
 
         assertThat(pdf).containsText("Inline content");
     }
+
+    @Test
+    void warmsUpChromeBinary() {
+        Html2Pdf.warmup();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `ChromiumPdfRenderer.warmup()`, which resolves (downloading if necessary) the chrome-headless-shell binary and logs its version and on-disk location.
- Adds a matching `Html2Pdf.warmup()` static convenience method on the shared facade.
- Lets callers eagerly trigger the download/verification at startup (e.g. during app boot or a readiness probe) instead of paying that cost on the first PDF render.

## Test plan
- [x] `mvn -pl flying-saucer-chrome-pdf test -Dtest=ChromiumPdfRendererTest,Html2PdfTest` — passes, downloads the real binary and logs e.g. `chrome-headless-shell is ready: Google Chrome for Testing 152.0.7977.42 at /Users/.../chrome-headless-shell`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warm-up operation to ensure the Chrome-based PDF renderer is ready before use.
  - Reports the detected Chrome version and executable location.
  - Added a simplified shared warm-up entry point for HTML-to-PDF workflows.

- **Bug Fixes**
  - Improved process output capture and logging during PDF rendering.

- **Tests**
  - Added coverage for successful renderer warm-up and automatic Chrome availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->