### PR TITLE
ci: run build matrix on ubuntu-latest and windows-latest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,12 +30,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
         matrix:
+            os: [ ubuntu-latest, windows-latest ]
             # The last 2 LTS releases
             java: [ 21, 25 ]
-    name: Java ${{matrix.java}}
+    name: Java ${{matrix.java}} (${{matrix.os}})
     steps:
       - uses: actions/checkout@v7
       - name: Setup java
@@ -55,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-report-${{matrix.java}}
+          name: test-report-${{matrix.java}}-${{matrix.os}}
           retention-days: 14
           path: |
             **/target/site

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/WordBreakTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/WordBreakTest.java
@@ -17,6 +17,7 @@ public class WordBreakTest {
     void breakAll() throws IOException {
         byte[] result = Html2Pdf.fromClasspathResource("org/xhtmlrenderer/pdf/break-all.html");
         PDF pdf = printFile(log, result, "break-all.pdf");
-        assertThat(pdf).containsExactText("HelloWorld1\nHelloWorld2\nHelloWorld3\nHelloWorld4\nHelloWorld5\n");
+        String nl = System.lineSeparator();
+        assertThat(pdf).containsExactText("HelloWorld1" + nl + "HelloWorld2" + nl + "HelloWorld3" + nl + "HelloWorld4" + nl + "HelloWorld5" + nl);
     }
 }

--- a/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/WordBreakTest.java
+++ b/flying-saucer-pdf/src/test/java/org/xhtmlrenderer/pdf/WordBreakTest.java
@@ -17,7 +17,6 @@ public class WordBreakTest {
     void breakAll() throws IOException {
         byte[] result = Html2Pdf.fromClasspathResource("org/xhtmlrenderer/pdf/break-all.html");
         PDF pdf = printFile(log, result, "break-all.pdf");
-        String nl = System.lineSeparator();
-        assertThat(pdf).containsExactText("HelloWorld1" + nl + "HelloWorld2" + nl + "HelloWorld3" + nl + "HelloWorld4" + nl + "HelloWorld5" + nl);
+        assertThat(pdf).containsExactText("HelloWorld1%nHelloWorld2%nHelloWorld3%nHelloWorld4%nHelloWorld5%n".formatted());
     }
 }

--- a/flying-saucer-pdf/src/test/resources/transform.html
+++ b/flying-saucer-pdf/src/test/resources/transform.html
@@ -1,6 +1,7 @@
 <html lang="en">
 <head>
     <title>TEST</title>
+    <style>@page { size: A4; }</style>
 </head>
 <body>
     <div style="width: 100px; height: 40px; background-color: cornflowerblue;">Not transformed</div>


### PR DESCRIPTION
## Summary
- Add `windows-latest` to the build matrix alongside `ubuntu-latest`, so tests run on both OSes for each supported Java version (21, 25).
- Disambiguate the job name and uploaded `test-report` artifact name by OS to avoid artifact-name collisions between OS runs for the same Java version.

## Test plan
- [ ] CI runs green on both `ubuntu-latest` and `windows-latest` for Java 21 and 25
- [ ] Watch the Windows runs specifically for chrome-headless-shell warmup/path issues, since that codepath hasn't been exercised on Windows in CI before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded build validation across Ubuntu and Windows with Java 21 and 25.
  * Test reports now clearly identify the Java version and operating system.
  * Improved cross-platform test reliability by using system-specific line separators.
  * Updated page-size test coverage for A4 documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->